### PR TITLE
Integrate cancel request for fullscreen loading feature #745

### DIFF
--- a/src/app/enrichment-tool/enrichment-tool.component.html
+++ b/src/app/enrichment-tool/enrichment-tool.component.html
@@ -12,5 +12,5 @@
       (click)="submitQuery()" />
     <gpf-save-query [disabled]="disableQueryButtons" queryType="enrichment"></gpf-save-query>
   </div>
-  <gpf-enrichment-table [enrichmentResults]="enrichmentResults"></gpf-enrichment-table>
+  <gpf-enrichment-table *ngIf="showResults" [enrichmentResults]="enrichmentResults"></gpf-enrichment-table>
 </div>

--- a/src/app/enrichment-tool/enrichment-tool.component.ts
+++ b/src/app/enrichment-tool/enrichment-tool.component.ts
@@ -22,6 +22,7 @@ export class EnrichmentToolComponent implements OnInit, OnDestroy {
   public enrichmentResults: EnrichmentResults;
   public selectedDataset: Dataset;
   public disableQueryButtons = false;
+  public showResults = true;
 
   @Select(EnrichmentToolComponent.enrichmentToolStateSelector) public state$: Observable<object[]>;
   @Select(ErrorsState) public errorsState$: Observable<ErrorsModel>;
@@ -63,7 +64,14 @@ export class EnrichmentToolComponent implements OnInit, OnDestroy {
   }
 
   public submitQuery(): void {
+    this.enrichmentResults = null;
     this.loadingService.setLoadingStart();
+    this.showResults = true;
+    this.loadingService.loadingStateChange.subscribe(val => {
+      if (val === 'break') {
+        this.showResults = false;
+      }
+    });
     this.enrichmentQueryService.getEnrichmentTest(this.enrichmentToolState).subscribe(
       (enrichmentResults) => {
         this.enrichmentResults = enrichmentResults;

--- a/src/app/fullscreen-loading/fullscreen-loading.component.css
+++ b/src/app/fullscreen-loading/fullscreen-loading.component.css
@@ -20,6 +20,17 @@ img {
   margin: auto;
 }
 
+.close-button {
+  font-size: 20px;
+  position: fixed;
+  left: 50%;
+  cursor: pointer;
+  transform: translateX(-60%);
+  bottom: 44%;
+  opacity: 50%;
+  z-index: 9999;
+}
+
 .dna {
   z-index: 1050;
   position: fixed;

--- a/src/app/fullscreen-loading/fullscreen-loading.component.html
+++ b/src/app/fullscreen-loading/fullscreen-loading.component.html
@@ -1,4 +1,5 @@
 <div *ngIf="showLoading" class="overlay"></div>
+<button *ngIf="showLoading" (click)="loadingStop()" type="button" class="btn btn-md btn-primary close-button">Cancel request</button>
 <div *ngIf="showLoading">
   <div class="dna">
     <div class="ele">

--- a/src/app/fullscreen-loading/fullscreen-loading.component.ts
+++ b/src/app/fullscreen-loading/fullscreen-loading.component.ts
@@ -14,8 +14,16 @@ export class FullscreenLoadingComponent {
   public constructor(
     private fullscreenLoadingService: FullscreenLoadingService
   ) {
-    fullscreenLoadingService.loadingStateChange.subscribe((state: boolean) => {
-      this.showLoading = state;
+    fullscreenLoadingService.loadingStateChange.subscribe((state: string) => {
+      if (state === 'loading') {
+        this.showLoading = true;
+      } else {
+        this.showLoading = false;
+      }
     });
+  }
+
+  public loadingStop(): void {
+    this.fullscreenLoadingService.setLoadingBreak();
   }
 }

--- a/src/app/fullscreen-loading/fullscreen-loading.service.ts
+++ b/src/app/fullscreen-loading/fullscreen-loading.service.ts
@@ -1,16 +1,22 @@
 // Loosely based on https://github.com/oxycoder/ng2-loading-animate
 
-import { Injectable, EventEmitter } from '@angular/core';
+import { Injectable, EventEmitter, Output } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class FullscreenLoadingService {
-  public loadingStateChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output()
+  public loadingStateChange: BehaviorSubject<string> = new BehaviorSubject<string>('stop');
 
   public setLoadingStart(): void {
-    this.loadingStateChange.emit(true);
+    this.loadingStateChange.next('loading');
   }
 
   public setLoadingStop(): void {
-    this.loadingStateChange.emit(false);
+    this.loadingStateChange.next('stop');
+  }
+
+  public setLoadingBreak(): void {
+    this.loadingStateChange.next('break');
   }
 }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -92,7 +92,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
         this.familyLoadingFinished = true;
       }),
       this.queryService.summaryStreamingFinishedSubject.subscribe(() => {
-        this.showResults = true;
+        this.showResults = this.loadingService.loadingStateChange.getValue() !== 'break';
         this.loadingService.setLoadingStop();
       }),
       this.route.parent.params.subscribe((params: Params) => {

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -94,6 +94,12 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
       this.genotypePreviewVariantsArray = null;
     });
 
+    this.loadingService.loadingStateChange.subscribe(val => {
+      if (val === 'break') {
+        this.genotypePreviewVariantsArray = null;
+      }
+    });
+
     this.errorsState$.subscribe(state => {
       setTimeout(() => this.disableQueryButtons = state.componentErrors.size > 0);
     });

--- a/src/app/pheno-tool/pheno-tool.component.ts
+++ b/src/app/pheno-tool/pheno-tool.component.ts
@@ -32,6 +32,8 @@ export class PhenoToolComponent implements OnInit, OnDestroy {
   public disableQueryButtons = false;
   public downloadInProgress = false;
 
+  private cancelRequest: boolean;
+
   public constructor(
     private datasetsService: DatasetsService,
     private loadingService: FullscreenLoadingService,
@@ -77,10 +79,17 @@ export class PhenoToolComponent implements OnInit, OnDestroy {
 
   public submitQuery(): void {
     this.loadingService.setLoadingStart();
+    this.phenoToolResults = null;
+    this.cancelRequest = false;
+    this.loadingService.loadingStateChange.subscribe(val => {
+      if (val === 'break') {
+        this.cancelRequest = true;
+      }
+    });
     this.phenoToolService.getPhenoToolResults(
       {datasetId: this.selectedDataset.id, ...this.phenoToolState}
     ).subscribe((phenoToolResults) => {
-      this.phenoToolResults = phenoToolResults;
+      this.phenoToolResults = this.cancelRequest === false ? phenoToolResults : null;
       this.loadingService.setLoadingStop();
     }, () => {
       this.loadingService.setLoadingStop();


### PR DESCRIPTION
## Background

Fullscreen loading is a feature that limits user interactability during requests by preventing clicks, buttons, and many other changes that the user is able to make during backend requests. However, there isn't any option to cancel the request in case the user has mistaken the input or wants to make a change. 

## Aim

The aim is to give the user more control with a feature that would help him to cancel an ongoing request. 

## Implementation

Closes #745.
