### PR TITLE
Empty dataset bugs

### DIFF
--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -57,7 +57,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
         this.setupSelectedDataset();
       }),
       this.datasets$.pipe(take(1)).subscribe(() => {
-        if (this.router.url === '/datasets' && this.datasetTrees[0] !== undefined) {
+        if (this.router.url === '/datasets' && this.datasetTrees.length > 0) {
           this.router.navigate(['/', 'datasets', this.datasetTrees[0].dataset.id]);
         }
       }),

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -57,7 +57,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
         this.setupSelectedDataset();
       }),
       this.datasets$.pipe(take(1)).subscribe(() => {
-        if (this.router.url === '/datasets') {
+        if (this.router.url === '/datasets' && this.datasetTrees[0] !== undefined) {
           this.router.navigate(['/', 'datasets', this.datasetTrees[0].dataset.id]);
         }
       }),

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -1,29 +1,42 @@
-<div class="row panel" id="gene-scores-panel" style="margin-left: 0px; margin-right: 0px">
-  <div class="col-sm-3">
-    <div class="select-wrapper">
-      <select class="form-control" [(ngModel)]="selectedGeneScores" required>
-        <option *ngFor="let geneScores of geneScoresArray" [ngValue]="geneScores">{{ geneScores.desc }}</option>
-      </select>
-      <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"> </span>
+<div *ngIf="selectedGeneScores">
+  <div class="row panel" id="gene-scores-panel" style="margin-left: 0px; margin-right: 0px">
+    <div class="col-sm-3">
+      <div class="select-wrapper">
+        <select class="form-control" [(ngModel)]="selectedGeneScores" required>
+          <option *ngFor="let geneScores of geneScoresArray" [ngValue]="geneScores">{{ geneScores.desc }}</option>
+        </select>
+        <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"> </span>
+      </div>
+      <div *ngIf="selectedGeneScores" style="margin-top: 5px">
+        <a class="download-link" href="{{ downloadUrl }}">Download</a>
+      </div>
     </div>
-    <div *ngIf="selectedGeneScores" style="margin-top: 5px">
-      <a class="download-link" href="{{ downloadUrl }}">Download</a>
+
+    <div class="col-sm-9">
+      <gpf-histogram
+        *ngIf="selectedGeneScores"
+        [width]="650"
+        [height]="145"
+        [bins]="selectedGeneScores.bins"
+        [bars]="selectedGeneScores.bars"
+        [logScaleX]="selectedGeneScores.logScaleX"
+        [logScaleY]="selectedGeneScores.logScaleY"
+        [rangesCounts]="rangesCounts | async"
+        [(rangeStart)]="rangeStart"
+        [(rangeEnd)]="rangeEnd">
+      </gpf-histogram>
+      <gpf-errors-alert [errors]="errors"></gpf-errors-alert>
     </div>
   </div>
-
-  <div class="col-sm-9">
-    <gpf-histogram
-      *ngIf="selectedGeneScores"
-      [width]="650"
-      [height]="145"
-      [bins]="selectedGeneScores.bins"
-      [bars]="selectedGeneScores.bars"
-      [logScaleX]="selectedGeneScores.logScaleX"
-      [logScaleY]="selectedGeneScores.logScaleY"
-      [rangesCounts]="rangesCounts | async"
-      [(rangeStart)]="rangeStart"
-      [(rangeEnd)]="rangeEnd">
-    </gpf-histogram>
-    <gpf-errors-alert [errors]="errors"></gpf-errors-alert>
+</div>
+<div *ngIf="!selectedGeneScores">
+  <div class="form-block" style="display: contents">
+    <div class="card">
+      <ul ngbNav #nav="ngbNav" class="navbar bg-light nav-pills" style="justify-content: center">
+        <li ngbNavItem>
+          <span style="opacity: 75%"><i>No gene scores available</i></span>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -7,7 +7,7 @@
         </select>
         <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"> </span>
       </div>
-      <div *ngIf="selectedGeneScores" style="margin-top: 5px">
+      <div style="margin-top: 5px">
         <a class="download-link" href="{{ downloadUrl }}">Download</a>
       </div>
     </div>

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -14,7 +14,7 @@ import { GeneScoresState } from './gene-scores.state';
 
 class MockGeneScoresService {
   public provide = true;
-  public getGeneScores(geneScoresIds?: string): Observable<GeneScores[]> {
+  public getGeneScores(_geneScoresIds?: string): Observable<GeneScores[]> {
     if (this.provide) {
       return of([new GeneScores([1, 2], 'score3', [4, 5], 'desc6', [7, 8], 'xScale9', 'yScale10'),
         new GeneScores([11, 12], 'score13', [14, 15], 'desc16', [17, 18], 'xScale19', 'yScale20')
@@ -53,13 +53,11 @@ describe('GeneScoresComponent', () => {
   it('should test empty gene sets', () => {
     expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).toBeTruthy();
     mockGeneScoresService.provide = false;
-    component.selectedGeneScores = undefined as any;
+    component.selectedGeneScores = undefined;
     component.ngOnInit();
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      expect(fixture.debugElement.query(By.css('div > div.form-block > div.card > ul > li > span'))).toBeTruthy();
-      expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).not.toBeTruthy();
-    });
+    expect(fixture.debugElement.query(By.css('div > div.form-block > div.card > ul > li > span'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).not.toBeTruthy();
   });
 });
 

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -29,7 +29,7 @@ describe('GeneScoresComponent', () => {
   let fixture: ComponentFixture<GeneScoresComponent>;
   const mockGeneScoresService: MockGeneScoresService = new MockGeneScoresService();
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxsModule.forRoot([GeneScoresState], {developmentMode: true}), HttpClientTestingModule, NgbNavModule
@@ -38,9 +38,6 @@ describe('GeneScoresComponent', () => {
       providers: [{provide: GeneScoresService, useValue: mockGeneScoresService}, ConfigService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
-  }));
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(GeneScoresComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxsModule } from '@ngxs/store';

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -1,0 +1,65 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgxsModule } from '@ngxs/store';
+import { ConfigService } from 'app/config/config.service';
+import { Observable } from 'rxjs';
+import { of } from 'rxjs/internal/observable/of';
+import { GeneScores } from './gene-scores';
+import { GeneScoresComponent } from './gene-scores.component';
+import { GeneScoresService } from './gene-scores.service';
+import { GeneScoresState } from './gene-scores.state';
+
+class MockGeneScoresService {
+  public provide = true;
+  public getGeneScores(geneScoresIds?: string): Observable<GeneScores[]> {
+    if (this.provide) {
+      return of([new GeneScores([1, 2], 'score3', [4, 5], 'desc6', [7, 8], 'xScale9', 'yScale10'),
+        new GeneScores([11, 12], 'score13', [14, 15], 'desc16', [17, 18], 'xScale19', 'yScale20')
+      ]);
+    } else {
+      return of([] as GeneScores[]);
+    }
+  }
+}
+describe('GeneScoresComponent', () => {
+  let component: GeneScoresComponent;
+  let fixture: ComponentFixture<GeneScoresComponent>;
+  const mockGeneScoresService: MockGeneScoresService = new MockGeneScoresService();
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NgxsModule.forRoot([GeneScoresState], {developmentMode: true}), HttpClientTestingModule, NgbNavModule
+      ],
+      declarations: [GeneScoresComponent],
+      providers: [{provide: GeneScoresService, useValue: mockGeneScoresService}, ConfigService],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GeneScoresComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should test empty gene sets', () => {
+    expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).toBeTruthy();
+    mockGeneScoresService.provide = false;
+    component.selectedGeneScores = undefined as any;
+    component.ngOnInit();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(fixture.debugElement.query(By.css('div > div.form-block > div.card > ul > li > span'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).not.toBeTruthy();
+    });
+  });
+});
+

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -14,7 +14,7 @@ import { GeneScoresState } from './gene-scores.state';
 
 class MockGeneScoresService {
   public provide = true;
-  public getGeneScores(_geneScoresIds?: string): Observable<GeneScores[]> {
+  public getGeneScores(): Observable<GeneScores[]> {
     if (this.provide) {
       return of([new GeneScores([1, 2], 'score3', [4, 5], 'desc6', [7, 8], 'xScale9', 'yScale10'),
         new GeneScores([11, 12], 'score13', [14, 15], 'desc16', [17, 18], 'xScale19', 'yScale20')

--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -65,8 +65,8 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
         for (const geneScore of this.geneScoresArray) {
           if (geneScore.score === state.geneScore.score) {
             this.selectedGeneScores = geneScore;
-            this.rangeStart = state.rangeStart;
-            this.rangeEnd = state.rangeEnd;
+            this.rangeStart = state.rangeStart as number;
+            this.rangeEnd = state.rangeEnd as number;
             break;
           }
         }

--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -128,13 +128,13 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
   }
 
   private getDownloadUrl(): string {
-    if(this.selectedGeneScores !== undefined) {
+    if (this.selectedGeneScores !== undefined) {
       return `${this.config.baseUrl}gene_scores/download/${this.selectedGeneScores.score}`;
     }
   }
 
   private changeDomain(scores: GeneScores): void {
-    if(scores !== undefined) {
+    if (scores !== undefined) {
       if (scores.domain !== null) {
         this.geneScoresLocalState.domainMin = scores.domain[0];
         this.geneScoresLocalState.domainMax = scores.domain[1];

--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -81,7 +81,7 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
 
   private updateLabels(): void {
     this.rangeChanges.next([
-      this.geneScoresLocalState.score.score,
+      this.geneScoresLocalState.score?.score,
       this.rangeStart,
       this.rangeEnd
     ]);
@@ -128,16 +128,20 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
   }
 
   private getDownloadUrl(): string {
-    return `${this.config.baseUrl}gene_scores/download/${this.selectedGeneScores.score}`;
+    if(this.selectedGeneScores !== undefined) {
+      return `${this.config.baseUrl}gene_scores/download/${this.selectedGeneScores.score}`;
+    }
   }
 
   private changeDomain(scores: GeneScores): void {
-    if (scores.domain !== null) {
-      this.geneScoresLocalState.domainMin = scores.domain[0];
-      this.geneScoresLocalState.domainMax = scores.domain[1];
-    } else {
-      this.geneScoresLocalState.domainMin = scores.bins[0];
-      this.geneScoresLocalState.domainMax = scores.bins[scores.bins.length - 1];
+    if(scores !== undefined) {
+      if (scores.domain !== null) {
+        this.geneScoresLocalState.domainMin = scores.domain[0];
+        this.geneScoresLocalState.domainMax = scores.domain[1];
+      } else {
+        this.geneScoresLocalState.domainMin = scores?.bins[0];
+        this.geneScoresLocalState.domainMax = scores?.bins[scores.bins.length - 1];
+      }
     }
   }
 }

--- a/src/app/gene-sets/gene-sets.component.html
+++ b/src/app/gene-sets/gene-sets.component.html
@@ -1,70 +1,95 @@
-<div class="row panel" id="gene-sets-panel" style="margin-left: 0px; margin-right: 0px">
-  <div class="col-sm-3">
-    <div class="select-wrapper">
-      <select class="row-sm-3 form-control" [(ngModel)]="selectedGeneSetsCollection" required style="width: 100%">
-        <option *ngFor="let collection of geneSetsCollections" [ngValue]="collection">{{ collection.desc }}</option>
-      </select>
-      <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"> </span>
-    </div>
-    <ngb-accordion
-      *ngIf="selectedGeneSetsCollection?.types"
-      activeIds="{{ defaultSelectedDenovoGeneSetId }}"
-      [destroyOnHide]="false"
-      #acc="ngbAccordion"
-      class="gene-sets-types row-sm-3">
-      <ngb-panel
-        *ngFor="let type of selectedGeneSetsCollection.types"
-        id="{{ type.datasetId }}-{{ type.personSetCollectionId }}-denovo-geneset">
-        <ng-template ngbPanelTitle *ngIf="selectedGeneSetsCollection?.types?.length > 0">
-          <div style="text-align: left">
-            <span style="display: block" class="btn-sm text-wrap"
-              >{{ type.datasetName }}: {{ type.personSetCollectionName }}</span
-            >
-          </div>
-        </ng-template>
-        <ng-template ngbPanelContent>
-          <div *ngFor="let personSet of type.personSetCollectionLegend">
-            <label [attr.for]="type.datasetId + '-checkbox-' + personSet.id">
-              <input
-                type="checkbox"
-                [attr.id]="type.datasetId + '-checkbox-' + personSet.id"
-                [ngModel]="isSelectedGeneType(type.datasetId, type.personSetCollectionId, personSet.id)"
-                (ngModelChange)="
-                  setSelectedGeneType(type.datasetId, type.personSetCollectionId, personSet.id, $event); onSearch()
-                " />
-              <span class="pedigree-icon" [style.background-color]="personSet.color"></span>
-              <span>{{ personSet.name }}</span>
-            </label>
-          </div>
-        </ng-template>
-      </ngb-panel>
-    </ngb-accordion>
-  </div>
-
-  <div class="col-sm-9">
-    <gpf-searchable-select
-      (search)="onSearch($event)"
-      (selectItem)="onSelect($event)"
-      [data]="geneSets"
-      caption="{{
-        selectedGeneSet ? selectedGeneSet.name + ' (' + selectedGeneSet.count + '): ' + selectedGeneSet.desc : ''
-      }}">
-      <div *gpf-searchable-select-template="let element">
-        <span
-          data-toggle="tooltip"
-          data-placement="bottom"
-          title="{{ element.name }} ({{ element.count }}): {{ element.desc }}"
-          innerHtml="{{ element.name | boldMatching: searchQuery }} ({{ element.count }}): {{
-            element.desc | boldMatching: searchQuery
-          }}">
-        </span>
+<div *ngIf="selectedGeneSetsCollection">
+  <div class="row panel" id="gene-sets-panel" style="margin-left: 0px; margin-right: 0px">
+    <div class="col-sm-3">
+      <div class="select-wrapper">
+        <select class="row-sm-3 form-control" [(ngModel)]="selectedGeneSetsCollection" required style="width: 100%">
+          <option *ngFor="let collection of geneSetsCollections" [ngValue]="collection">{{ collection.desc }}</option>
+        </select>
+        <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"> </span>
       </div>
-    </gpf-searchable-select>
-    <div *ngIf="selectedGeneSet">
-      <span style="margin-right: 5px">Count: {{ selectedGeneSet.count }}</span>
-      <span>(<a class="download-link" href="{{ downloadUrl }}">Download</a>)</span>
+      <ngb-accordion
+        *ngIf="selectedGeneSetsCollection?.types"
+        activeIds="{{ defaultSelectedDenovoGeneSetId }}"
+        [destroyOnHide]="false"
+        #acc="ngbAccordion"
+        class="gene-sets-types row-sm-3">
+        <ngb-panel
+          *ngFor="let type of selectedGeneSetsCollection.types"
+          id="{{ type.datasetId }}-{{ type.personSetCollectionId }}-denovo-geneset">
+          <ng-template ngbPanelTitle *ngIf="selectedGeneSetsCollection?.types?.length > 0">
+            <div style="text-align: left">
+              <span style="display: block" class="btn-sm text-wrap"
+                >{{ type.datasetName }}: {{ type.personSetCollectionName }}</span
+              >
+            </div>
+          </ng-template>
+          <ng-template ngbPanelContent>
+            <div *ngFor="let personSet of type.personSetCollectionLegend">
+              <label [attr.for]="type.datasetId + '-checkbox-' + personSet.id">
+                <input
+                  type="checkbox"
+                  [attr.id]="type.datasetId + '-checkbox-' + personSet.id"
+                  [ngModel]="isSelectedGeneType(type.datasetId, type.personSetCollectionId, personSet.id)"
+                  (ngModelChange)="
+                    setSelectedGeneType(type.datasetId, type.personSetCollectionId, personSet.id, $event); onSearch()
+                  " />
+                <span class="pedigree-icon" [style.background-color]="personSet.color"></span>
+                <span>{{ personSet.name }}</span>
+              </label>
+            </div>
+          </ng-template>
+        </ngb-panel>
+      </ngb-accordion>
     </div>
 
-    <gpf-errors-alert [errors]="errors"></gpf-errors-alert>
+    <div class="col-sm-9">
+      <gpf-searchable-select
+        (search)="onSearch($event)"
+        (selectItem)="onSelect($event)"
+        [data]="geneSets"
+        caption="{{
+          selectedGeneSet ? selectedGeneSet.name + ' (' + selectedGeneSet.count + '): ' + selectedGeneSet.desc : ''
+        }}">
+        <div *gpf-searchable-select-template="let element">
+          <span
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title="{{ element.name }} ({{ element.count }}): {{ element.desc }}"
+            innerHtml="{{ element.name | boldMatching: searchQuery }} ({{ element.count }}): {{
+              element.desc | boldMatching: searchQuery
+            }}">
+          </span>
+        </div>
+      </gpf-searchable-select>
+      <div *ngIf="selectedGeneSet">
+        <span style="margin-right: 5px">Count: {{ selectedGeneSet.count }}</span>
+        <span>(<a class="download-link" href="{{ downloadUrl }}">Download</a>)</span>
+      </div>
+
+      <gpf-errors-alert [errors]="errors"></gpf-errors-alert>
+    </div>
+  </div>
+</div>
+
+<div *ngIf="geneSetsLoaded === null">
+  <div class="form-block" style="display: contents">
+    <div class="card">
+      <ul ngbNav #nav="ngbNav" class="navbar bg-light nav-pills" style="justify-content: center">
+        <li ngbNavItem>
+          <span style="opacity: 75%"><i>Loading gene sets...</i></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+<div *ngIf="!selectedGeneSetsCollection && geneSetsLoaded !== null">
+  <div class="form-block" style="display: contents">
+    <div class="card">
+      <ul ngbNav #nav="ngbNav" class="navbar bg-light nav-pills" style="justify-content: center">
+        <li ngbNavItem>
+          <span style="opacity: 75%"><i>No gene sets collections available</i></span>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/src/app/gene-sets/gene-sets.component.spec.ts
+++ b/src/app/gene-sets/gene-sets.component.spec.ts
@@ -104,7 +104,7 @@ describe('GeneSetsComponent', () => {
   it('should change the gene set', () => {
     const geneSetMock1 = new GeneSet('name1', 1, 'desc1', 'download1');
     component.selectedGeneSet = geneSetMock1;
-    expect(component.selectedGeneSet).toEqual(GeneSet.fromJson({
+    expect(component.selectedGeneSet).toStrictEqual(GeneSet.fromJson({
       name: 'name1',
       count: 1,
       desc: 'desc1',
@@ -168,7 +168,7 @@ describe('GeneSetsComponent', () => {
     expect(spy).not.toHaveBeenCalledWith();
 
     component.onSelect(null);
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith();
   });
 
   it('should set onSearch', () => {
@@ -187,7 +187,7 @@ describe('GeneSetsComponent', () => {
     ];
     component.onSearch('name15');
     expect(component.searchQuery).toBe('name15');
-    expect(component.geneSets).toEqual([]);
+    expect(component.geneSets).toStrictEqual([]);
 
     component.geneSets = [
       new GeneSet('name13', 14, 'desc15', 'download16'),
@@ -195,7 +195,7 @@ describe('GeneSetsComponent', () => {
       new GeneSet('name17', 21, 'desc20', 'download21')
     ];
     component.onSearch('name17');
-    expect(component.geneSets).toEqual([
+    expect(component.geneSets).toStrictEqual([
       new GeneSet('name17', 18, 'desc19', 'download20'),
       new GeneSet('name17', 21, 'desc20', 'download21')]);
   });

--- a/src/app/gene-sets/gene-sets.component.spec.ts
+++ b/src/app/gene-sets/gene-sets.component.spec.ts
@@ -15,15 +15,12 @@ import { Observable } from 'rxjs/internal/Observable';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { GeneSetsState } from './gene-sets.state';
-import { FormsModule } from '@angular/forms';
-
 
 class MockDatasetsService {
   public getSelectedDataset(): object {
     return { id: 'testDataset' };
   }
 }
-
 class MockGeneSetsService {
   public provide = true;
 

--- a/src/app/gene-sets/gene-sets.component.spec.ts
+++ b/src/app/gene-sets/gene-sets.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgxsModule } from '@ngxs/store';
 import { ConfigService } from 'app/config/config.service';
@@ -75,7 +75,7 @@ describe('GeneSetsComponent', () => {
   let fixture: ComponentFixture<GeneSetsComponent>;
   const datasetsServiceMock = new MockDatasetsService();
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [GeneSetsComponent],
       imports: [
@@ -89,9 +89,7 @@ describe('GeneSetsComponent', () => {
         ConfigService, GeneSetsService, { provide: DatasetsService, useValue: datasetsServiceMock }, UsersService
       ], schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(GeneSetsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -208,7 +206,7 @@ describe('GeneSetsComponent MockedGeneSetsService', () => {
   const datasetsServiceMock = new MockDatasetsService();
   const mockGeneSetsService = new MockGeneSetsService();
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [GeneSetsComponent],
       imports: [
@@ -224,9 +222,7 @@ describe('GeneSetsComponent MockedGeneSetsService', () => {
         }, { provide: DatasetsService, useValue: datasetsServiceMock }, UsersService
       ], schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(GeneSetsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -24,7 +24,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
   public searchQuery: string;
   public defaultSelectedDenovoGeneSetId: string[] = [];
 
-  private geneSetsQueryChange = new Subject<[string, string, Object]>();
+  private geneSetsQueryChange = new Subject<[string, string, object]>();
   private geneSetsResult: Observable<GeneSet[]>;
 
   private selectedDatasetId: string;

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '../config/config.service';
 import { GeneSetsLocalState } from './gene-sets-state';
 import { Component, OnInit } from '@angular/core';
 import { GeneSetsService } from './gene-sets.service';
-import { GeneSetsCollection, GeneSet } from './gene-sets';
+import { GeneSetsCollection, GeneSet, GeneSetType } from './gene-sets';
 import { Subject, Observable, combineLatest, of } from 'rxjs';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { ValidateNested } from 'class-validator';
@@ -11,6 +11,7 @@ import { SetGeneSetsValues, GeneSetsState } from './gene-sets.state';
 import { catchError, debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { StatefulComponent } from 'app/common/stateful-component';
 import { environment } from 'environments/environment';
+import { PersonSet } from 'app/datasets/datasets';
 
 @Component({
   selector: 'gpf-gene-sets',
@@ -126,7 +127,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
     }
   }
 
-  private restoreGeneTypes(geneSetsTypes, geneSetCollection: GeneSetsCollection): void {
+  private restoreGeneTypes(geneSetsTypes: GeneSetType[], geneSetCollection: GeneSetsCollection): void {
     const geneTypes = geneSetCollection.types
       .filter(geneType => geneType.datasetId in geneSetsTypes &&
               geneType.personSetCollectionId in geneSetsTypes[geneType.datasetId]);
@@ -135,7 +136,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
       for (const geneType of geneTypes) {
         const datasetId = geneType.datasetId;
         const personSetCollectionId = geneType.personSetCollectionId;
-        for (const personSet of geneType.personSetCollectionLegend) {
+        for (const personSet of geneType.personSetCollectionLegend as PersonSet[]) {
           if (geneSetsTypes[datasetId][personSetCollectionId].indexOf(personSet.id) > -1) {
             const denovoGeneSetId = `${datasetId}-${personSetCollectionId}-denovo-geneset`;
             if (!this.defaultSelectedDenovoGeneSetId.includes(denovoGeneSetId)) {
@@ -162,7 +163,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
     }
 
     this.geneSetsQueryChange.next(
-      [this.selectedGeneSetsCollection.name, searchTerm, this.geneSetsLocalState.geneSetsTypes]
+      [this.selectedGeneSetsCollection.name, searchTerm, this.geneSetsLocalState.geneSetsTypes as GeneSetType[]]
     );
   }
 
@@ -202,7 +203,8 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
       ) || selectedGeneSetsCollection.types[0];
 
       this.setSelectedGeneType(
-        geneSetType.datasetId, geneSetType.personSetCollectionId, geneSetType.personSetCollectionLegend[0].id, true
+        geneSetType.datasetId, geneSetType.personSetCollectionId,
+        geneSetType.personSetCollectionLegend[0].id as string, true
       );
     }
 

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -15,7 +15,7 @@ import { environment } from 'environments/environment';
 @Component({
   selector: 'gpf-gene-sets',
   templateUrl: './gene-sets.component.html',
-  styleUrls: ['./gene-sets.component.css'],
+  styleUrls: ['./gene-sets.component.css']
 })
 export class GeneSetsComponent extends StatefulComponent implements OnInit {
   public geneSetsCollections: Array<GeneSetsCollection>;
@@ -28,6 +28,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
 
   private selectedDatasetId: string;
   public downloadUrl: string;
+  public geneSetsLoaded = 0;
 
   public imgPathPrefix = environment.imgPathPrefix;
 
@@ -44,6 +45,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
   }
 
   public ngOnInit(): void {
+    this.geneSetsLoaded = null;
     super.ngOnInit();
 
     this.selectedDatasetId = this.datasetService.getSelectedDataset().id;
@@ -77,6 +79,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
       this.geneSetsCollections = geneSetsCollections;
       this.selectedGeneSetsCollection = geneSetsCollections[0];
       this.restoreState(state);
+      this.geneSetsLoaded = geneSetsCollections.length;
     });
 
     this.geneSetsResult = this.geneSetsQueryChange.pipe(
@@ -193,7 +196,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
     this.geneSetsLocalState.geneSetsTypes = Object.create(null);
     this.geneSets = [];
 
-    if (selectedGeneSetsCollection.types.length > 0) {
+    if (selectedGeneSetsCollection?.types.length > 0) {
       const geneSetType = selectedGeneSetsCollection.types.find(
         genesetType => genesetType.datasetId === this.selectedDatasetId
       ) || selectedGeneSetsCollection.types[0];


### PR DESCRIPTION
## Background

GPF has never been tested on a empty dataset. When there is no data for the dataset, the gene scores, and the gene sets there are issues that don't give enough information about where is the problem. The instance doesn't know how to behave and throws unknown exceptions.

## Aim

The aim is to make the GPF as explicit as possible thus aiming for consistency.

## Implementation

The implementation consists of new ways of handling exceptions where not enough data is given. When there is an empty GPF instance the browser now doesn't display anything which closes #628. When there are no gene sets the browser now displays  - "No gene sets available", also now the instance waits for a response and meanwhile displays - "Loading gene sets" which closes #629. When there is no gene scores data the browser displays a more explicit exception - "No gene scores available" which closes #630.
 