### PR TITLE
Pheno browser now doesn't need events like mouse move or scroll in or…

### DIFF
--- a/src/app/pheno-browser-table/pheno-browser-table.component.ts
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -9,8 +9,7 @@ import { PhenoMeasures } from '../pheno-browser/pheno-browser';
 @Component({
   selector: 'gpf-pheno-browser-table',
   templateUrl: './pheno-browser-table.component.html',
-  styleUrls: ['./pheno-browser-table.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrls: ['./pheno-browser-table.component.css']
 })
 export class PhenoBrowserTableComponent {
   @Input() public measures: PhenoMeasures;


### PR DESCRIPTION
## Background

Currently, the phenotype browser needs events like mouse move or scroll for example in order to update the table measures.

## Aim

The table should dynamically be loaded without the need for events to be triggered in order to draw the results.

## Implementation

Closes #717.
