### PR TITLE
add pheno measure selector nothing found message

### DIFF
--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.css
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.css
@@ -2,4 +2,8 @@
   font-style: italic;
   text-align: center;
   opacity: 75%;
+  height: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -12,7 +12,11 @@
     (keydown.escape)="closeDropdown()"
     style="width: 100%" />
   <div ngbDropdownMenu style="z-index: 3; width: 100%; max-height: 200px; overflow-y: scroll">
-    <div id="loading-dropdown-text" *ngIf="filteredMeasures.length === 0"> Loading...</div>
+    <ng-container *ngIf="filteredMeasures.length === 0">
+      <div id="loading-dropdown-text" *ngIf="loadingMeasures || loadingDropdown">Loading...</div>
+      <div id="loading-dropdown-text" *ngIf="!loadingDropdown">Nothing found</div>
+    </ng-container>
+
     <button
       *ngFor="let measure of filteredMeasures | slice : 0 : 25"
       class="dropdown-item"

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.ts
@@ -23,6 +23,8 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   public filteredMeasures: Array<ContinuousMeasure> = [];
   public searchString = '';
   public selectedMeasure: ContinuousMeasure;
+  public loadingMeasures = false;
+  public loadingDropdown = false;
 
   public constructor(
     private measuresService: MeasuresService,
@@ -30,9 +32,11 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
 
   public ngOnChanges(): void {
     if (this.datasetId && this.measures.length === 0) {
+      this.loadingMeasures = true;
       this.measuresService.getContinuousMeasures(this.datasetId).pipe(first()).subscribe(measures => {
         this.measures = measures;
         this.measuresChange.emit(this.measures);
+        this.loadingMeasures = false;
       });
     }
   }
@@ -64,12 +68,22 @@ export class PhenoMeasureSelectorComponent implements OnChanges {
   }
 
   public loadDropdownData(): void {
-    if (this.measures.length === 0) {
-      // Wait and try again if measures are not loaded yet.
-      setTimeout(this.loadDropdownData.bind(this), 200);
-      return;
-    }
+    if (!this.loadingMeasures) {
+      this.filterData();
+    } else {
+      this.loadingDropdown = true;
 
+      const intervalId = setInterval(() => {
+        if (!this.loadingMeasures) {
+          this.filterData();
+          this.loadingDropdown = false;
+          clearInterval(intervalId);
+        }
+      }, 200);
+    }
+  }
+
+  private filterData(): void {
     this.filteredMeasures = this.measures;
 
     if (this.searchString.length) {


### PR DESCRIPTION
refactor loading logic
#743

## Background
![image](https://user-images.githubusercontent.com/71064753/218451560-5445397e-692f-4bfc-b9e3-0d07f6f8019a.png)

## Aim
Empty search results should display appropriate message.

## Implementation
Add logic that differentiates between empty results because loading and empty results because nothing found.
Refactor loading logic - no need to wait data first time when data is already loaded.
