### PR TITLE
Pheno measure selector fix

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -195,6 +195,7 @@
   },
   "defaultProject": "gpfjs",
   "cli": {
-    "defaultCollection": "@angular-eslint/schematics"
+    "defaultCollection": "@angular-eslint/schematics",
+    "analytics": false
   }
 }

--- a/src/app/continuous-filter/continuous-filter.component.spec.ts
+++ b/src/app/continuous-filter/continuous-filter.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ConfigService } from 'app/config/config.service';
 import { HistogramData } from 'app/measures/measures';
 import { MeasuresService } from 'app/measures/measures.service';

--- a/src/app/multi-continuous-filter/multi-continuous-filter.component.spec.ts
+++ b/src/app/multi-continuous-filter/multi-continuous-filter.component.spec.ts
@@ -12,7 +12,6 @@ import { Observable, of } from 'rxjs';
 import { NgxsModule } from '@ngxs/store';
 import { FormsModule } from '@angular/forms';
 import { PhenoMeasure } from 'app/pheno-browser/pheno-browser';
-import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 @Component({
   selector: 'gpf-searchable-select',
@@ -76,8 +75,7 @@ describe('MultiContinuousFilterComponent', () => {
         HttpClientTestingModule,
         ConfigService,
         {provide: DatasetsService, useValue: mockDatasetsService},
-        UsersService,
-        FullscreenLoadingService
+        UsersService
       ],
       imports: [
         RouterTestingModule,

--- a/src/app/multi-continuous-filter/multi-continuous-filter.component.spec.ts
+++ b/src/app/multi-continuous-filter/multi-continuous-filter.component.spec.ts
@@ -12,6 +12,7 @@ import { Observable, of } from 'rxjs';
 import { NgxsModule } from '@ngxs/store';
 import { FormsModule } from '@angular/forms';
 import { PhenoMeasure } from 'app/pheno-browser/pheno-browser';
+import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 @Component({
   selector: 'gpf-searchable-select',
@@ -76,6 +77,7 @@ describe('MultiContinuousFilterComponent', () => {
         ConfigService,
         {provide: DatasetsService, useValue: mockDatasetsService},
         UsersService,
+        FullscreenLoadingService
       ],
       imports: [
         RouterTestingModule,

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.css
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.css
@@ -1,0 +1,5 @@
+#loading-text {
+  font-style: italic;
+  text-align: center;
+  opacity: 75%;
+}

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.css
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.css
@@ -1,4 +1,4 @@
-#loading-text {
+#loading-dropdown-text {
   font-style: italic;
   text-align: center;
   opacity: 75%;

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -1,4 +1,4 @@
-<div ngbDropdown class="input-group" style="display: inline-flex; flex-wrap: nowrap">
+<div ngbDropdown *ngIf="filteredMeasures" class="input-group" style="display: inline-flex; flex-wrap: nowrap">
   <input
     ngbDropdownAnchor
     #searchBox

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -14,19 +14,16 @@
   <div ngbDropdownMenu style="z-index: 3; width: 100%; max-height: 200px; overflow-y: scroll">
     <div id="loading-dropdown-text" *ngIf="filteredMeasures.length === 0"> Loading...</div>
     <button
-      *ngFor="let measure of filteredMeasures"
+      *ngFor="let measure of filteredMeasures | slice : 0 : 25"
       class="dropdown-item"
       type="button"
       (click)="selectMeasure(measure)"
       (keydown.enter)="selectMeasure(measure)">
-      <span innerHtml="{{ measure.name | boldMatching: searchString }}"></span>
+      <span innerHtml="{{ measure.name | boldMatching : searchString }}"></span>
     </button>
   </div>
   <div class="input-group-append">
-    <button
-      (click)="clear()"
-      class="btn btn-secondary"
-      style="border-top-left-radius: 0; border-bottom-left-radius: 0"
+    <button (click)="clear()" class="btn btn-secondary" style="border-top-left-radius: 0; border-bottom-left-radius: 0"
       >&times;</button
     >
   </div>

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -1,4 +1,6 @@
-<div ngbDropdown *ngIf="filteredMeasures" class="input-group" style="display: inline-flex; flex-wrap: nowrap">
+<gpf-fullscreen-loading></gpf-fullscreen-loading>
+
+<div ngbDropdown *ngIf="measures.length" class="input-group" style="display: inline-flex; flex-wrap: nowrap">
   <input
     ngbDropdownAnchor
     #searchBox

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -1,6 +1,4 @@
-<gpf-fullscreen-loading></gpf-fullscreen-loading>
-
-<div ngbDropdown *ngIf="measures.length" class="input-group" style="display: inline-flex; flex-wrap: nowrap">
+<div ngbDropdown class="input-group" style="display: inline-flex; flex-wrap: nowrap">
   <input
     ngbDropdownAnchor
     #searchBox
@@ -9,11 +7,12 @@
     autocomplete="off"
     spellcheck="false"
     [(ngModel)]="searchString"
-    (keyup)="openDropdown(); searchBoxChange()"
-    (click)="clear(); openDropdown(); searchBoxChange()"
+    (keyup)="openDropdown(); loadDropdownData()"
+    (click)="clear(); openDropdown(); loadDropdownData()"
     (keydown.escape)="closeDropdown()"
     style="width: 100%" />
   <div ngbDropdownMenu style="z-index: 3; width: 100%; max-height: 200px; overflow-y: scroll">
+    <div id="loading-text" *ngIf="filteredMeasures.length === 0"> Loading...</div>
     <button
       *ngFor="let measure of filteredMeasures"
       class="dropdown-item"

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -12,7 +12,7 @@
     (keydown.escape)="closeDropdown()"
     style="width: 100%" />
   <div ngbDropdownMenu style="z-index: 3; width: 100%; max-height: 200px; overflow-y: scroll">
-    <div id="loading-text" *ngIf="filteredMeasures.length === 0"> Loading...</div>
+    <div id="loading-dropdown-text" *ngIf="filteredMeasures.length === 0"> Loading...</div>
     <button
       *ngFor="let measure of filteredMeasures"
       class="dropdown-item"

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.spec.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.spec.ts
@@ -10,7 +10,6 @@ import { SearchableSelectComponent } from 'app/searchable-select/searchable-sele
 import { UsersService } from 'app/users/users.service';
 
 import { PhenoMeasureSelectorComponent } from './pheno-measure-selector.component';
-import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 class MockDatasetsService {
   public getSelectedDataset(): object {
@@ -31,8 +30,7 @@ describe('PhenoMeasureSelectorComponent', () => {
         ConfigService,
         {provide: DatasetsService, useValue: mockDatasetsService},
         UsersService,
-        SearchableSelectComponent,
-        FullscreenLoadingService
+        SearchableSelectComponent
       ],
       imports: [HttpClientTestingModule, RouterTestingModule, NgxsModule.forRoot([], {developmentMode: true})],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.spec.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.spec.ts
@@ -10,6 +10,7 @@ import { SearchableSelectComponent } from 'app/searchable-select/searchable-sele
 import { UsersService } from 'app/users/users.service';
 
 import { PhenoMeasureSelectorComponent } from './pheno-measure-selector.component';
+import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 class MockDatasetsService {
   public getSelectedDataset(): object {
@@ -30,7 +31,8 @@ describe('PhenoMeasureSelectorComponent', () => {
         ConfigService,
         {provide: DatasetsService, useValue: mockDatasetsService},
         UsersService,
-        SearchableSelectComponent
+        SearchableSelectComponent,
+        FullscreenLoadingService
       ],
       imports: [HttpClientTestingModule, RouterTestingModule, NgxsModule.forRoot([], {developmentMode: true})],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
@@ -4,7 +4,6 @@ import { MeasuresService } from '../measures/measures.service';
 import { ContinuousMeasure } from '../measures/measures';
 import { first } from 'rxjs/operators';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
-import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 @Component({
   selector: 'gpf-pheno-measure-selector',
@@ -26,7 +25,6 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
 
   public constructor(
     private measuresService: MeasuresService,
-    private fullscreenLoadingService: FullscreenLoadingService
   ) { }
 
   public ngOnChanges(): void {

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnChanges, Input, ViewChild, Output, EventEmitter } from '@angular/core';
+import { Component, OnChanges, Input, ViewChild, Output, EventEmitter, 
+  ElementRef } from '@angular/core';
 
 import { MeasuresService } from '../measures/measures.service';
 import { ContinuousMeasure } from '../measures/measures';
@@ -15,7 +16,7 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   @Output() public selectedMeasureChange = new EventEmitter(true);
   @Output() public measuresChange = new EventEmitter(true);
 
-  @ViewChild('searchBox') private searchBox;
+  @ViewChild('searchBox') private searchBox: ElementRef;
   @ViewChild(NgbDropdown) private dropdown: NgbDropdown;
 
   public measures: Array<ContinuousMeasure> = [];
@@ -53,7 +54,7 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   public closeDropdown(): void {
     if (this.dropdown && this.dropdown.isOpen()) {
       this.dropdown.close();
-      this.searchBox.nativeElement.blur();
+      (this.searchBox.nativeElement as HTMLInputElement).blur();
     }
   }
 
@@ -65,13 +66,16 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   public loadDropdownData(): void {
     if (this.measures.length === 0) {
       // Wait and try again if measures are not loaded yet.
-      setTimeout(this.loadDropdownData.bind(this), 500);
-    } else if (this.searchString.length) {
-      this.filteredMeasures = this.measures.filter(value =>
-        value.name.toLowerCase().indexOf(this.searchString.toLowerCase()) !== -1
-      ).slice(0, 25);
-    } else {
-      this.filteredMeasures = this.measures.slice(0, 25);
+      setTimeout(this.loadDropdownData.bind(this), 200);
+      return;
+    }
+
+    this.filteredMeasures = this.measures;
+
+    if (this.searchString.length) {
+      this.filteredMeasures = this.filteredMeasures.filter(measure =>
+        measure.name.toLowerCase().indexOf(this.searchString.toLowerCase()) !== -1
+      );
     }
   }
 }

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
@@ -31,11 +31,9 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
 
   public ngOnChanges(): void {
     if (this.datasetId && this.measures.length === 0) {
-      this.fullscreenLoadingService.setLoadingStart();
       this.measuresService.getContinuousMeasures(this.datasetId).pipe(first()).subscribe(measures => {
         this.measures = measures;
         this.measuresChange.emit(this.measures);
-        this.fullscreenLoadingService.setLoadingStop();
       });
     }
   }
@@ -63,17 +61,19 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
 
   public clear(): void {
     this.selectMeasure(null);
-    this.searchBoxChange();
+    this.loadDropdownData();
   }
 
-  public searchBoxChange(): void {
-    if (this.searchString.length) {
+  public loadDropdownData(): void {
+    if (this.measures.length === 0) {
+      // Wait and try again if measures are not loaded yet.
+      setTimeout(this.loadDropdownData.bind(this), 500);
+    } else if (this.searchString.length) {
       this.filteredMeasures = this.measures.filter(value =>
         value.name.toLowerCase().indexOf(this.searchString.toLowerCase()) !== -1
-      );
+      ).slice(0, 25);
     } else {
-      this.filteredMeasures = this.measures;
+      this.filteredMeasures = this.measures.slice(0, 25);
     }
-    this.filteredMeasures = this.filteredMeasures.slice(0, 25);
   }
 }

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
@@ -4,6 +4,7 @@ import { MeasuresService } from '../measures/measures.service';
 import { ContinuousMeasure } from '../measures/measures';
 import { first } from 'rxjs/operators';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
+import { FullscreenLoadingService } from 'app/fullscreen-loading/fullscreen-loading.service';
 
 @Component({
   selector: 'gpf-pheno-measure-selector',
@@ -24,14 +25,17 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   public selectedMeasure: ContinuousMeasure;
 
   public constructor(
-    private measuresService: MeasuresService
+    private measuresService: MeasuresService,
+    private fullscreenLoadingService: FullscreenLoadingService
   ) { }
 
   public ngOnChanges(): void {
     if (this.datasetId && this.measures.length === 0) {
+      this.fullscreenLoadingService.setLoadingStart();
       this.measuresService.getContinuousMeasures(this.datasetId).pipe(first()).subscribe(measures => {
         this.measures = measures;
         this.measuresChange.emit(this.measures);
+        this.fullscreenLoadingService.setLoadingStop();
       });
     }
   }


### PR DESCRIPTION
## Background

Pheno measure selector dropdown can be opened when empty.

## Aim

Disable dropdown opening when empty.

## Implementation

Before showing the dropdown await the content.

fixes #730 