### PR TITLE
Chromosome only region filter

### DIFF
--- a/src/app/regions-filter/regions-filter.validator.ts
+++ b/src/app/regions-filter/regions-filter.validator.ts
@@ -2,7 +2,7 @@ import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validat
 
 @ValidatorConstraint({ name: 'customText', async: false })
 export class RegionsFilterValidator implements ValidatorConstraintInterface {
-  private static lineRegex = new RegExp('^(?:chr)?(?:[0-9xXyY]|[0-1][0-9]|2[0-2])(:([0-9,]+)(?:\-([0-9,]+))?)?$', 'i');
+  private static lineRegex = new RegExp('^[\\w\\d]+(:([0-9,]+)(?:\-([0-9,]+))?)?$', 'i');
 
   public validate(text: string): boolean {
     if (!text) {

--- a/src/app/regions-filter/regions-filter.validator.ts
+++ b/src/app/regions-filter/regions-filter.validator.ts
@@ -2,7 +2,7 @@ import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validat
 
 @ValidatorConstraint({ name: 'customText', async: false })
 export class RegionsFilterValidator implements ValidatorConstraintInterface {
-  private static lineRegex = new RegExp('^(?:chr)?(?:[0-9xX]|[0-1][0-9]|2[0-2]):([0-9,]+)(?:\-([0-9,]+))?$', 'i');
+  private static lineRegex = new RegExp('^(?:chr)?(?:[0-9xXyY]|[0-1][0-9]|2[0-2])(:([0-9,]+)(?:\-([0-9,]+))?)?$', 'i');
 
   public validate(text: string): boolean {
     if (!text) {


### PR DESCRIPTION
## Background

Currently, the region filter requires positions in order to get the variants between them. There is no support for region filtering on a whole chromosome.

## Aim

Provide support for handling chromosome filtering in region filter.

## Implementation

Closes #707. Linked with a back-end pull request on the same branch.

