### PR TITLE
Table now is more consistent when resized#764

### DIFF
--- a/src/app/genotype-preview-table/genotype-preview-table.component.html
+++ b/src/app/genotype-preview-table/genotype-preview-table.component.html
@@ -3,7 +3,7 @@
     <gpf-table
       id="gpf-table"
       [dataSource]="genotypePreviewVariantsArray.genotypePreviews"
-      style="display: inline-block">
+      style="display: inline-block; min-width: 1200px">
       <gpf-table-column *ngFor="let column of columns" [columnWidth]="singleColumnWidth">
         <gpf-table-header caption="{{ column.name }}"></gpf-table-header>
         <gpf-table-header>

--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -1,5 +1,5 @@
-<gpf-table [dataSource]="measures.measures" style="display: inline-block">
-  <gpf-table-column>
+<gpf-table [dataSource]="measures.measures" style="display: inline-block; min-width: 1200px">
+  <gpf-table-column [columnWidth]="'5%'">
     <gpf-table-header caption="Instrument" field="instrumentName"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -7,7 +7,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column>
+  <gpf-table-column [columnWidth]="'7.5%'">
     <gpf-table-header caption="Proband Pheno Measure" field="measureName"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -23,7 +23,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column>
+  <gpf-table-column [columnWidth]="'7.5%'">
     <gpf-table-header caption="Pheno Measure Values"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -33,7 +33,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column>
+  <gpf-table-column [columnWidth]="'25%'">
     <gpf-table-header>
       <gpf-table-subheader caption="Measure Type" field="measureType"></gpf-table-subheader>
       <gpf-table-subheader caption="Values Domain"></gpf-table-subheader>
@@ -57,7 +57,7 @@
     </gpf-table-content>
   </gpf-table-column>
   <ng-container *ngFor="let regressionId of measures.regressionNames | getRegressionIds">
-    <gpf-table-column>
+    <gpf-table-column [columnWidth]="'5%'">
       <gpf-table-header
         caption="Regression by {{
           measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
@@ -75,7 +75,7 @@
         </span>
       </gpf-table-content>
     </gpf-table-column>
-    <gpf-table-column>
+    <gpf-table-column [columnWidth]="'5%'">
       <gpf-table-header
         caption="{{
           measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId

--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -1,5 +1,5 @@
 <gpf-table [dataSource]="measures.measures" style="display: inline-block; min-width: 1200px">
-  <gpf-table-column [columnWidth]="'5%'">
+  <gpf-table-column [columnWidth]="singleColumnWidth">
     <gpf-table-header caption="Instrument" field="instrumentName"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -7,7 +7,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column [columnWidth]="'7.5%'">
+  <gpf-table-column [columnWidth]="singleColumnWidth">
     <gpf-table-header caption="Proband Pheno Measure" field="measureName"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -23,7 +23,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column [columnWidth]="'7.5%'">
+  <gpf-table-column [columnWidth]="singleColumnWidth">
     <gpf-table-header caption="Pheno Measure Values"></gpf-table-header>
     <gpf-table-content>
       <span *gpfTableCellContent="let data">
@@ -33,7 +33,7 @@
       </span>
     </gpf-table-content>
   </gpf-table-column>
-  <gpf-table-column [columnWidth]="'25%'">
+  <gpf-table-column [columnWidth]="singleColumnWidth">
     <gpf-table-header>
       <gpf-table-subheader caption="Measure Type" field="measureType"></gpf-table-subheader>
       <gpf-table-subheader caption="Values Domain"></gpf-table-subheader>
@@ -57,7 +57,7 @@
     </gpf-table-content>
   </gpf-table-column>
   <ng-container *ngFor="let regressionId of measures.regressionNames | getRegressionIds">
-    <gpf-table-column [columnWidth]="'5%'">
+    <gpf-table-column [columnWidth]="singleColumnWidth">
       <gpf-table-header
         caption="Regression by {{
           measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
@@ -75,7 +75,7 @@
         </span>
       </gpf-table-content>
     </gpf-table-column>
-    <gpf-table-column [columnWidth]="'5%'">
+    <gpf-table-column [columnWidth]="singleColumnWidth">
       <gpf-table-header
         caption="{{
           measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId

