### PR TITLE
GPF-1809 Table now dosent call function in the template

### DIFF
--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -13,7 +13,7 @@
   <div [style.display]="beforeDataCellHeight ? 'table-row' : 'none'" [style.height]="beforeDataCellHeight + 'px'">
     <td *ngFor="let column of columnsChildren"></td>
   </div>
-  <div #rows style="display: table-row" *ngFor="let data of visibleData" class="table-row">
+  <div #rows style="display: table-row" *ngFor="let data of tableData" class="table-row">
     <gpf-table-view-cell
       #cells
       *ngFor="let column of columnsChildren"
@@ -34,11 +34,11 @@
   </div>
 </div>
 
-<div *ngIf="visibleData.length === 0">
+<div *ngIf="tableData.length === 0">
   <gpf-nothing-found-row [style.width]="noResultsWidth" [style.min-width]="noResultsWidth" style="height: 100%">
   </gpf-nothing-found-row>
 </div>
 
-<div *ngIf="showLegend && visibleData.length > 0" id="legend-wrapper">
+<div *ngIf="showLegend && tableData.length > 0" id="legend-wrapper">
   <ng-template *ngIf="legend?.templateRef" [ngTemplateOutlet]="legend.templateRef"></ng-template>
 </div>

--- a/src/app/table/table.component.spec.ts
+++ b/src/app/table/table.component.spec.ts
@@ -91,7 +91,7 @@ describe('GpfTableComponent', () => {
     expect(component.beforeDataCellHeight).toBe(0);
     expect(component.afterDataCellHeight).toBe(0);
 
-    expect(component.visibleData).toEqual([
+    expect(component.getVisibleData()).toEqual([
       {field: 3, arrayPosition: 0},
       {field: 2, arrayPosition: 0},
       {field: 4, arrayPosition: 0},
@@ -104,7 +104,7 @@ describe('GpfTableComponent', () => {
     expect(component.beforeDataCellHeight).toBe(0);
     expect(component.afterDataCellHeight).toBe(0);
 
-    expect(component.visibleData).toEqual([
+    expect(component.getVisibleData()).toEqual([
       {field: 3, arrayPosition: 0},
       {field: 2, arrayPosition: 0},
       {field: 4, arrayPosition: 0},
@@ -114,6 +114,6 @@ describe('GpfTableComponent', () => {
     component.dataSource = null;
 
     expect(component.getScrollIndices()).toEqual([0, 0]);
-    expect(component.visibleData).toEqual([]);
+    expect(component.getVisibleData()).toEqual([]);
   });
 });

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -1,5 +1,5 @@
 import {
-  ContentChild, ViewChildren, ViewChild, HostListener, Input, Component, ContentChildren, QueryList
+  ContentChild, ViewChildren, ViewChild, HostListener, Input, Component, ContentChildren, QueryList, OnChanges
 } from '@angular/core';
 import { GpfTableColumnComponent } from './component/column.component';
 import { GpfTableSubheaderComponent } from './component/subheader.component';
@@ -17,7 +17,7 @@ export class SortInfo {
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.css']
 })
-export class GpfTableComponent {
+export class GpfTableComponent implements OnChanges {
   @ViewChild('table') public tableViewChild: any;
   @ViewChildren('rows') public rowViewChildren: QueryList<any>;
 
@@ -32,9 +32,14 @@ export class GpfTableComponent {
   private tableTopPosition = 0;
 
   public noResultsWidth: string;
+  public tableData: Array<any> = [];
 
   public showFloatingHeader: boolean;
   public showLegend: boolean;
+
+  public ngOnChanges() {
+    this.tableData = this.getVisibleData();
+  }
 
   @HostListener('window:scroll', ['$event'])
   public onWindowScroll(): void {
@@ -53,6 +58,7 @@ export class GpfTableComponent {
     }
 
     this.showFloatingHeader = this.tableTop();
+    this.tableData = this.getVisibleData();
   }
 
   public set sortingInfo(sortingInfo: SortInfo) {
@@ -104,9 +110,9 @@ export class GpfTableComponent {
     return result > 0 ? result : 0;
   }
 
-  public get visibleData(): Array<any> {
+  public getVisibleData(): Array<any> {
     if (this.dataSource === undefined || this.dataSource === null || this.dataSource.length === 0) {
-      if (this.columnsChildren !== undefined || this.columnsChildren !== null) {
+      if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
         let width = 0;
         this.columnsChildren.forEach(column => {
           width += Number(column.columnWidth.split('px')[0]);


### PR DESCRIPTION
## Background

GPF table component used a function in the template in order to get which data is visible for the moment.

## Aim

We aim not to use function calls in the HTML templates because that causes a lot of overhead.

## Implementation

The visible table data is now calculated only on certain event. This optimizes the browser performance.