### PR TITLE
Stop loading service on ngOnDestroy hook

### DIFF
--- a/src/app/enrichment-tool/enrichment-tool.component.ts
+++ b/src/app/enrichment-tool/enrichment-tool.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Observable } from 'rxjs';
@@ -18,7 +18,7 @@ import { ErrorsState, ErrorsModel } from 'app/common/errors.state';
   templateUrl: './enrichment-tool.component.html',
   styleUrls: ['./enrichment-tool.component.css'],
 })
-export class EnrichmentToolComponent implements OnInit {
+export class EnrichmentToolComponent implements OnInit, OnDestroy {
   public enrichmentResults: EnrichmentResults;
   public selectedDataset: Dataset;
   public disableQueryButtons = false;
@@ -49,6 +49,10 @@ export class EnrichmentToolComponent implements OnInit {
         this.disableQueryButtons = state.componentErrors.size > 0;
       });
     });
+  }
+
+  public ngOnDestroy(): void {
+    this.loadingService.setLoadingStop();
   }
 
   @Selector([GenesBlockComponent.genesBlockState, EnrichmentModelsState])

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -111,6 +111,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
+    this.loadingService.setLoadingStop();
     this.subscriptions.map(subscription => subscription.unsubscribe());
   }
 

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { QueryService } from '../query/query.service';
 import { FullscreenLoadingService } from '../fullscreen-loading/fullscreen-loading.service';
@@ -24,7 +24,7 @@ import { downloadBlobResponse } from 'app/utils/blob-download';
   templateUrl: './genotype-browser.component.html',
   styleUrls: ['./genotype-browser.component.css'],
 })
-export class GenotypeBrowserComponent implements OnInit {
+export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public genotypePreviewVariantsArray: GenotypePreviewVariantsArray;
   public tablePreview: boolean;
   public legend: Array<PersonSet>;
@@ -97,6 +97,10 @@ export class GenotypeBrowserComponent implements OnInit {
     this.errorsState$.subscribe(state => {
       setTimeout(() => this.disableQueryButtons = state.componentErrors.size > 0);
     });
+  }
+
+  public ngOnDestroy(): void {
+    this.loadingService.setLoadingStop();
   }
 
   public submitQuery(): void {

--- a/src/app/pheno-tool/pheno-tool.component.ts
+++ b/src/app/pheno-tool/pheno-tool.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { DatasetsService } from '../datasets/datasets.service';
 import { Dataset } from '../datasets/datasets';
 import { FullscreenLoadingService } from '../fullscreen-loading/fullscreen-loading.service';
@@ -20,7 +20,7 @@ import { downloadBlobResponse } from 'app/utils/blob-download';
   templateUrl: './pheno-tool.component.html',
   styleUrls: ['./pheno-tool.component.css'],
 })
-export class PhenoToolComponent implements OnInit {
+export class PhenoToolComponent implements OnInit, OnDestroy {
   @Select(PhenoToolComponent.phenoToolStateSelector) public state$: Observable<object[]>;
   @Select(ErrorsState) public errorsState$: Observable<ErrorsModel>;
 
@@ -69,6 +69,10 @@ export class PhenoToolComponent implements OnInit {
         this.disableQueryButtons = state.componentErrors.size > 0;
       });
     });
+  }
+
+  public ngOnDestroy(): void {
+    this.loadingService.setLoadingStop();
   }
 
   public submitQuery(): void {


### PR DESCRIPTION
Fix a bug where the loading screen would get stuck on the screen infinitely after the user makes a request and uses browser back navigation
see #678 for more information