--- a/src/app/pheno-browser-table/pheno-browser-table.component.ts
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.ts
@@ -15,7 +15,7 @@ export class PhenoBrowserTableComponent implements OnInit {
   @Input() public measures: PhenoMeasures;
 
   public singleColumnWidth;
-  private columnsCount = 8; // This is the number of columns
+  private columnsCount = 8;
 
   public constructor(
     private modalService: NgbModal

--- a/src/app/pheno-browser-table/pheno-browser-table.component.ts
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { OnInit, Component, HostListener, Input } from '@angular/core';
 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -11,12 +11,19 @@ import { PhenoMeasures } from '../pheno-browser/pheno-browser';
   templateUrl: './pheno-browser-table.component.html',
   styleUrls: ['./pheno-browser-table.component.css']
 })
-export class PhenoBrowserTableComponent {
+export class PhenoBrowserTableComponent implements OnInit {
   @Input() public measures: PhenoMeasures;
+
+  public singleColumnWidth;
+  private columnsCount = 8; // This is the number of columns
 
   public constructor(
     private modalService: NgbModal
   ) { }
+
+  public ngOnInit(): void {
+    this.onResize();
+  }
 
   public static compare(leftVal: any, rightVal: any): number {
     if (leftVal === null && rightVal === null) {
@@ -34,6 +41,15 @@ export class PhenoBrowserTableComponent {
     }
 
     return leftVal.localeCompare(rightVal);
+  }
+
+  @HostListener('window:resize', ['$event'])
+  public onResize(): void {
+    const screenWidth = window.innerWidth;
+    const padding = 60;
+    const scrollSize = 15;
+
+    this.singleColumnWidth = `${(screenWidth - padding - scrollSize) / this.columnsCount}px`;
   }
 
   public openModal(imageUrl: string): void {

--- a/src/app/table/component/column.component.ts
+++ b/src/app/table/component/column.component.ts
@@ -25,6 +25,6 @@ export class GpfTableColumnComponent implements OnInit {
   private updateColumnWidth(percentage): void {
     const browserWidth = window.innerWidth;
     const pixelWidth = browserWidth * percentage / 100;
-    this.columnWidth = String(pixelWidth) + 'px';
+    this.columnWidth = `${pixelWidth}px`;
   }
 }

--- a/src/app/table/component/column.component.ts
+++ b/src/app/table/component/column.component.ts
@@ -1,4 +1,4 @@
-import { Input, ContentChildren, QueryList, Component } from '@angular/core';
+import { Input, ContentChildren, QueryList, Component, OnInit } from '@angular/core';
 import { GpfTableContentHeaderComponent } from './header.component';
 import { GpfTableContentComponent } from './content.component';
 
@@ -6,9 +6,25 @@ import { GpfTableContentComponent } from './content.component';
   selector: 'gpf-table-column',
   template: '',
 })
-export class GpfTableColumnComponent {
+export class GpfTableColumnComponent implements OnInit {
   @ContentChildren(GpfTableContentHeaderComponent) public headerChildren: QueryList<GpfTableContentHeaderComponent>;
   @ContentChildren(GpfTableContentComponent) public contentChildren: QueryList<GpfTableContentComponent>;
   @Input() public columnWidth = '';
   @Input() public columnMaxWidth = '';
+
+  public ngOnInit(): void {
+    if (this.columnWidth.endsWith('%')) {
+      const percentage = Number(this.columnWidth.slice(0, -1));
+      this.updateColumnWidth(percentage);
+      window.addEventListener('resize', () => {
+        this.updateColumnWidth(percentage);
+      });
+    }
+  }
+
+  private updateColumnWidth(percentage): void {
+    const browserWidth = window.innerWidth;
+    const pixelWidth = browserWidth * percentage / 100;
+    this.columnWidth = String(pixelWidth) + 'px';
+  }
 }

--- a/src/app/table/table.component.css
+++ b/src/app/table/table.component.css
@@ -4,15 +4,13 @@ gpf-table-view-empty-cell {
 
 gpf-table-view-header-cell {
   display: table-cell;
+  height: auto;
 }
 
 gpf-table-view-cell {
   display: table-cell;
-  height: 111px;
-  max-height: 111px;
+  overflow-wrap: break-word;
   border: 1px solid #ddd;
-  width: 150px;
-  max-width: 150px;
   overflow: hidden;
   padding: 8px;
   text-align: center;

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -21,7 +21,6 @@
       [columnInfo]="column"
       [data]="data"
       [noScrollOptimization]="noScrollOptimization"
-      [style.white-space]="'nowrap'"
       [style.width]="column.columnWidth ? column.columnWidth : null"
       [style.min-width]="column.columnWidth ? column.columnWidth : null"
       [style.max-width]="column.columnWidth ? column.columnWidth : null"

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -22,6 +22,7 @@
       [data]="data"
       [noScrollOptimization]="noScrollOptimization"
       [style.width]="column.columnWidth ? column.columnWidth : null"
+      [style.min-width]="column.columnWidth ? column.columnWidth : null"
       [style.max-width]="column.columnWidth ? column.columnWidth : null"
       style="vertical-align: middle">
     </gpf-table-view-cell>

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -21,6 +21,7 @@
       [columnInfo]="column"
       [data]="data"
       [noScrollOptimization]="noScrollOptimization"
+      [style.white-space]="'nowrap'"
       [style.width]="column.columnWidth ? column.columnWidth : null"
       [style.min-width]="column.columnWidth ? column.columnWidth : null"
       [style.max-width]="column.columnWidth ? column.columnWidth : null"

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -21,9 +21,9 @@
       [columnInfo]="column"
       [data]="data"
       [noScrollOptimization]="noScrollOptimization"
-      [style.width]="column.columnWidth ? column.columnWidth : null"
-      [style.min-width]="column.columnWidth ? column.columnWidth : null"
-      [style.max-width]="column.columnWidth ? column.columnWidth : null"
+      [style.width]="column.columnWidth || null"
+      [style.min-width]="column.columnWidth || null"
+      [style.max-width]="column.columnWidth || null"
       style="vertical-align: middle">
     </gpf-table-view-cell>
   </div>

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -75,8 +75,18 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
 
   @HostListener('window:resize', ['$event'])
   public onWindowResize(): void {
-    this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
+    this.tableWidth = '0';
+    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
+      this.columnsChildren.forEach(column => {
+        this.tableWidth = String(parseFloat(this.tableWidth) + parseFloat(column.columnWidth));
+      });
+      this.tableWidth += 'px';
+      if (parseFloat(this.tableWidth) <= this.tableViewChild?.nativeElement.offsetWidth) {
+        this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
+      }
+    }
   }
+
 
   public set sortingInfo(sortingInfo: SortInfo) {
     this.previousSortingInfo = sortingInfo;
@@ -129,7 +139,17 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
   }
 
   public getVisibleData(): Array<any> {
-    this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
+    this.tableWidth = '0';
+    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
+      this.columnsChildren.forEach(column => {
+        this.tableWidth = String(parseFloat(this.tableWidth) + parseFloat(column.columnWidth));
+      });
+      this.tableWidth += 'px';
+      if (parseFloat(this.tableWidth) <= this.tableViewChild?.nativeElement.offsetWidth) {
+        this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
+      }
+    }
+    //this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
     if (!this.dataSource) {
       return [];
     }

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -75,7 +75,7 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
 
   @HostListener('window:resize', ['$event'])
   public onWindowResize(): void {
-    this.tableWidth = String(this.calculateTableWidthFloat()) + 'px';
+    this.tableWidth = `${this.calculateTableWidthFloat()}px`;
   }
 
 
@@ -130,7 +130,7 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
   }
 
   public getVisibleData(): Array<any> {
-    this.tableWidth = String(this.calculateTableWidthFloat()) + 'px';
+    this.tableWidth = `${this.calculateTableWidthFloat()}px`;
     if (!this.dataSource) {
       return [];
     }
@@ -142,13 +142,13 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
   }
 
   public calculateTableWidthFloat(): number {
-    let tableWidthFloat = 0;
-    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
-      this.columnsChildren.forEach(column => {
-        tableWidthFloat += parseFloat(column.columnWidth);
-      });
-      return tableWidthFloat;
+    if (!this.columnsChildren) {
+      return undefined;
     }
-    return undefined;
+    let tableWidthFloat = 0;
+    this.columnsChildren.forEach(column => {
+      tableWidthFloat += parseFloat(column.columnWidth);
+    });
+    return tableWidthFloat;
   }
 }

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -75,16 +75,7 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
 
   @HostListener('window:resize', ['$event'])
   public onWindowResize(): void {
-    this.tableWidth = '0';
-    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
-      this.columnsChildren.forEach(column => {
-        this.tableWidth = String(parseFloat(this.tableWidth) + parseFloat(column.columnWidth));
-      });
-      this.tableWidth += 'px';
-      if (parseFloat(this.tableWidth) <= this.tableViewChild?.nativeElement.offsetWidth) {
-        this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
-      }
-    }
+    this.tableWidth = String(this.calculateTableWidthFloat()) + 'px';
   }
 
 
@@ -139,17 +130,7 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
   }
 
   public getVisibleData(): Array<any> {
-    this.tableWidth = '0';
-    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
-      this.columnsChildren.forEach(column => {
-        this.tableWidth = String(parseFloat(this.tableWidth) + parseFloat(column.columnWidth));
-      });
-      this.tableWidth += 'px';
-      if (parseFloat(this.tableWidth) <= this.tableViewChild?.nativeElement.offsetWidth) {
-        this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
-      }
-    }
-    //this.tableWidth = this.tableViewChild?.nativeElement.offsetWidth;
+    this.tableWidth = String(this.calculateTableWidthFloat()) + 'px';
     if (!this.dataSource) {
       return [];
     }
