### PR TITLE
Gene browser now show family variants on initial load #731

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -329,10 +329,10 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
 
   private updateShownTablePreviewVariantsArray(): void {
     this.familyLoadingFinished = false;
-    const tempRequestParam = this.requestParams;
-    delete tempRequestParam['summaryVariantIds'];
+    const parameters = this.requestParams;
+    delete parameters['summaryVariantIds'];
     const requestParams = {
-      ...tempRequestParam,
+      ...parameters,
       maxVariantsCount: this.maxFamilyVariants,
       uniqueFamilyVariants: this.uniqueFamilyVariants,
     };

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -329,8 +329,10 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
 
   private updateShownTablePreviewVariantsArray(): void {
     this.familyLoadingFinished = false;
+    const tempRequestParam = this.requestParams;
+    delete tempRequestParam['summaryVariantIds'];
     const requestParams = {
-      ...this.requestParams,
+      ...tempRequestParam,
       maxVariantsCount: this.maxFamilyVariants,
       uniqueFamilyVariants: this.uniqueFamilyVariants,
     };


### PR DESCRIPTION
## Background

Gene browser currently shows "Nothing found" in table results. It doesn't load family variants initially and requires the user to zoom in on the gene plot in order to fill the table.

## Aim

The aim is to fix the bug and provide more clean experience

## Implementation

Closes #731.