### PR TITLE
Gene scores histogram partitions fix

### DIFF
--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -1,12 +1,9 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Partitions, GeneScoresLocalState, GeneScores } from './gene-scores';
 import { GeneScoresService } from './gene-scores.service';
-// eslint-disable-next-line no-restricted-imports
-import { ReplaySubject ,  Observable, combineLatest, of } from 'rxjs';
-
+import { ReplaySubject, Observable, combineLatest, of } from 'rxjs';
 import { Store } from '@ngxs/store';
 import { ConfigService } from '../config/config.service';
-
 import { SetGeneScore, SetHistogramValues, GeneScoresState } from './gene-scores.state';
 import { catchError, debounceTime, distinctUntilChanged, map, switchMap } from 'rxjs/operators';
 import { StatefulComponent } from 'app/common/stateful-component';
@@ -22,16 +19,15 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
   private rangeChanges = new ReplaySubject<[string, number, number]>(1);
   private partitions: Observable<Partitions>;
 
-  geneScoresArray: GeneScores[];
-  rangesCounts: Observable<Array<number>>;
+  public geneScoresArray: GeneScores[];
+  public rangesCounts: Observable<Array<number>>;
   public downloadUrl: string;
 
-  @ValidateNested()
-  geneScoresLocalState = new GeneScoresLocalState();
+  @ValidateNested() private geneScoresLocalState = new GeneScoresLocalState();
 
   public imgPathPrefix = environment.imgPathPrefix;
 