@@ -158,5 +139,16 @@ export class GpfTableComponent implements OnChanges, AfterViewChecked {
     }
     const scrollIndices = this.getScrollIndices();
     return this.dataSource.slice(scrollIndices[0], scrollIndices[1]);
+  }
+
+  public calculateTableWidthFloat(): number {
+    let tableWidthFloat = 0;
+    if (this.columnsChildren !== undefined && this.columnsChildren !== null) {
+      this.columnsChildren.forEach(column => {
+        tableWidthFloat += parseFloat(column.columnWidth);
+      });
+      return tableWidthFloat;
+    }
+    return undefined;
   }
 }

--- a/src/app/table/view/header/header-cell.component.css
+++ b/src/app/table/view/header/header-cell.component.css
@@ -9,6 +9,16 @@
   height: 12px;
 }
 
+span.holder {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+span {
+  white-space: pre-line;
+  display: inline-block;
+}
+
 #sorting-buttons {
   display: table-cell;
   vertical-align: middle;

--- a/src/app/table/view/header/header-cell.component.html
+++ b/src/app/table/view/header/header-cell.component.html
@@ -5,7 +5,7 @@
         <div (click)="onSortClick(columnInfo)" [class.clickable]="columnInfo.sortable" id="sort">
           <ng-template *ngIf="columnInfo.contentTemplateRef" [ngTemplateOutlet]="columnInfo.contentTemplateRef">
           </ng-template>
-          <span *ngIf="columnInfo.caption">{{ columnInfo.caption }}</span>
+          <span style="word-break: break-word" *ngIf="columnInfo.caption">{{ columnInfo.caption }}</span>
         </div>
         <div (click)="onSortClick(columnInfo)" [class.clickable]="columnInfo.sortable" id="sorting-buttons">
           <i

--- a/src/app/table/view/header/header-cell.component.html
+++ b/src/app/table/view/header/header-cell.component.html
@@ -33,7 +33,7 @@
       <div *ngFor="let child of columnInfo.subcolumnsChildren" style="display: table-row">
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sort-child">
           <ng-template *ngIf="child.contentTemplateRef" [ngTemplateOutlet]="child.contentTemplateRef"></ng-template>
-          <span style="word-break: nowrap" *ngIf="!child.contentTemplateRef">{{ child.caption }}</span>
+          <span *ngIf="!child.contentTemplateRef" style="word-break: nowrap">{{ child.caption }}</span>
         </div>
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sorting-buttons">
           <i

--- a/src/app/table/view/header/header-cell.component.html
+++ b/src/app/table/view/header/header-cell.component.html
@@ -5,7 +5,7 @@
         <div (click)="onSortClick(columnInfo)" [class.clickable]="columnInfo.sortable" id="sort">
           <ng-template *ngIf="columnInfo.contentTemplateRef" [ngTemplateOutlet]="columnInfo.contentTemplateRef">
           </ng-template>
-          <span style="word-break: break-word" *ngIf="columnInfo.caption">{{ columnInfo.caption }}</span>
+          <span *ngIf="columnInfo.caption">{{ columnInfo.caption }}</span>
         </div>
         <div (click)="onSortClick(columnInfo)" [class.clickable]="columnInfo.sortable" id="sorting-buttons">
           <i
@@ -33,7 +33,7 @@
       <div *ngFor="let child of columnInfo.subcolumnsChildren" style="display: table-row">
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sort-child">
           <ng-template *ngIf="child.contentTemplateRef" [ngTemplateOutlet]="child.contentTemplateRef"></ng-template>
-          <span *ngIf="!child.contentTemplateRef" style="word-break: nowrap">{{ child.caption }}</span>
+          <span *ngIf="!child.contentTemplateRef">{{ child.caption }}</span>
         </div>
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sorting-buttons">
           <i

--- a/src/app/table/view/header/header-cell.component.html
+++ b/src/app/table/view/header/header-cell.component.html
@@ -33,7 +33,7 @@
       <div *ngFor="let child of columnInfo.subcolumnsChildren" style="display: table-row">
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sort-child">
           <ng-template *ngIf="child.contentTemplateRef" [ngTemplateOutlet]="child.contentTemplateRef"></ng-template>
-          <span *ngIf="!child.contentTemplateRef">{{ child.caption }}</span>
+          <span style="word-break: nowrap" *ngIf="!child.contentTemplateRef">{{ child.caption }}</span>
         </div>
         <div (click)="onSortClick(child)" [class.clickable]="child.sortable" id="sorting-buttons">
           <i

--- a/src/app/table/view/header/header.component.css
+++ b/src/app/table/view/header/header.component.css
@@ -4,5 +4,6 @@ gpf-table-view-header-cell {
   font-size: 0.9em;
   background: #eee;
   font-weight: 500;
+  height: auto;
   display: table-cell;
 }

--- a/src/app/table/view/header/header.component.html
+++ b/src/app/table/view/header/header.component.html
@@ -4,9 +4,9 @@
     *ngFor="let column of columns"
     [columnInfo]="column.headerChildren.toArray()[i]"
     [sortingInfo]="sortingInfo"
-    [style.width]="column.columnWidth ? column.columnWidth : null"
-    [style.min-width]="column.columnWidth ? column.columnWidth : null"
-    [style.max-width]="column.columnWidth ? column.columnWidth : null"
+    [style.width]="column.columnWidth || null"
+    [style.min-width]="column.columnWidth || null"
+    [style.max-width]="column.columnWidth || null"
     (sortingInfoChange)="sortingInfoChange.emit($event)"
     style="vertical-align: middle">
   </gpf-table-view-header-cell>

--- a/src/app/table/view/header/header.component.html
+++ b/src/app/table/view/header/header.component.html
@@ -4,7 +4,6 @@
     *ngFor="let column of columns"
     [columnInfo]="column.headerChildren.toArray()[i]"
     [sortingInfo]="sortingInfo"
-    [style.white-space]="'break-spaces'"
     [style.width]="column.columnWidth ? column.columnWidth : null"
     [style.min-width]="column.columnWidth ? column.columnWidth : null"
     [style.max-width]="column.columnWidth ? column.columnWidth : null"

--- a/src/app/table/view/header/header.component.html
+++ b/src/app/table/view/header/header.component.html
@@ -4,6 +4,7 @@
     *ngFor="let column of columns"
     [columnInfo]="column.headerChildren.toArray()[i]"
     [sortingInfo]="sortingInfo"
+    [style.white-space]="'break-spaces'"
     [style.width]="column.columnWidth ? column.columnWidth : null"
     [style.min-width]="column.columnWidth ? column.columnWidth : null"
     [style.max-width]="column.columnWidth ? column.columnWidth : null"

--- a/src/app/table/view/header/header.component.html
+++ b/src/app/table/view/header/header.component.html
@@ -4,11 +4,10 @@
     *ngFor="let column of columns"
     [columnInfo]="column.headerChildren.toArray()[i]"
     [sortingInfo]="sortingInfo"
-    [style.min-width]="column.columnWidth ? column.columnWidth : null"
     [style.width]="column.columnWidth ? column.columnWidth : null"
+    [style.min-width]="column.columnWidth ? column.columnWidth : null"
     [style.max-width]="column.columnWidth ? column.columnWidth : null"
     (sortingInfoChange)="sortingInfoChange.emit($event)"
-    style="vertical-align: middle"
-    [style.width]="column.columnWidth ? column.columnWidth : null">
+    style="vertical-align: middle">
   </gpf-table-view-header-cell>
 </div>

--- a/src/app/table/view/header/header.component.html
+++ b/src/app/table/view/header/header.component.html
@@ -4,10 +4,11 @@
     *ngFor="let column of columns"
     [columnInfo]="column.headerChildren.toArray()[i]"
     [sortingInfo]="sortingInfo"
-    [style.width]="getWidth(column)"
-    [style.min-width]="getWidth(column)"
-    [style.max-width]="getMaxWidth(column)"
+    [style.min-width]="column.columnWidth ? column.columnWidth : null"
+    [style.width]="column.columnWidth ? column.columnWidth : null"
+    [style.max-width]="column.columnWidth ? column.columnWidth : null"
     (sortingInfoChange)="sortingInfoChange.emit($event)"
-    style="vertical-align: middle">
+    style="vertical-align: middle"
+    [style.width]="column.columnWidth ? column.columnWidth : null">
   </gpf-table-view-header-cell>
 </div>

--- a/src/app/table/view/header/header.component.spec.ts
+++ b/src/app/table/view/header/header.component.spec.ts
@@ -96,7 +96,7 @@ describe('GpfTableHeaderComponent', () => {
   });
 
   it('should give column width', () => {
-    expect(component.getWidth(testComponent)).toBe('50.0');
+    expect(testComponent.columnWidth).toBe('50.0');
     expect(component.getWidth(null)).toBeNull();
   });
 });

