### PR TITLE
Fix various broken download functionalities

### DIFF
--- a/src/app/categorical-filter/categorical-filter.component.spec.ts
+++ b/src/app/categorical-filter/categorical-filter.component.spec.ts
@@ -8,6 +8,7 @@ import { DatasetsService } from 'app/datasets/datasets.service';
 import { PhenoBrowserService } from 'app/pheno-browser/pheno-browser.service';
 import { UsersService } from 'app/users/users.service';
 import { CategoricalFilterComponent } from './categorical-filter.component';
+import { APP_BASE_HREF } from '@angular/common';
 
 class MockDatasetsService {
   public getSelectedDataset(): object {
@@ -27,7 +28,8 @@ describe('CategoricalFilterComponent', () => {
         { provide: DatasetsService, useValue: datasetsServiceMock },
         PhenoBrowserService,
         ConfigService,
-        UsersService
+        UsersService,
+        { provide: APP_BASE_HREF, useValue: '' }
       ],
       imports: [
         HttpClientTestingModule, RouterTestingModule, FormsModule,

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -168,14 +168,13 @@
       </gpf-gene-plot>
       <div class="row" style="padding-top: 15px">
         <div class="col-12" *ngIf="selectedGene">
-          <form
-            id="summary_download"
-            (ngSubmit)="onSubmitSummary($event)"
-            action="{{ configService.baseUrl }}gene_view/download_summary_variants"
-            method="post">
-            <input name="queryData" type="hidden" />
-            <button class="btn btn-md btn-primary btn-right" id="download-summary-button" type="submit">Download Summary</button>
-          </form>
+          <button
+           class="btn btn-md btn-primary btn-right"
+           id="download-summary-button"
+           (click)="onDownloadSummary()">
+            <span *ngIf="downloadInProgressSummary">Downloading...</span>
+            <span *ngIf="!downloadInProgressSummary">Download Summary</span>
+          </button>
         </div>
       </div>
 
@@ -208,14 +207,13 @@
           </gpf-loading-spinner>
         </div>
         <div class="col-6" *ngIf="selectedGene">
-          <form
-            id="family_download"
-            (ngSubmit)="onSubmit($event)"
-            action="{{ configService.baseUrl }}genotype_browser/query"
-            method="post">
-            <input name="queryData" type="hidden" />
-            <button class="btn btn-md btn-primary btn-right" id="download-button" type="submit">Download</button>
-          </form>
+          <button
+           class="btn btn-md btn-primary btn-right"
+           id="download-button"
+           (click)="onDownload()">
+            <span *ngIf="downloadInProgress">Downloading...</span>
+            <span *ngIf="!downloadInProgress">Download</span>
+          </button>
         </div>
       </div>
 

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -19,15 +19,14 @@
   <gpf-unique-family-variants-filter></gpf-unique-family-variants-filter>
 
   <div class="form-block">
-    <form (ngSubmit)="onSubmit($event)" action="{{ configService.baseUrl }}genotype_browser/query" method="post">
-      <input name="queryData" type="hidden" />
-      <button
-        class="btn btn-md btn-primary btn-right"
-        id="download-button"
-        [disabled]="disableQueryButtons"
-        type="submit">Download</button
-      >
-    </form>
+    <button
+      class="btn btn-md btn-primary btn-right"
+      id="download-button"
+      (click)="onDownload()"
+      [disabled]="disableQueryButtons">
+       <span *ngIf="downloadInProgress">Downloading...</span>
+       <span *ngIf="!downloadInProgress">Download</span>
+    </button>
     <div class="button">
       <input
         type="button"

--- a/src/app/pheno-browser/pheno-browser.service.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.service.spec.ts
@@ -6,6 +6,8 @@ import { CookieService } from 'ngx-cookie-service';
 import { of } from 'rxjs';
 import { fakeJsonMeasure } from './pheno-browser.spec';
 import { HttpClient } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_BASE_HREF } from '@angular/common';
 
 describe('pheno browser service', () => {
   let phenoBrowserService: PhenoBrowserService;
@@ -21,11 +23,13 @@ describe('pheno browser service', () => {
     };
 
     TestBed.configureTestingModule({
+      imports: [ RouterTestingModule ],
       providers: [
         PhenoBrowserService,
         { provide: CookieService, useValue: cookieSpyObj },
         { provide: ConfigService, useValue: configMock },
         { provide: HttpClient, useValue: httpSpyObj },
+        { provide: APP_BASE_HREF, useValue: '' },
       ]
     });
 

--- a/src/app/pheno-tool/pheno-tool.component.html
+++ b/src/app/pheno-tool/pheno-tool.component.html
@@ -24,10 +24,14 @@
         <gpf-save-query [disabled]="disableQueryButtons" queryType="phenotool"></gpf-save-query>
       </div>
       <div class="btn-group">
-        <form (ngSubmit)="onDownload($event)" action="{{ configService.baseUrl }}pheno_tool/download" method="post">
-          <input name="queryData" type="hidden" />
-          <button class="btn btn-md btn-primary" [disabled]="disableQueryButtons" type="submit">Download</button>
-        </form>
+        <button
+          class="btn btn-md btn-primary"
+          id="download-button"
+          (click)="onDownload()"
+          [disabled]="disableQueryButtons">
+           <span *ngIf="downloadInProgress">Downloading...</span>
+           <span *ngIf="!downloadInProgress">Download</span>
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/pheno-tool/pheno-tool.component.spec.ts
+++ b/src/app/pheno-tool/pheno-tool.component.spec.ts
@@ -39,26 +39,18 @@ describe('PhenoToolComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         PhenoToolComponent,
-        // PhenoToolGenotypeBlockComponent,
         GenesBlockComponent,
         GeneSymbolsComponent,
         PhenoToolMeasureComponent,
-        // PhenoMeasureSelectorComponent,
-        // ErrorsAlertComponent,
-        // SaveQueryComponent,
-        // PhenoToolEffectTypesComponent,
-        // EffecttypesColumnComponent,
-        // CheckboxListComponent,
       ],
       providers: [
         {provide: ActivatedRoute, useValue: new ActivatedRoute()},
         {provide: DatasetsService, useValue: new MockDatasetsService()},
         {provide: ConfigService, useValue: configMock},
+        {provide: PhenoToolService, useValue: phenoToolMockService},
         UsersService,
         FullscreenLoadingService,
-        {provide: PhenoToolService, useValue: phenoToolMockService},
         MeasuresService,
-        // QueryService
       ],
       imports: [
         HttpClientTestingModule,
@@ -115,20 +107,6 @@ describe('PhenoToolComponent', () => {
     fixture.detectChanges();
     component.submitQuery();
     expect(component.phenoToolResults).toEqual('fakeValue' as any);
-  });
-
-  it('should test on download event', () => {
-    const form = document.createElement('form');
-    form.onsubmit = (): boolean => false; // This supresses an error from JSDOM, purely cosmetic
-    const event = {target: form};
-    event.target.queryData = {
-      value: 'id'
-    };
-    const submitSpy = jest.spyOn(event.target, 'submit');
-
-    component.onDownload(event as any);
-    expect(submitSpy).toHaveBeenCalledTimes(1);
-    expect(event.target.queryData.value).toEqual('{"datasetId":"testDatasetId"}');
   });
 
   it('should hide results on a state change', () => {

--- a/src/app/pheno-tool/pheno-tool.service.ts
+++ b/src/app/pheno-tool/pheno-tool.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 // eslint-disable-next-line no-restricted-imports
 import { Observable } from 'rxjs';
 
@@ -10,7 +10,7 @@ import { map } from 'rxjs/operators';
 @Injectable()
 export class PhenoToolService {
   private readonly phenoToolUrl = 'pheno_tool';
-  private headers = new Headers({ 'Content-Type': 'application/json' });
+  private readonly headers = new HttpHeaders({ 'Content-Type': 'application/json' });
 
   public constructor(
     private http: HttpClient,
@@ -23,5 +23,13 @@ export class PhenoToolService {
 
     return this.http.post(this.config.baseUrl + this.phenoToolUrl, filter, options)
       .pipe(map(res => PhenoToolResults.fromJson(res)));
+  }
+
+  public downloadPhenoToolResults(filter: object): Observable<HttpResponse<Blob>> {
+    return this.http.post(
+      this.config.baseUrl + this.phenoToolUrl + '/download',
+      filter,
+      {observe: 'response', headers: this.headers, responseType: 'blob'}
+    );
   }
 }

--- a/src/app/query/query.service.ts
+++ b/src/app/query/query.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 // eslint-disable-next-line no-restricted-imports
@@ -17,6 +17,7 @@ import { AuthService } from 'app/auth.service';
 export class QueryService {
   private readonly genotypePreviewVariantsUrl = 'genotype_browser/query';
   private readonly geneViewVariants = 'gene_view/query_summary_variants';
+  private readonly geneViewVariantsDownload = 'gene_view/download_summary_variants';
   private readonly saveQueryEndpoint = 'query_state/save';
   private readonly loadQueryEndpoint = 'query_state/load';
   private readonly deleteQueryEndpoint = 'query_state/delete';
@@ -118,6 +119,22 @@ export class QueryService {
     });
 
     return genotypePreviewVariantsArray;
+  }
+
+  public downloadVariants(filter: object): Observable<HttpResponse<Blob>> {
+    return this.http.post(
+      `${environment.apiPath}${this.genotypePreviewVariantsUrl}`,
+      filter,
+      {observe: 'response', headers: this.headers, responseType: 'blob'}
+    );
+  }
+
+  public downloadVariantsSummary(filter: object): Observable<HttpResponse<Blob>> {
+    return this.http.post(
+      `${environment.apiPath}${this.geneViewVariantsDownload}`,
+      filter,
+      {observe: 'response', headers: this.headers, responseType: 'blob'}
+    );
   }
 
   public getSummaryVariants(filter): SummaryAllelesArray {

--- a/src/app/utils/blob-download.ts
+++ b/src/app/utils/blob-download.ts
@@ -1,0 +1,10 @@
+import { HttpResponse } from '@angular/common/http';
+
+export function downloadBlobResponse(response: HttpResponse<Blob>, filename: string) {
+  const downloadLink = document.createElement('a');
+  const url = URL.createObjectURL(new Blob([response.body], { type: response.body.type }));
+  downloadLink.href = url;
+  downloadLink.download = filename;
+  downloadLink.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -269,3 +269,8 @@ ng-multiselect-dropdown > span.selected-item {
   float: left;
   margin-bottom: 0;
 }
+
+.download-link {
+  cursor: pointer;
+  user-select: none;
+}

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -31,7 +31,10 @@
 
     <h5 id="total-number-of-families">
       <span>Total number of families: {{ variantReport.familyReport.familiesTotal }}</span>
-      <span style="padding-left: 5px">(<a class="download-link" [href]="getDownloadLink()" download>Download</a>)</span>
+      <span style="padding-left: 5px">(<a class="download-link" (click)="onDownload()">
+          <span *ngIf="downloadInProgress">Downloading...</span>
+          <span *ngIf="!downloadInProgress">Download</span>
+      </a>)</span>
     </h5>
   </div>
 

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -10,6 +10,7 @@ import { environment } from 'environments/environment';
 import { Dictionary } from 'lodash';
 import * as _ from 'lodash';
 import { IDropdownSettings } from 'ng-multiselect-dropdown';
+import { downloadBlobResponse } from 'app/utils/blob-download';
 
 @Pipe({ name: 'getPeopleCounterRow' })
 export class PeopleCounterRowPipe implements PipeTransform {
@@ -44,6 +45,7 @@ export class VariantReportsComponent implements OnInit {
 
   public denovoVariantsTableWidth: number;
   private denovoVariantsTableColumnWidth = 140;
+  public downloadInProgress = false;
 
   public constructor(
     private variantReportsService: VariantReportsService,
@@ -160,8 +162,14 @@ export class VariantReportsComponent implements OnInit {
     return this.orderByColumnOrder(effectType.data, phenotypes);
   }
 
-  public getDownloadLink(): string {
-    return this.variantReportsService.getDownloadLink();
+  public onDownload(): void {
+    this.downloadInProgress = true;
+    this.variantReportsService.downloadFamilies().pipe(take(1)).subscribe((response) => {
+      this.downloadInProgress = false;
+      downloadBlobResponse(response, 'families.ped');
+    }, (err) => {
+      this.downloadInProgress = false;
+    });
   }
 
   public getDownloadLinkTags(): void {

--- a/src/app/variant-reports/variant-reports.service.ts
+++ b/src/app/variant-reports/variant-reports.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { ConfigService } from '../config/config.service';
 import { Observable, Subscription } from 'rxjs';
 import { VariantReport } from './variant-reports';
@@ -28,9 +28,13 @@ export class VariantReportsService {
     return this.http.get(url, options).pipe(map(response => VariantReport.fromJson(response)));
   }
 
-  public getDownloadLink(): string {
+  private getDownloadLink(): string {
     const selectedDatasetId = this.datasetsService.getSelectedDataset().id;
     return `${environment.apiPath}${this.downloadUrl}${selectedDatasetId}`;
+  }
+
+  public downloadFamilies(): Observable<HttpResponse<Blob>> {
+    return this.http.get(this.getDownloadLink(), {observe: 'response', responseType: 'blob'});
   }
 
   public getFamilies(datasetId: string, groupName: string, counterId: number): Observable<string[]> {


### PR DESCRIPTION
## Background

Various download functionalities were broken because they used HTML form elements to initiate the download. Headers cannot be set on HTML forms, making it impossible to attach an authorization token. In the case of the variants-reports component, instead of a form element, it would navigate you directly to the download link.

## Aim

Return all downloads to a working state.

## Implementation

Make all downloads via Typescript code in order to allow attaching the authorization header. Created a helper function to download a blob response and various methods in different services to provide said blob responses.