### PR TITLE
Fix for family filters advanced tab default state issue #716

### DIFF
--- a/src/app/person-filters/person-filters.component.ts
+++ b/src/app/person-filters/person-filters.component.ts
@@ -5,7 +5,6 @@ import { Store } from '@ngxs/store';
 import { SetFamilyFilters, SetPersonFilters, PersonFiltersState } from './person-filters.state';
 import { StatefulComponent } from 'app/common/stateful-component';
 import { IsNotEmpty, ValidateNested } from 'class-validator';
-import { filter } from 'lodash';
 
 @Component({
   selector: 'gpf-person-filters',
@@ -72,6 +71,7 @@ export class PersonFiltersComponent extends StatefulComponent implements OnChang
         }
       }
     });
+    this.updateFilters();
   }
 
   public get categoricalFilters(): PersonFilterState[] {


### PR DESCRIPTION
## Background

When the "Advanced" tab is clicked in the "Family filters" block at the genotype browser or phenotype tool there is a bug that renders the user able to make a request even if it is empty.

## Aim

The aim is to show the user that he cannot make a request without selecting the family filter if the advanced tab is selected.

## Implementation

Closes #716.
