### PR TITLE
GPF-1822 Words no longer break in the phenotype browser

### DIFF
--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -1,4 +1,4 @@
-<gpf-table [dataSource]="measures.measures" style="display: inline-block">
+<gpf-table [dataSource]="measures.measures" style="display: inline-block; white-space: nowrap">
     <gpf-table-column>
         <gpf-table-header caption="Instrument" field="instrumentName"></gpf-table-header>
         <gpf-table-content>


### PR DESCRIPTION
## Background

Words are warping in the phenotype browser. This is rather exception as it is explicitly stated in the genotype browser has rules for the words that prevent them from overflowing.

## Aim

The aim is to push for consistency. The words no longer break as it is in the genotype browser

## Implementation

Implementation is based around CSS rules that prevent words from warping/overflowing/going next line mid-word.