### PR TITLE
Pedigree counter download refactor

### DIFF
--- a/src/app/pedigree/pedigree.component.css
+++ b/src/app/pedigree/pedigree.component.css
@@ -61,3 +61,10 @@ form {
 hr {
   margin: 8px 0;
 }
+
+.pedigree-download-panel {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+}

--- a/src/app/pedigree/pedigree.component.html
+++ b/src/app/pedigree/pedigree.component.html
@@ -16,19 +16,12 @@
 
   <ng-container *ngIf="!modalSimpleView">
     <div class="modal-family">
-      <div style="padding-right: 8px">
-        <form
-          (ngSubmit)="onSubmit($event)"
-          action="{{ configService.baseUrl }}common_reports/family_counters/download"
-          method="post">
-          <input name="queryData" type="hidden" />
-          <span *ngIf="familyIdsList" id="modal-family-count">{{ familyIdsList.length }}</span>
-          <button class="btn btn-md btn-primary" id="download-button">
-            <i class="fa fa-solid fa-download" style="scale: 1.2"></i>
-          </button>
-        </form>
+      <div class="pedigree-download-panel">
+        <span *ngIf="familyIdsList" id="modal-family-count">{{ familyIdsList.length }}</span>
+        <button (click)="onSubmit($event)" class="btn btn-md btn-primary" id="download-button">
+          <i class="fa fa-solid fa-download" style="scale: 1.2"></i>
+        </button>
       </div>
-
       <hr />
 
       <div id="family-ids-list-wrapper" style="height: 100px">

--- a/src/app/pedigree/pedigree.component.ts
+++ b/src/app/pedigree/pedigree.component.ts
@@ -3,6 +3,7 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ConfigService } from 'app/config/config.service';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { PedigreeData } from 'app/genotype-preview-model/genotype-preview';
+import { downloadBlobResponse } from 'app/utils/blob-download';
 import { VariantReportsService } from 'app/variant-reports/variant-reports.service';
 
 @Component({
@@ -61,11 +62,15 @@ export class PedigreeComponent {
   }
 
   public onSubmit(event): void {
-    event.target.queryData.value = JSON.stringify({
+    event.preventDefault();
+    const args = {
       study_id: this.datasetsService.getSelectedDataset().id,
       group_name: this.groupName,
       counter_id: this.counterId
+    };
+    this.variantReportsService.downloadPedigreeCount(args).subscribe((response) => {
+      downloadBlobResponse(response, 'family.ped');
+    }, (err) => {
     });
-    event.target.submit();
   }
 }

--- a/src/app/pedigree/pedigree.component.ts
+++ b/src/app/pedigree/pedigree.component.ts
@@ -62,7 +62,6 @@ export class PedigreeComponent {
   }
 
   public onSubmit(event): void {
-    event.preventDefault();
     const args = {
       study_id: this.datasetsService.getSelectedDataset().id,
       group_name: this.groupName,

--- a/src/app/variant-reports/variant-reports.service.ts
+++ b/src/app/variant-reports/variant-reports.service.ts
@@ -52,9 +52,9 @@ export class VariantReportsService {
     return this.http.get(`${this.config.baseUrl}${this.tagsUrl}`, options);
   }
 
-  public downloadPedigreeCount(json): Observable<HttpResponse<Blob>> {
+  public downloadPedigreeCount(params): Observable<HttpResponse<Blob>> {
     return this.http.post(`${environment.apiPath}${this.pedigreeDownloadUrl}`,
-      json, {
+      params, {
         observe: 'response', headers: new HttpHeaders({ 'Content-Type': 'application/json'}), responseType: 'blob'
       });
   }


### PR DESCRIPTION
## Background

Family counters download follows the old type of requests that parse JSON which is unnecessary and outdated.

## Aim

The aim is to follow the consistency of the other download requests. This is also backed up by a small change in the gpfjs method of making requests.

## Implementation

The implementation is to remove the unneeded JSON logic, change the way the request is submitted and the handling in the variants service.
