### PR TITLE
gene browser: condense introns auto check logic

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -158,6 +158,7 @@
       <gpf-gene-plot
         [gene]="selectedGene"
         [variantsArray]="summaryVariantsArrayFiltered"
+        [condenseIntrons]="summaryVariantsFilter.codingOnly"
         [frequencyDomain]="[geneBrowserConfig.domainMin, geneBrowserConfig.domainMax]"
         [yAxisLabel]="geneBrowserConfig.frequencyName || geneBrowserConfig.frequencyColumn"
         [allVariantsCounts]="[

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -177,9 +177,6 @@ describe('GeneBrowserComponent', () => {
 
   it('should reset filters on new request', async() => {
     jest.spyOn<any, any>(component, 'updateShownTablePreviewVariantsArray').mockImplementation(() => null);
-    jest.spyOn<any, any>(component, 'waitForGenePlotComponent').mockImplementation(
-      () => new Promise<void>(resolve => resolve())
-    );
     component.summaryVariantsFilter = new SummaryAllelesFilter(true, false, true);
     component.checkEffectType('CNV+', true);
     component.checkEffectType('missense', true);

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -191,10 +191,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     await this.waitForGenePlotComponent();
 
     this.updateShownTablePreviewVariantsArray();
-
-    if (!this.summaryVariantsFilter.codingOnly) {
-      this.genePlotComponent.toggleCondenseIntrons();
-    }
   }
 
   public onDownload(): void {

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -11,7 +11,6 @@ import { Subject, Subscription } from 'rxjs';
 import { Dataset, GeneBrowser, PersonSet } from 'app/datasets/datasets';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
-import { GenePlotComponent } from 'app/gene-plot/gene-plot.component';
 import { ConfigService } from 'app/config/config.service';
 import { clone } from 'lodash';
 import * as d3 from 'd3';
@@ -26,7 +25,6 @@ import { downloadBlobResponse } from 'app/utils/blob-download';
   styleUrls: ['./gene-browser.component.css'],
 })
 export class GeneBrowserComponent implements OnInit, OnDestroy {
-  @ViewChild(GenePlotComponent) private genePlotComponent: GenePlotComponent;
   @ViewChild(NgbDropdown) private dropdown: NgbDropdown;
   @ViewChild('searchBox') private searchBox: ElementRef;
   @ViewChild('filters', { static: false }) public set filters(element: HTMLElement) {
@@ -188,8 +186,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       0, this.geneBrowserConfig.domainMax
     ];
 
-    await this.waitForGenePlotComponent();
-
     this.updateShownTablePreviewVariantsArray();
   }
 
@@ -296,18 +292,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
 
   public getAffectedStatusColor(affectedStatus: string): string {
     return draw.affectedStatusColors[affectedStatus];
-  }
-
-
-  private async waitForGenePlotComponent(): Promise<void> {
-    return new Promise<void>(resolve => {
-      const timer = setInterval(() => {
-        if (this.genePlotComponent !== undefined) {
-          resolve();
-          clearInterval(timer);
-        }
-      }, 100);
-    });
   }
 
   private get requestParams(): Record<string, unknown> {

--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -17,6 +17,7 @@ export class GenePlotComponent implements OnChanges {
   @Input() public readonly frequencyDomain: [number, number];
   @Input() public readonly yAxisLabel: string;
   @Input() public readonly allVariantsCounts: [number, number];
+  @Input() public condenseIntrons: boolean;
 
   @Output() public selectedRegion = new EventEmitter<[number, number]>();
   @Output() public selectedFrequencies = new EventEmitter<[number, number]>();
@@ -70,7 +71,6 @@ export class GenePlotComponent implements OnChanges {
   private genePlotModel: GenePlotModel;
   public zoomHistory: GenePlotZoomHistory;
   public showTranscripts = true;
-  public condenseIntrons = true;
   private normalRange: number[];
   private condensedRange: number[];
   private denovoLevels: number;


### PR DESCRIPTION
problem:
There is a logic to initially match the values of the "Condense introns" and the "Coding only" checkboxes (because if the user only wanted to see non-coding variants, he wouldn't want to condense introns, and the opposite for coding variants).
When this happens, the plot is visibly changing (see attached video on #720). 

solution:
Instead of manually checking the checkbox in gene-browser.component.ts: submitGeneRequest() function, make gene plot's variable "condenseIntrons" @Input() and give it value equal to the Coding only checkbox

closes #720
