### PR TITLE
Unique family variants show only when a selected dataset is not a sin…

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="isUniqueFamilyVariantsVisible" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="selectedDataset.studies?.length > 1" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="selectedDataset.studies?.length > 1" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="selectedDataset.studies?.length >= 1" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="selectedDataset.studies?.length >= 1" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="selectedDataset.studies?.length > 1" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="selectedDataset.parents.length > 0" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="selectedDataset.studies?.length !== null" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="selectedDataset.studies?.length > 1" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="isUniqueFamilyFitlerVisible" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div *ngIf="selectedDataset.studies?.length !== null" id="unique-family-variants-block" class="form-block">
+      <div *ngIf="isUniqueFamilyVariantsVisible" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -179,7 +179,7 @@
 
       <hr />
 
-      <div id="unique-family-variants-block" class="form-block">
+      <div *ngIf="selectedDataset.parents.length > 0" id="unique-family-variants-block" class="form-block">
         <div class="card">
           <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
             <label

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -55,6 +55,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public legend: Array<PersonSet>;
   public geneSymbolSuggestions: string[] = [];
   public searchBoxInput$: Subject<string> = new Subject();
+  public isUniqueFamilyFitlerVisible = false;
 
   private subscriptions: Subscription[] = [];
   private selectedDatasetId: string;
@@ -112,6 +113,9 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
           });
       })
     );
+    if (this.selectedDataset.studies?.length > 1) {
+      this.isUniqueFamilyFitlerVisible = true;
+    }
   }
 
   public ngOnDestroy(): void {

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -55,6 +55,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public legend: Array<PersonSet>;
   public geneSymbolSuggestions: string[] = [];
   public searchBoxInput$: Subject<string> = new Subject();
+  public isUniqueFamilyVariantsVisible = false;
 
   private subscriptions: Subscription[] = [];
   private selectedDatasetId: string;
@@ -112,6 +113,10 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
           });
       })
     );
+
+    if (this.datasetsService.getSelectedDataset().studies?.length > 1) {
+      this.isUniqueFamilyVariantsVisible = true;
+    }
   }
 
   public ngOnDestroy(): void {

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -55,7 +55,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public legend: Array<PersonSet>;
   public geneSymbolSuggestions: string[] = [];
   public searchBoxInput$: Subject<string> = new Subject();
-  public isUniqueFamilyVariantsVisible = false;
 
   private subscriptions: Subscription[] = [];
   private selectedDatasetId: string;
@@ -113,10 +112,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
           });
       })
     );
