### PR TITLE
gene plot: update counters style

### DIFF
--- a/src/app/gene-plot/gene-plot.component.css
+++ b/src/app/gene-plot/gene-plot.component.css
@@ -38,12 +38,11 @@ label {
   overflow: hidden;
 }
 
-#counters span {
-  width: 15em;
-}
-
-#summary-alleles-count {
-  padding-right: 16px;
+#summary-alleles-count,
+#family-variants-count {
+  display: inline-grid;
+  min-width: 150px;
+  text-align: center;
 }
 
 #summary-alleles-count span,

--- a/src/app/gene-plot/gene-plot.component.html
+++ b/src/app/gene-plot/gene-plot.component.html
@@ -47,7 +47,7 @@
     </span>
 
     <span id="counters" class="header-item">
-      <span>
+      <span style="padding-right: 32px">
         <span>Summary alleles:</span>
         <span id="summary-alleles-count">
           <span>{{ this.variantsArray?.totalSummaryAllelesCount }} / {{ this.allVariantsCounts[0] }}</span>


### PR DESCRIPTION
On selecting variants the gene symbol title and the counter positions would move. Add min-width to make the counters more static (up to 6 digit numbers)