-  constructor(
+  public constructor(
     protected store: Store,
     private geneScoresService: GeneScoresService,
     private config: ConfigService,
@@ -40,33 +36,31 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
     this.partitions = this.rangeChanges.pipe(
       debounceTime(100),
       distinctUntilChanged(),
-      switchMap(([score, internalRangeStart, internalRangeEnd]) => {
-        return this.geneScoresService.getPartitions(score, internalRangeStart, internalRangeEnd);
-      }),
+      switchMap(([score, internalRangeStart, internalRangeEnd]) =>
+        this.geneScoresService.getPartitions(score, internalRangeStart, internalRangeEnd)
+      ),
       catchError(error => {
         console.warn(error);
         return of(null);
       })
     );
 
-    this.rangesCounts = this.partitions.pipe(map((partitions) => {
-       return [partitions.leftCount, partitions.midCount, partitions.rightCount];
-    }));
+    this.rangesCounts = this.partitions.pipe(
+      map((partitions) =>
+        [partitions.leftCount, partitions.midCount, partitions.rightCount]
+      )
+    );
   }
 
-  ngOnInit() {
+  public ngOnInit(): void {
     super.ngOnInit();
     this.geneScoresService.getGeneScores().pipe(
-      switchMap(geneScores => {
-        return combineLatest([
-          of(geneScores),
-          this.store.selectOnce(GeneScoresState)
-        ]);
-      })
+      switchMap(geneScores =>
+        combineLatest([of(geneScores), this.store.selectOnce(GeneScoresState)])
+      )
     ).subscribe(([geneScores, state]) => {
       this.geneScoresArray = geneScores;
-      // restore state
-      // console.log(state);
+
       if (state.geneScore !== null) {
         for (const geneScore of this.geneScoresArray) {
           if (geneScore.score === state.geneScore.score) {
@@ -80,34 +74,32 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
         this.selectedGeneScores = this.geneScoresArray[0];
       }
     });
-    if(this.geneScoresLocalState.score !== null && this.rangeStart !== null && this.rangeEnd !== null) {
-        this.updateHistogramState();
+    if (this.geneScoresLocalState.score !== null && this.rangeStart !== null && this.rangeEnd !== null) {
+      this.updateHistogramState();
     }
-}
+  }
 
-  private updateLabels() {
+  private updateLabels(): void {
     this.rangeChanges.next([
       this.geneScoresLocalState.score.score,
       this.rangeStart,
       this.rangeEnd
     ]);
-    //console.log(this.geneScoresLocalState.score.score ,this.rangeStart, this.rangeEnd);
   }
 
-  updateHistogramState() {
+  private updateHistogramState(): void {
     this.updateLabels();
     this.store.dispatch(new SetHistogramValues(
       this.geneScoresLocalState.rangeStart,
       this.geneScoresLocalState.rangeEnd,
     ));
-    console.log(this.geneScoresLocalState.rangeStart, this.geneScoresLocalState.rangeEnd);
   }
 
-  get selectedGeneScores() {
+  public get selectedGeneScores(): GeneScores {
     return this.geneScoresLocalState.score;
   }
 
-  set selectedGeneScores(selectedGeneScores: GeneScores) {
+  public set selectedGeneScores(selectedGeneScores: GeneScores) {
     this.geneScoresLocalState.score = selectedGeneScores;
     this.rangeStart = null;
     this.rangeEnd = null;
@@ -117,29 +109,29 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
     this.store.dispatch(new SetGeneScore(this.geneScoresLocalState.score));
   }
 
-  set rangeStart(range: number) {
+  public set rangeStart(range: number) {
     this.geneScoresLocalState.rangeStart = range;
     this.updateHistogramState();
   }
 
-  get rangeStart() {
+  public get rangeStart(): number {
     return this.geneScoresLocalState.rangeStart;
   }
 
-  set rangeEnd(range: number) {
+  public set rangeEnd(range: number) {
     this.geneScoresLocalState.rangeEnd = range;
     this.updateHistogramState();
   }
 
-  get rangeEnd() {
+  public get rangeEnd(): number {
     return this.geneScoresLocalState.rangeEnd;
   }
 
-  getDownloadUrl(): string {
+  private getDownloadUrl(): string {
     return `${this.config.baseUrl}gene_scores/download/${this.selectedGeneScores.score}`;
   }
 
-  changeDomain(scores: GeneScores) {
+  private changeDomain(scores: GeneScores): void {
     if (scores.domain !== null) {
       this.geneScoresLocalState.domainMin = scores.domain[0];
       this.geneScoresLocalState.domainMax = scores.domain[1];

--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -101,9 +101,9 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
 
   public set selectedGeneScores(selectedGeneScores: GeneScores) {
     this.geneScoresLocalState.score = selectedGeneScores;
-    this.rangeStart = null;
-    this.rangeEnd = null;
     this.changeDomain(selectedGeneScores);
+    this.rangeStart = this.geneScoresLocalState.domainMin;
+    this.rangeEnd = this.geneScoresLocalState.domainMax;
     this.updateLabels();
     this.downloadUrl = this.getDownloadUrl();
     this.store.dispatch(new SetGeneScore(this.geneScoresLocalState.score));

--- a/src/app/gene-scores/gene-scores.service.ts
+++ b/src/app/gene-scores/gene-scores.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-// eslint-disable-next-line no-restricted-imports
 import { Observable } from 'rxjs';
-
 import { GeneScores, Partitions } from './gene-scores';
 import { ConfigService } from '../config/config.service';
 import { map } from 'rxjs/operators';
@@ -12,36 +10,26 @@ export class GeneScoresService {
   private readonly geneScoresUrl = 'gene_scores';
   private readonly geneScoresPartitionsUrl = 'gene_scores/partitions';
 
-  constructor(
+  public constructor(
     private http: HttpClient,
     private config: ConfigService
   ) {}
 
-  getGeneScores(geneScoresIds?: string): Observable<GeneScores[]> {
+  public getGeneScores(geneScoresIds?: string): Observable<GeneScores[]> {
     let url = this.config.baseUrl + this.geneScoresUrl;
-
     if (geneScoresIds) {
       const searchParams = new HttpParams().set('ids', geneScoresIds);
       url += `?${searchParams.toString()}`;
     }
-
-    return this.http.get(url).pipe(map((res: any) => {
-      return GeneScores.fromJsonArray(res);
-    }));
+    return this.http.get(url).pipe(map((res: any) => GeneScores.fromJsonArray(res)));
   }
 
-  getPartitions(score: string, min: number, max: number): Observable<Partitions> {
+  public getPartitions(score: string, min: number, max: number): Observable<Partitions> {
     const headers = { 'Content-Type': 'application/json' };
     const options = { headers: headers };
 
     return this.http
       .post(this.config.baseUrl + this.geneScoresPartitionsUrl, {score: score, min: min, max: max}, options)
-      .pipe(map((res: any) => {
-        return Partitions.fromJson(res);
-      }));
+      .pipe(map((res: any) => Partitions.fromJson(res)));
   }
 }
-
-
-// 1) search -> rename 
-// 2) test(unit) 


### PR DESCRIPTION
Instead of setting rangeStart and rangeEnd to null when a gene score is changed, set them to the domain's min and max values as the backend requires a proper value in the partitions request

closes #625