### PR TITLE
Improve variant streaming

### DIFF
--- a/src/app/genotype-browser/genotype-browser.component.css
+++ b/src/app/genotype-browser/genotype-browser.component.css
@@ -15,6 +15,7 @@
   padding-top: 20px;
   font-size: 0.75em;
   font-weight: 500;
+  vertical-align: middle;
 }
 
 .button {
@@ -24,4 +25,26 @@
   display: inline-block;
   margin-left: 0.3%;
   margin-right: 0.3%;
+}
+
+.loader {
+  border: 6px solid #cccccc;
+  border-radius: 50%;
+  border-top: 6px solid #ff2222;
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  -webkit-animation: spin 1s linear infinite; /* Safari */
+  animation: spin 1s linear infinite;
+}
+
+/* Safari */
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -34,9 +34,17 @@
       </div>
     </div>
     <div class="genotype-browser-results" *ngIf="genotypePreviewVariantsArray">
+      
       <p class="overview">
-        {{ genotypePreviewVariantsArray.variantsCount() }}
+        <span *ngIf="!loadingFinished">
+          <span class="loader"></span>
+            Loading variants...
+          </span>
+        <span *ngIf="loadingFinished">
+          {{ genotypePreviewVariantsArray.variantsCount() }}
+        </span>
       </p>
+
       <gpf-genotype-preview-table
       	*ngIf="tablePreview"
         [columns]="dataset?.genotypeBrowserConfig?.columns"

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -29,6 +29,7 @@ export class GenotypeBrowserComponent extends QueryStateCollector
   selectedDatasetId: string;
   selectedDataset$: Observable<Dataset>;
   private genotypeBrowserState: Object;
+  private loadingFinished: boolean;
 
   constructor(
     private queryService: QueryService,
@@ -75,6 +76,7 @@ export class GenotypeBrowserComponent extends QueryStateCollector
   }
 
   submitQuery() {
+    this.loadingFinished = false;
     this.loadingService.setLoadingStart();
     this.getCurrentState()
       .subscribe(state => {
@@ -88,12 +90,15 @@ export class GenotypeBrowserComponent extends QueryStateCollector
 
             this.genotypeBrowserState = state;
 
+            this.queryService.streamingFinishedSubject.subscribe(
+              _ => { this.loadingFinished = true; }
+            );
+
             this.genotypePreviewVariantsArray =
               this.queryService.getGenotypePreviewVariantsByFilter(
-                state, this.genotypePreviewInfo
+                state, this.genotypePreviewInfo, this.loadingService
               );
 
-            this.loadingService.setLoadingStop();
           }, error => {
             console.warn(error);
           }

--- a/src/app/genotype-preview-model/genotype-preview.ts
+++ b/src/app/genotype-preview-model/genotype-preview.ts
@@ -55,9 +55,9 @@ export class GenotypePreview {
         const propertyValue = row[elem];
 
         if (mapper) {
-          result.data[columns[elem]] = mapper(propertyValue);
+          result.data.set(columns[elem], mapper(propertyValue));
         } else if (propertyValue !== 'nan' && propertyValue !== '') {
-          result.data[columns[elem]] = propertyValue;
+          result.data.set(columns[elem], propertyValue);
         }
       }
     }
@@ -66,7 +66,7 @@ export class GenotypePreview {
   }
 
   get(key: string): any {
-    return this.data[key];
+    return this.data.get(key);
   }
 
 }
@@ -100,7 +100,9 @@ export class GenotypePreviewVariantsArray {
       return;
     }
     const genotypePreview = GenotypePreview.fromJson(row, genotypePreviewInfo.columns);
-    this.genotypePreviews.push(genotypePreview);
+    if (genotypePreview.data.size) {
+      this.genotypePreviews.push(genotypePreview);
+    }
   }
 
   variantsCount() {


### PR DESCRIPTION
Fixed variant count when no variants have been loaded (was 1, now is 0)
Loading overlay is now removed when at least one variant has been loaded
Variants' count displays a loading message until all variants have been streamed