### PR TITLE
Standardize buttons

### DIFF
--- a/src/app/enrichment-tool/enrichment-tool.component.html
+++ b/src/app/enrichment-tool/enrichment-tool.component.html
@@ -8,7 +8,7 @@
       [disabled]="disableQueryButtons"
       class="btn btn-md btn-primary"
       type="button"
-      value="Enrichment Test"
+      value="View"
       (click)="submitQuery()" />
     <gpf-save-query [disabled]="disableQueryButtons" queryType="enrichment"></gpf-save-query>
   </div>

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -52,12 +52,7 @@
   </div>
 
   <div style="margin-top: 15px">
-    <input
-      type="button"
-      style="width: 75px"
-      class="btn btn-md btn-primary"
-      value="View"
-      (click)="submitGeneRequest()" />
+    <input type="button" class="btn btn-md btn-primary" value="View" (click)="submitGeneRequest()" />
   </div>
 
   <div *ngIf="showResults">

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -52,7 +52,12 @@
   </div>
 
   <div style="margin-top: 15px">
-    <input type="button" style="width: 75px" class="btn btn-md btn-primary" value="Go" (click)="submitGeneRequest()" />
+    <input
+      type="button"
+      style="width: 75px"
+      class="btn btn-md btn-primary"
+      value="View"
+      (click)="submitGeneRequest()" />
   </div>
 
   <div *ngIf="showResults">

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -24,8 +24,8 @@
       id="download-button"
       (click)="onDownload()"
       [disabled]="disableQueryButtons">
-       <span *ngIf="downloadInProgress">Downloading...</span>
-       <span *ngIf="!downloadInProgress">Download</span>
+      <span *ngIf="downloadInProgress">Downloading...</span>
+      <span *ngIf="!downloadInProgress">Download</span>
     </button>
     <div class="button">
       <input
@@ -33,7 +33,7 @@
         [disabled]="disableQueryButtons"
         class="btn btn-md btn-primary"
         id="table-preview-button"
-        value="Table Preview"
+        value="View"
         (click)="submitQuery()" />
       <gpf-save-query [disabled]="disableQueryButtons" queryType="genotype"></gpf-save-query>
     </div>

--- a/src/app/pheno-tool/pheno-tool.component.html
+++ b/src/app/pheno-tool/pheno-tool.component.html
@@ -19,7 +19,7 @@
           class="btn btn-md btn-primary"
           (click)="submitQuery()"
           [disabled]="disableQueryButtons">
-          Report
+          View
         </button>
         <gpf-save-query [disabled]="disableQueryButtons" queryType="phenotool"></gpf-save-query>
       </div>
@@ -29,8 +29,8 @@
           id="download-button"
           (click)="onDownload()"
           [disabled]="disableQueryButtons">
-           <span *ngIf="downloadInProgress">Downloading...</span>
-           <span *ngIf="!downloadInProgress">Download</span>
+          <span *ngIf="downloadInProgress">Downloading...</span>
+          <span *ngIf="!downloadInProgress">Download</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Background

Main buttons in Gene browser, Genotype browser, Enrichment tool and Phenotype tool have different design.

## Aim

To make the buttons look the same.

## Implementation

Make the buttons to have the same text and design.
