### PR TITLE
fix dataset description edit icon overlap #734

### DIFF
--- a/src/app/dataset-description/dataset-description.component.css
+++ b/src/app/dataset-description/dataset-description.component.css
@@ -1,11 +1,27 @@
+.container {
+  margin-top: 20px;
+}
+
+#edit-container {
+  display: flex;
+}
+
+#edit-description {
+  display: flex;
+  position: relative;
+}
+
 #empty-description {
+  padding-top: 7px;
+}
+
+#empty-description > span {
   font-style: italic;
   opacity: 75%;
+  margin-right: 558px;
 }
 
 #edit-icon {
-  position: absolute;
-  right: 0;
   padding: 6px;
   cursor: pointer;
   margin-top: 5px;
@@ -34,7 +50,6 @@
   border: none;
   outline: none;
   cursor: not-allowed;
-
 }
 
 :host::ng-deep.md-header .btn-sm[title="Preview"] {

--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -1,6 +1,10 @@
-<div *ngIf="dataset$ | async as dataset" class="container" style="margin-top: 20px">
-  <div *ngIf="!editMode">
-    <div style="position: relative">
+<div *ngIf="dataset$ | async as dataset" class="container">
+  <div id="edit-container" *ngIf="!editMode">
+    <div *ngIf="!dataset.description" id="empty-description">
+      <span>Empty description. Write a description using the pencil button to the right.</span>
+    </div>
+    <div id="edit-description">
+      <markdown [data]="dataset.description || ''"></markdown>
       <i
         *ngIf="('' | userInfo)?.isAdministrator"
         (click)="edit()"
@@ -8,10 +12,6 @@
         class="fa fa-pencil fa-lg"
         title="Edit">
       </i>
-      <markdown [data]="dataset.description || ''"></markdown>
-    </div>
-    <div *ngIf="!dataset.description" style="padding-top: 7px">
-      <span id="empty-description">Empty description. Write a description using the pencil button to the right.</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Background

Edit icon is overlapping the description text.

## Aim

To separate them.

## Implementation

Made them separeted by using css property "display: flex".