### PR TITLE
gene browser: make intron hovering easier

### DIFF
--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -479,6 +479,9 @@ export class GenePlotComponent implements OnChanges {
     brushSize: { nonCoding?: number; coding: number }
   ): void {
     draw.line(svgGroup, xStart, xEnd, y + brushSize.coding / 2, title);
+
+    // draw 0 opacity line with bigger height to make hovering easier
+    draw.line(svgGroup, xStart, xEnd, y + brushSize.coding / 2, title, 0, 10);
   }
 
   private drawUTRLabels(

--- a/src/app/utils/svg-drawing.ts
+++ b/src/app/utils/svg-drawing.ts
@@ -155,7 +155,9 @@ export const line = (
   xStart: number,
   xEnd: number,
   y: number,
-  svgTitle: string
+  svgTitle: string,
+  opacity = 100,
+  strokeWidth = 1
 ): void => {
   element.append('line')
     .attr('x1', xStart)
@@ -163,5 +165,7 @@ export const line = (
     .attr('x2', xEnd)
     .attr('y2', y)
     .attr('stroke', 'black')
+    .attr('opacity', `${opacity}%`)
+    .attr('stroke-width', strokeWidth)
     .append('svg:title').text(svgTitle);
 };


### PR DESCRIPTION
Hovering on the intron line to get the title with extra information is too hard, as we draw the intron as a 1px line.
Added 0 opacity line ontop of the intron to make hovering easier
issue - #688