--- a/src/app/table/view/header/header.component.spec.ts
+++ b/src/app/table/view/header/header.component.spec.ts
@@ -97,6 +97,5 @@ describe('GpfTableHeaderComponent', () => {
 
   it('should give column width', () => {
     expect(testComponent.columnWidth).toBe('50.0');
-    expect(component.getWidth(null)).toBeNull();
   });
 });

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -15,11 +15,11 @@ export class GpfTableHeaderComponent {
   @Output() public sortingInfoChange = new EventEmitter();
   @Input() public sortingInfo: SortInfo;
 
-  public constructor(private cd: ChangeDetectorRef) {}
+  public constructor(private cdr: ChangeDetectorRef) {}
 
   @HostListener('window:resize', ['$event'])
   public onWindowResize(): void {
-    this.cd.detectChanges();
+    this.cdr.detectChanges();
   }
 
   public get subheadersCount(): number[] {

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -12,10 +12,6 @@ export class GpfTableHeaderComponent {
   @Output() public sortingInfoChange = new EventEmitter();
   @Input() public sortingInfo: SortInfo;
 
-  @HostListener('window:resize', ['$event'])
-  public onWindowResize(): void {
-  }
-
   public get subheadersCount(): number[] {
     if (this.columns.first) {
       const length: number = this.columns.first.headerChildren.length;

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, HostListener } from '@angular/core';
 import { SortInfo } from '../../table.component';
 
 @Component({
@@ -11,6 +11,10 @@ export class GpfTableHeaderComponent {
   @Input() public columns: any;
   @Output() public sortingInfoChange = new EventEmitter();
   @Input() public sortingInfo: SortInfo;
+
+  @HostListener('window:resize', ['$event'])
+  public onWindowResize(): void {
+  }
 
   public get subheadersCount(): number[] {
     if (this.columns.first) {

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
-import { GpfTableColumnComponent } from 'app/table/component/column.component';
 import { SortInfo } from '../../table.component';
 
 @Component({

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -20,20 +20,4 @@ export class GpfTableHeaderComponent {
     }
     return [];
   }
-
-  public getMaxWidth(column): number {
-    if (column.columnMaxWidth) {
-      return column.columnMaxWidth;
-    }
-  }
-
-  public getWidth(column: GpfTableColumnComponent): string {
-    let width: string;
-    if (column === null) {
-      width = null;
-    } else if (column.columnWidth) {
-      width = column.columnWidth;
-    }
-    return width;
-  }
 }

--- a/src/app/table/view/header/header.component.ts
+++ b/src/app/table/view/header/header.component.ts
@@ -1,4 +1,7 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, HostListener } from '@angular/core';
+import {
+  Component, Input, Output, EventEmitter,
+  ChangeDetectionStrategy, HostListener, ChangeDetectorRef
+} from '@angular/core';
 import { SortInfo } from '../../table.component';
 
 @Component({
@@ -11,6 +14,13 @@ export class GpfTableHeaderComponent {
   @Input() public columns: any;
   @Output() public sortingInfoChange = new EventEmitter();
   @Input() public sortingInfo: SortInfo;
+
+  public constructor(private cd: ChangeDetectorRef) {}
+
+  @HostListener('window:resize', ['$event'])
+  public onWindowResize(): void {
+    this.cd.detectChanges();
+  }
 
   public get subheadersCount(): number[] {
     if (this.columns.first) {


### PR DESCRIPTION
## Background

When the table is resized, it affects headers in a way breaking their width.

## Aim

Provide stability when the table is resized. The sticky headers should not scale with the current width but take the table width.

## Implementation

Closes #764.
