### PR TITLE
NAN bug in genotype preview table

### DIFF
--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -24,16 +24,23 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
     this.formattedValue = this.formatValue();
   }
 
+  private doFormat(format, value) {
+    if(value === 'nan') {
+      return value;
+    }
+    return sprintf(format, value);
+  }
+
   public formatValue() {
     if (this.value) {
       if (this.format) {
         if (this.value.constructor === Array) {
-          return this.value.map(x => x === "-" ? "-" : sprintf(this.format, x));
+          return this.value.map(x => x === '-' ? '-' : this.doFormat(this.format, x));
         }
         if (typeof this.value === 'string') {
           return this.value;
         }
-        return sprintf(this.format, this.value);
+        return this.doFormat(this.format, this.value);
       }
       return this.value;
     }


### PR DESCRIPTION
## Background

The genotype preview table is a frequently used component. There is a bug that provides NaN to the table and the table doesn't know how to render it due to helper functions that format how the data is displayed into the cells.

## Aim

The aim is to provide flexibility and avoid sudden crashes in the table.

## Implementation

The implementation consists of helper function that provides sprintf correct data according to the different cases data is provided.
