### PR TITLE
Gene browser gene title position

### DIFF
--- a/src/app/gene-browser/gene-browser.component.css
+++ b/src/app/gene-browser/gene-browser.component.css
@@ -1,7 +1,7 @@
 .filter {
   margin-top: 40px;
-  margin-bottom: 40px;
-  height: 100px;
+  min-height: 100px;
+  margin-right: 30px;
 }
 
 .filter .card-block {
@@ -37,4 +37,5 @@
 #filters {
   display: flex;
   flex-wrap: wrap;
+  margin-bottom: 40px;
 }

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -89,10 +89,7 @@
         </div>
       </div>
 
-      <div
-        id="effect-types-filters"
-        class="effect-card card filter"
-        [ngStyle]="{ 'margin-left': geneBrowserConfig.hasAffectedStatus ? '30px' : '0' }">
+      <div id="effect-types-filters" class="effect-card card filter">
         <div class="card-header card-title">Effect Types</div>
         <div class="card-block">
           <div *ngFor="let effect of effectTypeValues; let i = index" class="checkbox">
@@ -109,7 +106,7 @@
         </div>
       </div>
 
-      <div id="inheritance-types-filters" class="effect-card card filter" style="margin-left: 30px">
+      <div id="inheritance-types-filters" class="effect-card card filter">
         <div class="card-header card-title">Inheritance Types</div>
         <div class="card-block">
           <div class="checkbox">
@@ -138,7 +135,7 @@
         </div>
       </div>
 
-      <div id="variant-types-filters" class="effect-card card filter" style="margin-left: 30px">
+      <div id="variant-types-filters" class="effect-card card filter">
         <div class="card-header card-title">Variant Types</div>
         <div class="card-block">
           <div *ngFor="let variantType of variantTypeValues; let i = index" class="checkbox">

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -1,8 +1,6 @@
 <div style="padding: 30px">
   <div class="effect-card card">
-    <div style="font-family: Roboto; font-weight: 500; border-bottom: none" class="card-header card-title">
-      Gene Symbols
-    </div>
+    <div style="font-family: Roboto; font-weight: 500; border-bottom: none" class="card-header card-title">Gene Symbols</div>
     <div class="card-block">
       <div ngbDropdown class="input-group panel" style="padding: 15px">
         <input

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -1,6 +1,8 @@
 <div style="padding: 30px">
   <div class="effect-card card">
-    <div style="font-family: Roboto; font-weight: 500; border-bottom: none" class="card-header card-title">Gene Symbols</div>
+    <div style="font-family: Roboto; font-weight: 500; border-bottom: none" class="card-header card-title">
+      Gene Symbols
+    </div>
     <div class="card-block">
       <div ngbDropdown class="input-group panel" style="padding: 15px">
         <input

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -44,7 +44,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public familyLoadingFinished: boolean;
   public geneBrowserConfig: GeneBrowser;
 
-  public readonly affectedStatusValues = ['Affected only', 'Unaffected only', 'Affected and unaffected'];;
+  public readonly affectedStatusValues = ['Affected only', 'Unaffected only', 'Affected and unaffected'];
   public readonly effectTypeValues = ['LGDs', 'missense', 'synonymous', 'CNV+', 'CNV-', 'Other'];
   public readonly variantTypeValues = ['sub', 'ins', 'del', 'CNV+', 'CNV-'];
 

--- a/src/app/gene-plot/gene-plot.component.css
+++ b/src/app/gene-plot/gene-plot.component.css
@@ -38,6 +38,10 @@ label {
   overflow: hidden;
 }
 
+.header-item:nth-child(3) span{
+  width: 15em;
+}
+
 #summary-alleles-count {
   padding-right: 16px;
 }

--- a/src/app/gene-plot/gene-plot.component.css
+++ b/src/app/gene-plot/gene-plot.component.css
@@ -38,7 +38,7 @@ label {
   overflow: hidden;
 }
 
-.header-item:nth-child(3) span{
+#counters span{
   width: 15em;
 }
 

--- a/src/app/gene-plot/gene-plot.component.html
+++ b/src/app/gene-plot/gene-plot.component.html
@@ -46,7 +46,7 @@
       <span [attr.title]="'Gene symbol: ' + gene.geneSymbol + '\n' + chromosomesTitle">{{ gene?.geneSymbol }}</span>
     </span>
 
-    <span class="header-item">
+    <span id="counters" class="header-item">
       <span>
         <span>Summary alleles:</span>
         <span id="summary-alleles-count">


### PR DESCRIPTION
## Background

Changing gene browser gene title position. Unaligned filter blocks and content leak in smaller resolution.

## Aim

To make gene title position fixed. To align blocks and make flexible height.

## Implementation

Edit the height property and margin of the blocks in css. Give Summary alleles and Family variants width in card header.