-
-    if (this.datasetsService.getSelectedDataset().studies?.length > 1) {
-      this.isUniqueFamilyVariantsVisible = true;
-    }
   }
 
   public ngOnDestroy(): void {

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="this.datasetService.getSelectedDataset().studies?.length > 1"
+  *ngIf="visible"
   id="unique-family-variants-block"
   class="form-block">
   <div class="card">

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="datasetService.getSelectedDataset().parents.length > 0" id="unique-family-variants-block" class="form-block"
+  *ngIf="datasetService.getSelectedDataset().studies?.length !== null" id="unique-family-variants-block" class="form-block"
 >
   <div class="card">
     <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,4 +1,7 @@
-<div *ngIf="isUniqueFamilyVariantsVisible" id="unique-family-variants-block" class="form-block">
+<div
+  *ngIf="this.datasetService.getSelectedDataset().studies?.length >= 1"
+  id="unique-family-variants-block"
+  class="form-block">
   <div class="card">
     <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
       <label

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,4 +1,6 @@
-<div id="unique-family-variants-block" class="form-block">
+<div
+  *ngIf="datasetService.getSelectedDataset().parents.length > 0" id="unique-family-variants-block" class="form-block"
+>
   <div class="card">
     <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
       <label

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,6 +1,4 @@
-<div
-  *ngIf="datasetService.getSelectedDataset().studies?.length !== null" id="unique-family-variants-block" class="form-block"
->
+<div *ngIf="isUniqueFamilyVariantsVisible" id="unique-family-variants-block" class="form-block">
   <div class="card">
     <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
       <label

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="this.datasetService.getSelectedDataset().studies?.length >= 1"
+  *ngIf="this.datasetService.getSelectedDataset().studies?.length > 1"
   id="unique-family-variants-block"
   class="form-block">
   <div class="card">

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="visible"
+  *ngIf="isVisible"
   id="unique-family-variants-block"
   class="form-block">
   <div class="card">

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.html
@@ -1,7 +1,4 @@
-<div
-  *ngIf="isVisible"
-  id="unique-family-variants-block"
-  class="form-block">
+<div *ngIf="isVisible" id="unique-family-variants-block" class="form-block">
   <div class="card">
     <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
       <label

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
@@ -6,7 +6,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { DatasetsService } from 'app/datasets/datasets.service';
 
 class DatasetsServiceMock {
-  public getSelectedDataset() {
+  public getSelectedDataset(): object {
     return {parents: []};
   }
 }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
@@ -3,10 +3,6 @@ import { UniqueFamilyVariantsFilterComponent } from './unique-family-variants-fi
 import { NgxsModule } from '@ngxs/store';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { ConfigService } from 'app/config/config.service';
-import { UsersService } from 'app/users/users.service';
-import { APP_BASE_HREF } from '@angular/common';
-import { Dataset } from 'app/datasets/datasets';
 import { DatasetsService } from 'app/datasets/datasets.service';
 
 class DatasetsServiceMock {
@@ -25,9 +21,7 @@ describe('UniqueFamilyVariantsFilterComponent', () => {
       providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock()}],
       imports: [HttpClientModule, NgxsModule.forRoot([], {developmentMode: true}), FormsModule]
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(UniqueFamilyVariantsFilterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
@@ -2,6 +2,18 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UniqueFamilyVariantsFilterComponent } from './unique-family-variants-filter.component';
 import { NgxsModule } from '@ngxs/store';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { ConfigService } from 'app/config/config.service';
+import { UsersService } from 'app/users/users.service';
+import { APP_BASE_HREF } from '@angular/common';
+import { Dataset } from 'app/datasets/datasets';
+import { DatasetsService } from 'app/datasets/datasets.service';
+
+class DatasetsServiceMock {
+  public getSelectedDataset() {
+    return {parents: []};
+  }
+}
 
 describe('UniqueFamilyVariantsFilterComponent', () => {
   let component: UniqueFamilyVariantsFilterComponent;
@@ -10,7 +22,8 @@ describe('UniqueFamilyVariantsFilterComponent', () => {
   beforeEach(async() => {
     await TestBed.configureTestingModule({
       declarations: [UniqueFamilyVariantsFilterComponent],
-      imports: [NgxsModule.forRoot([], {developmentMode: true}), FormsModule]
+      providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock}, ConfigService, UsersService, { provide: APP_BASE_HREF, useValue: '' }],
+      imports: [HttpClientModule, NgxsModule.forRoot([], {developmentMode: true}), FormsModule]
     }).compileComponents();
   });
 

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
@@ -22,7 +22,7 @@ describe('UniqueFamilyVariantsFilterComponent', () => {
   beforeEach(async() => {
     await TestBed.configureTestingModule({
       declarations: [UniqueFamilyVariantsFilterComponent],
-      providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock}, ConfigService, UsersService, { provide: APP_BASE_HREF, useValue: '' }],
+      providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock()}],
       imports: [HttpClientModule, NgxsModule.forRoot([], {developmentMode: true}), FormsModule]
     }).compileComponents();
   });

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -13,6 +13,7 @@ import { DatasetsService } from 'app/datasets/datasets.service';
 export class UniqueFamilyVariantsFilterComponent extends StatefulComponent implements OnChanges, OnInit {
   @Validate(IsDefined, {message: 'Must have a boolean value.'})
   private enabled = false;
+  public isVisible = false;
 
   public constructor(protected store: Store, public datasetService: DatasetsService) {
     super(store, UniqueFamilyVariantsFilterState, 'uniqueFamilyVariantsFilter');
@@ -29,6 +30,9 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
+    if (this.datasetService.getSelectedDataset().studies?.length > 1) {
+      this.isVisible = true;
+    }
   }
 
   public get filterValue(): boolean {

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -3,6 +3,7 @@ import { Store } from '@ngxs/store';
 import { UniqueFamilyVariantsFilterState, SetUniqueFamilyVariantsFilter } from './unique-family-variants-filter.state';
 import { Validate, IsDefined } from 'class-validator';
 import { StatefulComponent } from '../common/stateful-component';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-unique-family-variants-filter',
@@ -13,7 +14,7 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
   @Validate(IsDefined, {message: 'Must have a boolean value.'})
   private enabled = false;
 
-  public constructor(protected store: Store) {
+  public constructor(protected store: Store, public datasetService: DatasetsService) {
     super(store, UniqueFamilyVariantsFilterState, 'uniqueFamilyVariantsFilter');
   }
 


### PR DESCRIPTION
## Background

When the single study is selected there is no use for a unique family variants filter.

## Aim

Optimize this feature to match the targeted requirements.

## Implementation

Closes #709.
