### PR TITLE
#649 fix log out button word break issue

### DIFF
--- a/src/app/users/users.component.css
+++ b/src/app/users/users.component.css
@@ -1,4 +1,5 @@
 #log-out-button {
   padding: 4px 8px;
   border: 1px solid #ddd;
+  white-space: nowrap;
 }


### PR DESCRIPTION
When resizing, the "Log Out" button would word-break and move to 2 rows (see img in issue)