### PR TITLE
build.sh: update project compile options for conda

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,7 +98,7 @@ function main() {
   {
     build_run rm -rf dist/
   
-    build_run npm run-script ng build -- --aot --configuration 'conda' --base-href '' --deploy-url '/static/gpfjs/gpfjs/'
+    build_run npm run-script ng build -- --aot --configuration 'conda' --base-href '/gpfjs/' --deploy-url '/static/gpfjs/gpfjs/'
     build_run /usr/bin/python3 ppindex.py
   }
 


### PR DESCRIPTION
add base-href prefix to the ng build command in order to workaround an issue with the url navigation in the packaged gpfjs