### PR TITLE
Multiple chromosomes gene browser fix

### DIFF
--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -43,10 +43,10 @@ class MockGeneService {
   public getGene(): Observable<Record<string, unknown>> {
     return of({
       geneSymbol: 'POGZ',
-      collapsedTranscript: {
+      collapsedTranscripts: [{
         start: 1,
         stop: 2
-      },
+      }],
       getRegionString: () => ''
     });
   }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -168,8 +168,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     this.variantTypeValues.forEach(vt => this.checkVariantType(vt, true));
 
     this.summaryVariantsFilter.selectedRegion = [
-      this.selectedGene.collapsedTranscript.start,
-      this.selectedGene.collapsedTranscript.stop
+      this.selectedGene.collapsedTranscripts[0].start,
+      this.selectedGene.collapsedTranscripts[this.selectedGene.collapsedTranscripts.length - 1].stop
     ];
     this.summaryVariantsFilter.selectedFrequencies = [
       0, this.geneBrowserConfig.domainMax

--- a/src/app/gene-browser/gene.spec.ts
+++ b/src/app/gene-browser/gene.spec.ts
@@ -1,3 +1,4 @@
+import { IS_RFC_3339 } from 'class-validator';
 import { Transcript, Gene, TranscriptSegment } from './gene';
 
 describe('TranscriptSegment', () => {
@@ -157,14 +158,14 @@ describe('Transcript', () => {
     ];
 
     for (let i = 0; i < transcript.segments.length; i++) {
-      expect(transcript.segments[i].chromosome).toEqual(expectedSegments[i].chromosome);
-      expect(transcript.segments[i].start).toEqual(expectedSegments[i].start);
-      expect(transcript.segments[i].stop).toEqual(expectedSegments[i].stop);
-      expect(transcript.segments[i].isExon).toEqual(expectedSegments[i].isExon);
-      expect(transcript.segments[i].isCDS).toEqual(expectedSegments[i].isCDS);
-      expect(transcript.segments[i].isSpacer).toEqual(expectedSegments[i].isSpacer);
-      expect(transcript.segments[i].label).toEqual(expectedSegments[i].label);
-      expect(transcript.segments[i].length).toEqual(expectedSegments[i].length);
+      expect(transcript.segments[i].chromosome).toStrictEqual(expectedSegments[i].chromosome);
+      expect(transcript.segments[i].start).toStrictEqual(expectedSegments[i].start);
+      expect(transcript.segments[i].stop).toStrictEqual(expectedSegments[i].stop);
+      expect(transcript.segments[i].isExon).toStrictEqual(expectedSegments[i].isExon);
+      expect(transcript.segments[i].isCDS).toStrictEqual(expectedSegments[i].isCDS);
+      expect(transcript.segments[i].isSpacer).toStrictEqual(expectedSegments[i].isSpacer);
+      expect(transcript.segments[i].label).toStrictEqual(expectedSegments[i].label);
+      expect(transcript.segments[i]).toHaveLength(expectedSegments[i].length);
     }
   });
 
@@ -176,14 +177,14 @@ describe('Transcript', () => {
       cds: [{ chromosome: 'chr1', start: 1, stop: 10 }, { chromosome: 'chr2', start: 11, stop: 20 }],
       exons: [{ chromosome: 'chr3', start: 21, stop: 31}, { chromosome: 'chr4', start: 32, stop: 43 }]
     });
-    expect(transcript.transcriptId).toEqual('testTranscriptId');
-    expect(transcript.chromosome).toEqual('testChrom');
-    expect(transcript.strand).toEqual('testStrand');
-    expect(transcript.codingSequences).toEqual([
+    expect(transcript.transcriptId).toBe('testTranscriptId');
+    expect(transcript.chromosome).toBe('testChrom');
+    expect(transcript.strand).toBe('testStrand');
+    expect(transcript.codingSequences).toStrictEqual([
       { chromosome: 'chr1', start: 1, stop: 10 },
       { chromosome: 'chr2', start: 11, stop: 20 }
     ]);
-    expect(transcript.exons).toEqual([
+    expect(transcript.exons).toStrictEqual([
       { chromosome: 'chr3', start: 21, stop: 31 },
       { chromosome: 'chr4', start: 32, stop: 43 }
     ]);
@@ -218,7 +219,7 @@ describe('Gene', () => {
         'id1',
         'chrom1',
         'strand1',
-        [{ chromosome: 'coding1', start: 1, stop: 5 },
+        [{ chromosome: 'coding1', start: 1, stop: 10 },
           { chromosome: 'coding2', start: 12, stop: 15 }],
         [{ chromosome: 'exon1', start: 7, stop: 11 },
           { chromosome: 'exon2', start: 20, stop: 25 }]
@@ -230,23 +231,31 @@ describe('Gene', () => {
         [{ chromosome: 'coding3', start: 3, stop: 10 },
           { chromosome: 'coding4', start: 18, stop: 20 }],
         [{ chromosome: 'exon3', start: 13, stop: 16 },
-          { chromosome: 'exon4', start: 18, stop: 22 }]
+          { chromosome: 'exon4', start: 18, stop: 25 }]
       )
     ];
-    const expectedCollapsedTranscript = new Transcript(
-      'collapsed',
-      'strand1',
-      'chrom1',
-      [{ chromosome: 'coding1', start: 1, stop: 10 },
-        { chromosome: 'coding2', start: 12, stop: 15 },
-        { chromosome: 'coding4', start: 18, stop: 20 }],
-      [{ chromosome: 'exon1', start: 7, stop: 11 },
-        { chromosome: 'exon3', start: 13, stop: 16 },
-        { chromosome: 'exon4', start: 18, stop: 25 }]
-    );
+
+    const expectedTranscripts = [
+      new Transcript(
+        'collapsed',
+        'chrom1',
+        'strand1',
+        [{ chromosome: 'coding1', start: 1, stop: 10 },
+          { chromosome: 'coding2', start: 12, stop: 15 }],
+        [{ chromosome: 'exon1', start: 7, stop: 11 }, { chromosome: 'exon2', start: 20, stop: 25 }]
+      ),
+      new Transcript(
+        'collapsed',
+        'chrom2',
+        'strand1',
+        [{chromosome: 'coding3', start: 3, stop: 10}, { chromosome: 'coding4', start: 18, stop: 20 }],
+        [{ chromosome: 'exon3', start: 13, stop: 16 },
+          { chromosome: 'exon4', start: 18, stop: 25 }]
+      )
+    ];
 
     const gene = new Gene('gene1', transcripts);
-    expect(gene.collapsedTranscript).toEqual(expectedCollapsedTranscript);
+    expect(gene.collapsedTranscripts).toStrictEqual(expectedTranscripts);
   });
 
   it('should set chromosomes during construction', () => {
@@ -278,8 +287,8 @@ describe('Gene', () => {
     ];
 
     const gene = new Gene('gene1', transcripts);
-    expect(gene.chromosomes.get('chrom1')).toEqual([3, 35]);
-    expect(gene.chromosomes.get('chrom2')).toEqual([13, 22]);
+    expect(gene.chromosomes.get('chrom1')).toStrictEqual([3, 35]);
+    expect(gene.chromosomes.get('chrom2')).toStrictEqual([13, 22]);
   });
 
   it('should create from json', () => {
@@ -319,7 +328,7 @@ describe('Gene', () => {
     ];
     const gene = new Gene('gene1', transcripts);
 
-    expect(geneFromJson).toEqual(gene);
+    expect(geneFromJson).toStrictEqual(gene);
   });
 
   it('should get region string', () => {
@@ -355,5 +364,61 @@ describe('Gene', () => {
     expect(gene.getRegionString(7, 10)).toEqual(['chrom1:7-10', 'chrom3:7-10']);
     expect(gene.getRegionString(0, 6)).toEqual(['chrom3:3-6']);
     expect(gene.getRegionString(27, 100)).toEqual(['chrom3:27-35']);
+  });
+
+  it('should check gene on multiple chromosomes', () => {
+    const transcripts = [
+      new Transcript(
+        'id1',
+        'chrom1',
+        'strand1',
+        [{ chromosome: '', start: 0, stop: 0 }],
+        [{ chromosome: 'exon1', start: 7, stop: 11 },
+          { chromosome: 'exon2', start: 20, stop: 25 }]
+      ),
+      new Transcript(
+        'id2',
+        'chrom2',
+        'strand2',
+        [{ chromosome: '', start: 0, stop: 0 }],
+        [{ chromosome: 'exon3', start: 13, stop: 16 },
+          { chromosome: 'exon4', start: 18, stop: 22 }]
+      ),
+      new Transcript(
+        'id3',
+        'chrom3',
+        'strand3',
+        [{ chromosome: '', start: 0, stop: 0 }],
+        [{ chromosome: 'exon5', start: 3, stop: 16 },
+          { chromosome: 'exon6', start: 18, stop: 35 }]
+      )
+    ];
+
+    const gene = new Gene('gene1', transcripts);
+    expect(gene.collapsedTranscripts).toHaveLength(transcripts.length);
+    expect(gene.collapsedTranscripts[0]).toStrictEqual(new Transcript(
+      'collapsed',
+      'chrom1',
+      'strand1',
+      [{ chromosome: '', start: 0, stop: 0 }],
+      [{ chromosome: 'exon1', start: 7, stop: 11 },
+        { chromosome: 'exon2', start: 20, stop: 25 }]
+    ));
+    expect(gene.collapsedTranscripts[1]).toStrictEqual(new Transcript(
+      'collapsed',
+      'chrom2',
+      'strand1',
+      [{ chromosome: '', start: 0, stop: 0 }],
+      [{ chromosome: 'exon3', start: 13, stop: 16 },
+        { chromosome: 'exon4', start: 18, stop: 22 }]
+    ));
+    expect(gene.collapsedTranscripts[2]).toStrictEqual(new Transcript(
+      'collapsed',
+      'chrom3',
+      'strand1',
+      [{ chromosome: '', start: 0, stop: 0 }],
+      [{ chromosome: 'exon5', start: 3, stop: 16 },
+        { chromosome: 'exon6', start: 18, stop: 35 }]
+    ));
   });
 });

--- a/src/app/gene-browser/gene.spec.ts
+++ b/src/app/gene-browser/gene.spec.ts
@@ -1,4 +1,3 @@
-import { IS_RFC_3339 } from 'class-validator';
 import { Transcript, Gene, TranscriptSegment } from './gene';
 
 describe('TranscriptSegment', () => {
@@ -219,10 +218,17 @@ describe('Gene', () => {
         'id1',
         'chrom1',
         'strand1',
-        [{ chromosome: 'coding1', start: 1, stop: 10 },
+        [{ chromosome: 'coding1', start: 1, stop: 5 },
           { chromosome: 'coding2', start: 12, stop: 15 }],
         [{ chromosome: 'exon1', start: 7, stop: 11 },
           { chromosome: 'exon2', start: 20, stop: 25 }]
+      ),
+      new Transcript(
+        'id1.2',
+        'chrom1',
+        'strand1',
+        [{ chromosome: 'coding1.2', start: 3, stop: 10 }],
+        [{ chromosome: 'exon1', start: 7, stop: 11 }]
       ),
       new Transcript(
         'id2',
@@ -247,7 +253,7 @@ describe('Gene', () => {
       new Transcript(
         'collapsed',
         'chrom2',
-        'strand1',
+        'strand2',
         [{chromosome: 'coding3', start: 3, stop: 10}, { chromosome: 'coding4', start: 18, stop: 20 }],
         [{ chromosome: 'exon3', start: 13, stop: 16 },
           { chromosome: 'exon4', start: 18, stop: 25 }]
@@ -407,7 +413,7 @@ describe('Gene', () => {
     expect(gene.collapsedTranscripts[1]).toStrictEqual(new Transcript(
       'collapsed',
       'chrom2',
-      'strand1',
+      'strand2',
       [{ chromosome: '', start: 0, stop: 0 }],
       [{ chromosome: 'exon3', start: 13, stop: 16 },
         { chromosome: 'exon4', start: 18, stop: 22 }]
@@ -415,7 +421,7 @@ describe('Gene', () => {
     expect(gene.collapsedTranscripts[2]).toStrictEqual(new Transcript(
       'collapsed',
       'chrom3',
-      'strand1',
+      'strand3',
       [{ chromosome: '', start: 0, stop: 0 }],
       [{ chromosome: 'exon5', start: 3, stop: 16 },
         { chromosome: 'exon6', start: 18, stop: 35 }]

--- a/src/app/gene-browser/gene.ts
+++ b/src/app/gene-browser/gene.ts
@@ -21,7 +21,7 @@ function mergeSegments(exons: Segment[]): Segment[] {
   return result;
 }
 
-function collapseTranscripts(transcripts: Transcript[]): Transcript {
+function collapseSegments(transcripts: Transcript[]): Transcript {
   const allExons: Segment[] = [];
   const allCodingSequences: Segment[] = [];
   for (const transcript of transcripts) {
@@ -169,16 +169,16 @@ export class Transcript {
 }
 
 export class Gene {
-  public readonly collapsedTranscript: Transcript;
+  public readonly allSegments: TranscriptSegment[] = [];
   public readonly collapsedTranscripts: Transcript[];
   public readonly chromosomes: Map<string, [number, number]>;
+  public readonly medianExon: Map<string, number>;
+  public readonly medianExonLength;
 
   public constructor(
     public readonly geneSymbol: string,
     public readonly transcripts: Transcript[]
   ) {
-    this.collapsedTranscript = collapseTranscripts(this.transcripts);
-
     this.chromosomes = new Map<string, [number, number]>();
     for (const transcript of this.transcripts) {
       if (!this.chromosomes.has(transcript.chromosome)) {
@@ -193,6 +193,8 @@ export class Gene {
     this.collapsedTranscripts = collapseMultipleTranscripts(
       new Array(...this.chromosomes).map(chrom => chrom[0]), this.transcripts
     );
+    this.allSegments = collapseSegments(transcripts).segments;
+    this.medianExonLength = collapseSegments(transcripts).medianExonLength;
   }
 
   public static fromJson(json: object): Gene {

--- a/src/app/gene-browser/gene.ts
+++ b/src/app/gene-browser/gene.ts
@@ -29,7 +29,7 @@ function collapseSegments(transcripts: Transcript[]): Transcript {
     allCodingSequences.push(...transcript.codingSequences);
   }
   return new Transcript(
-    'collapsed', transcripts[0].strand, transcripts[0].chromosome,
+    'collapsed', transcripts[0].chromosome, transcripts[0].strand,
     mergeSegments(allCodingSequences), mergeSegments(allExons)
   );
 }
@@ -38,17 +38,7 @@ function collapseMultipleTranscripts(chromKeys: string[], transcripts: Transcrip
   let trans: Transcript[] = [];
   for (const key of chromKeys) {
     const chromosomeTranscripts = transcripts.filter(t => t.chromosome === key);
-    const allExons: Segment[] = [];
-    const allCodingSequences: Segment[] = [];
-    for (const transcript of chromosomeTranscripts) {
-      allExons.push(...transcript.exons);
-      allCodingSequences.push(...transcript.codingSequences);
-    }
-
-    trans.push(new Transcript(
-      'collapsed', key, transcripts[0].strand,
-      mergeSegments(allCodingSequences), mergeSegments(allExons)
-    ));
+    trans.push(collapseSegments(chromosomeTranscripts));
   }
   return trans;
 }
@@ -193,8 +183,9 @@ export class Gene {
     this.collapsedTranscripts = collapseMultipleTranscripts(
       new Array(...this.chromosomes).map(chrom => chrom[0]), this.transcripts
     );
-    this.allSegments = collapseSegments(transcripts).segments;
-    this.medianExonLength = collapseSegments(transcripts).medianExonLength;
+    const collapsedSegments = collapseSegments(transcripts);
+    this.allSegments = collapsedSegments.segments;
+    this.medianExonLength = collapsedSegments.medianExonLength;
   }
 
   public static fromJson(json: object): Gene {

--- a/src/app/gene-plot/gene-plot.component.spec.ts
+++ b/src/app/gene-plot/gene-plot.component.spec.ts
@@ -21,8 +21,4 @@ describe('GenePlotComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should check gene on multiple chromosomes', () => {
-    expect(component).toBeTruthy();
-  });
 });

--- a/src/app/gene-plot/gene-plot.component.spec.ts
+++ b/src/app/gene-plot/gene-plot.component.spec.ts
@@ -5,22 +5,24 @@ describe('GenePlotComponent', () => {
   let component: GenePlotComponent;
   let fixture: ComponentFixture<GenePlotComponent>;
 
-  beforeEach(async() => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       declarations: [GenePlotComponent]
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(GenePlotComponent);
     component = fixture.componentInstance;
-    (component.gene as any) = {geneSymbol: 'POGZ'};
-    (component['frequencyDomain'] as any) = [0, 0];
-    (component.allVariantsCounts as any) = [0, 0];
+    (component.gene as object) = {geneSymbol: 'POGZ'};
+    (component['frequencyDomain'] as [number, number]) = [0, 0];
+    (component.allVariantsCounts as [number, number]) = [0, 0];
     fixture.detectChanges();
   });
 
   it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should check gene on multiple chromosomes', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -364,13 +364,15 @@ export class GenePlotComponent implements OnChanges {
       transcriptY += this.constants.frequencyPlotPadding
         + ((this.genePlotModel.gene.collapsedTranscripts.length - 1) * this.constants.multipleChromosomesGap);
     } else {
-      this.drawTranscript(collapsedTranscriptElement, this.genePlotModel.gene.collapsedTranscript, transcriptY);
+      this.drawTranscript(collapsedTranscriptElement, this.genePlotModel.gene.collapsedTranscripts[0], transcriptY);
     }
 
     if (this.showTranscripts) {
       const transcriptsElement = this.plotElement.append('g').attr('id', 'transcripts');
       transcriptY += this.constants.collapsedTranscriptTextHeight
-        + this.constants.collapsedTranscriptPadding; // Add some extra padding after the collapsed transcript
+        + this.constants.collapsedTranscriptPadding
+        + (this.genePlotModel.gene.collapsedTranscripts.length > 1
+          ? this.constants.multipleChromosomesGap : 0); // Add some extra padding after the collapsed transcript
       for (const geneViewTranscript of this.genePlotModel.gene.transcripts) {
         transcriptY += this.constants.transcriptHeight;
         this.drawTranscript(transcriptsElement, geneViewTranscript, transcriptY);

--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -145,7 +145,7 @@ export class GenePlotComponent implements OnChanges {
   private get svgHeight(): number {
     const transcriptsCount = (
       this.showTranscripts ?
-        this.genePlotModel.gene.transcripts.length : this.genePlotModel.gene.collapsedTranscripts.length - 1) + 1;
+        this.genePlotModel.gene.transcripts.length : this.genePlotModel.gene.collapsedTranscripts.length);
     return this.frequencyPlotHeight
       + this.constants.frequencyPlotPadding
       + this.constants.margin.top
@@ -153,7 +153,7 @@ export class GenePlotComponent implements OnChanges {
       + this.constants.collapsedTranscriptTextHeight
       + (this.showTranscripts ? this.constants.collapsedTranscriptPadding : 0)
       + transcriptsCount * this.constants.transcriptHeight
-      + (this.constants.multipleChromosomesGap * (this.genePlotModel.gene.collapsedTranscripts.length - 1) * 1.5);
+      + (this.constants.multipleChromosomesGap * this.genePlotModel.gene.collapsedTranscripts.length * 1.5);
   }
 
   private get frequencyPlotHeight(): number {
@@ -370,9 +370,9 @@ export class GenePlotComponent implements OnChanges {
     if (this.showTranscripts) {
       const transcriptsElement = this.plotElement.append('g').attr('id', 'transcripts');
       transcriptY += this.constants.collapsedTranscriptTextHeight
-        + this.constants.collapsedTranscriptPadding
         + (this.genePlotModel.gene.collapsedTranscripts.length > 1
-          ? this.constants.multipleChromosomesGap : 0); // Add some extra padding after the collapsed transcript
+          ? this.constants.multipleChromosomesGap : 0)
+        + this.constants.collapsedTranscriptPadding; // Add some extra padding after the collapsed transcript;
       for (const geneViewTranscript of this.genePlotModel.gene.transcripts) {
         transcriptY += this.constants.transcriptHeight;
         this.drawTranscript(transcriptsElement, geneViewTranscript, transcriptY);
@@ -381,7 +381,8 @@ export class GenePlotComponent implements OnChanges {
   }
 
   private drawTranscript(
-    svgGroup: d3.Selection<SVGGElement, unknown, HTMLElement, any>, transcript: Transcript, yPos: number, flag = false
+    svgGroup: d3.Selection<SVGGElement, unknown, HTMLElement, any>,
+    transcript: Transcript, yPos: number, drawLabelsFlag = false
   ): void {
     const domainMin = this.scale.x.domain()[0];
     const domainMax = this.scale.x.domain()[this.scale.x.domain().length - 1];
@@ -407,7 +408,7 @@ export class GenePlotComponent implements OnChanges {
         nonCoding: this.constants.exonThickness.collapsed,
         coding: this.constants.cdsThickness.collapsed
       };
-      if (flag === false) {
+      if (!drawLabelsFlag) {
         this.drawChromosomeLabels(svgGroup, yPos);
       }
     }
@@ -431,13 +432,13 @@ export class GenePlotComponent implements OnChanges {
     let svgTitle: string;
 
     if (transcriptId !== 'collapsed') {
-      svgTitle =
-        `Transcript id: ${transcriptId}\nChromosome: ${transcript.chromosome}\nExons length: ${
-          this.commaSeparateNumber(exonsLength)
-        }`;
+      svgTitle = `Transcript id: ${transcriptId}` +
+        `\nChromosome: ${transcript.chromosome}` +
+        `\nExons length: ${this.commaSeparateNumber(exonsLength)}`;
     } else {
-      svgTitle =
-        `COLLAPSED TRANSCRIPT\n${this.chromosomesTitle}\nExons length: ${this.commaSeparateNumber(exonsLength)}`;
+      svgTitle = `COLLAPSED TRANSCRIPT` +
+        `\n${this.chromosomesTitle}` +
+        `\nExons length: ${this.commaSeparateNumber(exonsLength)}`;
     }
 
     draw.hoverText(
@@ -517,7 +518,7 @@ export class GenePlotComponent implements OnChanges {
           (this.scale.x(fromX) + this.scale.x(toX)) / 2 + chromosome.length * 3.3,
           yPos
           + this.constants.chromosomeLabelPadding
-          - this.constants.transcriptHeight + (counter * (this.constants.multipleChromosomesGap) * 2),
+          - this.constants.transcriptHeight + (counter * this.constants.multipleChromosomesGap * 2),
           chromosome,
           `Chromosome: ${chromosome}`,
           this.constants.fontSize

--- a/src/app/gene-plot/gene-plot.ts
+++ b/src/app/gene-plot/gene-plot.ts
@@ -19,7 +19,7 @@ export class GenePlotModel {
     this.condensedRange = this.buildRange(0, 3000000000, rangeWidth, true);
   }
 
-  public buildDomain(domainMin: number, domainMax: number) {
+  public buildDomain(domainMin: number, domainMax: number): number[] {
     const lastSegment = this.gene.allSegments[this.gene.allSegments.length - 1];
     return this.gene.allSegments
       .filter(seg => seg.intersectionLength(domainMin, domainMax) > 0)

--- a/src/app/gene-plot/gene-plot.ts
+++ b/src/app/gene-plot/gene-plot.ts
@@ -19,9 +19,9 @@ export class GenePlotModel {
     this.condensedRange = this.buildRange(0, 3000000000, rangeWidth, true);
   }
 
-  public buildDomain(domainMin: number, domainMax: number): number[] {
-    const lastSegment = this.gene.collapsedTranscript.segments[this.gene.collapsedTranscript.segments.length - 1];
-    return this.gene.collapsedTranscript.segments
+  public buildDomain(domainMin: number, domainMax: number) {
+    const lastSegment = this.gene.allSegments[this.gene.allSegments.length - 1];
+    return this.gene.allSegments
       .filter(seg => seg.intersectionLength(domainMin, domainMax) > 0)
       .map(seg => seg.intersection(domainMin, domainMax)[0])
       .concat(domainMax < lastSegment.stop ? domainMax : lastSegment.stop);
@@ -29,8 +29,8 @@ export class GenePlotModel {
 
   public buildRange(domainMin: number, domainMax: number, rangeWidth: number, condenseIntrons: boolean): number[] {
     const range: number[] = [0];
-    const medianExonLength: number = this.gene.collapsedTranscript.medianExonLength;
-    const filteredSegments = this.gene.collapsedTranscript.segments.filter(
+    const medianExonLength: number = this.gene.medianExonLength;
+    const filteredSegments = this.gene.allSegments.filter(
       seg => seg.intersectionLength(domainMin, domainMax) > 0
     );
 


### PR DESCRIPTION
## Background

In its current state, the gene browser can't draw introns or handle properly transcripts in an expected way. Instead, it only flattens all the different chromosome transcripts as one collapsed transcript.

## Aim

To develop a way to handle genes with multiple chromosome transcripts - to collapse different transcripts as one chromosome, thus displaying all the different chromosomes as different transcripts.

## Implementation

The gene browser now handles multiple transcripts when a gene has multiple chromosomes. Unit tests are also added.