### PR TITLE
Gene browser download buttons redesign

### DIFF
--- a/src/app/gene-browser/gene-browser.component.css
+++ b/src/app/gene-browser/gene-browser.component.css
@@ -43,3 +43,62 @@
   flex-wrap: wrap;
   margin-bottom: 40px;
 }
+
+#family-variants-wrapper {
+  display: flex;
+  justify-content: end;
+  border-radius: 0.375rem;
+}
+
+#download-family-variants-button {
+  margin-left: 10px;
+  font-size: 15px;
+  padding: 5px;
+  width: 35px;
+  height: 30px;
+  text-align: center;
+}
+
+#family-variants-block {
+  background-color: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 12.5%);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  margin-bottom: 15px;
+}
+
+#family-variants-count {
+  margin-left: 8px;
+  background-color: #eee;
+  padding: 2px;
+  border: 1px solid rgba(0, 0, 0, 12.5%);
+  display: inline-grid;
+  min-width: 150px;
+  text-align: center;
+}
+
+#unique-family-variants {
+  display: flex;
+}
+
+.loader {
+  border: 4px solid #f3f3f3;
+  border-radius: 50%;
+  border-top: 4px solid #2a6395;
+  width: 20px;
+  height: 20px;
+  animation: spin 2s linear infinite;
+  margin-left: 2px;
+  margin-top: -1px;
+}
+
+.loader:hover {
+  border-top-color: #173c5c;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/gene-browser/gene-browser.component.css
+++ b/src/app/gene-browser/gene-browser.component.css
@@ -67,6 +67,7 @@
   align-items: center;
   padding: 10px;
   margin-bottom: 15px;
+  border-radius: 5px;
 }
 
 #family-variants-count {

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -161,7 +161,7 @@
         [condenseIntrons]="summaryVariantsFilter.codingOnly"
         [frequencyDomain]="[geneBrowserConfig.domainMin, geneBrowserConfig.domainMax]"
         [yAxisLabel]="geneBrowserConfig.frequencyName || geneBrowserConfig.frequencyColumn"
-        [summaryVariantsCounts]="summaryVariantsArray.totalSummaryAllelesCount"
+        [summaryVariantsCount]="summaryVariantsArray.totalSummaryAllelesCount"
         (selectedRegion)="setSelectedRegion($event)"
         (selectedFrequencies)="setSelectedFrequencies($event)"
         [selectedGene]="selectedGene"
@@ -180,7 +180,7 @@
           <input
             id="unique-family-variants-checkbox"
             type="checkbox"
-            [disabled]="!isUniqueFamilyFitlerEnable"
+            [disabled]="!isUniqueFamilyFilterEnabled"
             (click)="checkUniqueFamilyVariantsFilter()" />
         </div>
         <div id="family-variants-wrapper">

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -197,6 +197,7 @@
           <div *ngIf="selectedGene">
             <button
               class="btn btn-md btn-primary btn-right"
+              [disabled]="this.summaryVariantsArrayFiltered?.totalFamilyVariantsCount === 0"
               id="download-family-variants-button"
               (click)="onDownload()"
               title="Download family variants">

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -161,41 +161,51 @@
         [condenseIntrons]="summaryVariantsFilter.codingOnly"
         [frequencyDomain]="[geneBrowserConfig.domainMin, geneBrowserConfig.domainMax]"
         [yAxisLabel]="geneBrowserConfig.frequencyName || geneBrowserConfig.frequencyColumn"
-        [allVariantsCounts]="[
-          summaryVariantsArray.totalSummaryAllelesCount,
-          summaryVariantsArray.totalFamilyVariantsCount
-        ]"
+        [summaryVariantsCounts]="summaryVariantsArray.totalSummaryAllelesCount"
         (selectedRegion)="setSelectedRegion($event)"
-        (selectedFrequencies)="setSelectedFrequencies($event)">
+        (selectedFrequencies)="setSelectedFrequencies($event)"
+        [selectedGene]="selectedGene"
+        [downloadInProgressSummary]="downloadInProgressSummary"
+        (downloadSummaryVariants)="onDownloadSummary()">
       </gpf-gene-plot>
-      <div class="row" style="padding-top: 15px">
-        <div class="col-12" *ngIf="selectedGene">
-          <button class="btn btn-md btn-primary btn-right" id="download-summary-button" (click)="onDownloadSummary()">
-            <span *ngIf="downloadInProgressSummary">Downloading...</span>
-            <span *ngIf="!downloadInProgressSummary">Download Summary</span>
-          </button>
+
+      <fieldset id="family-variants-block" class="form-block">
+        <div id="unique-family-variants">
+          <label
+            for="unique-family-variants-checkbox"
+            class="nav-title-custom"
+            style="width: unset; margin-right: unset; padding-right: 10px"
+            >Unique family variants</label
+          >
+          <input
+            id="unique-family-variants-checkbox"
+            type="checkbox"
+            [disabled]="!isUniqueFamilyFitlerEnable"
+            (click)="checkUniqueFamilyVariantsFilter()" />
         </div>
-      </div>
-
-      <hr />
-
-      <div *ngIf="isUniqueFamilyFitlerVisible" id="unique-family-variants-block" class="form-block">
-        <div class="card">
-          <ul ngbNav class="navbar bg-light nav-pills" style="justify-content: flex-start">
-            <label
-              for="unique-family-variants-checkbox"
-              class="nav-title-custom"
-              style="width: unset; margin-right: unset; padding-right: 10px"
-              >Unique family variants</label
-            >
-            <li ngbNavItem style="display: flex">
-              <input id="unique-family-variants-checkbox" type="checkbox" (click)="checkUniqueFamilyVariantsFilter()" />
-            </li>
-          </ul>
+        <div id="family-variants-wrapper">
+          <span title="Family variants">
+            <span class="d-none d-xl-inline">Family variants:</span>
+            <span class="d-none d-md-inline d-xl-none d-xxl-none">FV:</span>
+            <span id="family-variants-count">
+              <span
+                >{{ this.summaryVariantsArrayFiltered?.totalFamilyVariantsCount }} /
+                {{ this.summaryVariantsArray.totalFamilyVariantsCount }}</span
+              >
+            </span>
+          </span>
+          <div *ngIf="selectedGene">
+            <button
+              class="btn btn-md btn-primary btn-right"
+              id="download-family-variants-button"
+              (click)="onDownload()"
+              title="Download family variants">
+              <div *ngIf="downloadInProgress" class="loader"></div>
+              <span *ngIf="!downloadInProgress"><i class="fa fa-solid fa-download"></i></span>
+            </button>
+          </div>
         </div>
-      </div>
-
-      <hr />
+      </fieldset>
 
       <div class="row">
         <div class="col-6">
@@ -204,12 +214,6 @@
             [loadingFinished]="familyLoadingFinished"
             [count]="genotypePreviewVariantsArray?.getVariantsCount(maxFamilyVariants)">
           </gpf-loading-spinner>
-        </div>
-        <div class="col-6" *ngIf="selectedGene">
-          <button class="btn btn-md btn-primary btn-right" id="download-button" (click)="onDownload()">
-            <span *ngIf="downloadInProgress">Downloading...</span>
-            <span *ngIf="!downloadInProgress">Download</span>
-          </button>
         </div>
       </div>
 

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -55,7 +55,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public legend: Array<PersonSet>;
   public geneSymbolSuggestions: string[] = [];
   public searchBoxInput$: Subject<string> = new Subject();
-  public isUniqueFamilyFitlerVisible = false;
+  public isUniqueFamilyFitlerEnable = false;
 
   private subscriptions: Subscription[] = [];
   private selectedDatasetId: string;
@@ -122,7 +122,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     });
 
     if (this.selectedDataset.studies?.length > 1) {
-      this.isUniqueFamilyFitlerVisible = true;
+      this.isUniqueFamilyFitlerEnable = true;
     }
   }
 

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -55,7 +55,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public legend: Array<PersonSet>;
   public geneSymbolSuggestions: string[] = [];
   public searchBoxInput$: Subject<string> = new Subject();
-  public isUniqueFamilyFitlerEnable = false;
+  public isUniqueFamilyFilterEnabled = false;
 
   private subscriptions: Subscription[] = [];
   private selectedDatasetId: string;
@@ -122,7 +122,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     });
 
     if (this.selectedDataset.studies?.length > 1) {
-      this.isUniqueFamilyFitlerEnable = true;
+      this.isUniqueFamilyFilterEnabled = true;
     }
   }
 

--- a/src/app/gene-plot/gene-plot.component.css
+++ b/src/app/gene-plot/gene-plot.component.css
@@ -37,17 +37,43 @@ label {
   overflow: hidden;
 }
 
-#summary-alleles-count,
-#family-variants-count {
+#summary-alleles-count {
   display: inline-grid;
   min-width: 150px;
   text-align: center;
 }
 
-#summary-alleles-count span,
-#family-variants-count span {
+#summary-alleles-count span {
   margin-left: 8px;
   background-color: #eee;
   padding: 2px;
   border: 1px solid rgba(0, 0, 0, 12.5%);
+}
+
+#download-summary-variants-button {
+  margin-left: 10px;
+  font-size: 15px;
+  padding: 5px;
+  width: 35px;
+  height: 30px;
+}
+
+.loader {
+  border: 4px solid #f3f3f3;
+  border-radius: 50%;
+  border-top: 4px solid #2a6395;
+  width: 20px;
+  height: 20px;
+  animation: spin 2s linear infinite;
+  margin-left: 2px;
+  margin-top: -1px;
+}
+
+.loader:hover {
+  border-top-color: #173c5c;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }

--- a/src/app/gene-plot/gene-plot.component.html
+++ b/src/app/gene-plot/gene-plot.component.html
@@ -51,7 +51,7 @@
         <span class="d-none d-xl-inline">Summary alleles:</span>
         <span class="d-none d-md-inline d-xl-none d-xxl-none">SA:</span>
         <span id="summary-alleles-count">
-          <span>{{ this.variantsArray?.totalSummaryAllelesCount }} / {{ this.summaryVariantsCounts }}</span>
+          <span>{{ this.variantsArray?.totalSummaryAllelesCount }} / {{ this.summaryVariantsCount }}</span>
         </span>
       </span>
 

--- a/src/app/gene-plot/gene-plot.component.html
+++ b/src/app/gene-plot/gene-plot.component.html
@@ -51,19 +51,20 @@
         <span class="d-none d-xl-inline">Summary alleles:</span>
         <span class="d-none d-md-inline d-xl-none d-xxl-none">SA:</span>
         <span id="summary-alleles-count">
-          <span>{{ this.variantsArray?.totalSummaryAllelesCount }} / {{ this.allVariantsCounts[0] }}</span>
+          <span>{{ this.variantsArray?.totalSummaryAllelesCount }} / {{ this.summaryVariantsCounts }}</span>
         </span>
       </span>
 
-      <div style="padding-right: 24px"></div>
-
-      <span title="Family variants">
-        <span class="d-none d-xl-inline">Family variants:</span>
-        <span class="d-none d-md-inline d-xl-none d-xxl-none">FV:</span>
-        <span id="family-variants-count">
-          <span>{{ this.variantsArray?.totalFamilyVariantsCount }} / {{ this.allVariantsCounts[1] }}</span>
-        </span>
-      </span>
+      <div *ngIf="selectedGene">
+        <button
+          class="btn btn-md btn-primary btn-right"
+          id="download-summary-variants-button"
+          (click)="onDownload()"
+          title="Download summary variants">
+          <div *ngIf="downloadInProgressSummary" class="loader"></div>
+          <span *ngIf="!downloadInProgressSummary"><i class="fa fa-solid fa-download"></i></span>
+        </button>
+      </div>
     </span>
   </div>
   <div id="svg-container"></div>

--- a/src/app/gene-plot/gene-plot.component.html
+++ b/src/app/gene-plot/gene-plot.component.html
@@ -58,6 +58,7 @@
       <div *ngIf="selectedGene">
         <button
           class="btn btn-md btn-primary btn-right"
+          [disabled]="this.variantsArray?.totalSummaryAllelesCount === 0"
           id="download-summary-variants-button"
           (click)="onDownload()"
           title="Download summary variants">

--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -16,7 +16,7 @@ export class GenePlotComponent implements OnChanges {
   @Input() public readonly variantsArray: SummaryAllelesArray;
   @Input() public readonly frequencyDomain: [number, number];
   @Input() public readonly yAxisLabel: string;
-  @Input() public readonly summaryVariantsCounts: number;
+  @Input() public readonly summaryVariantsCount: number;
   @Input() public condenseIntrons: boolean;
 
   @Input() public downloadInProgressSummary: boolean;
@@ -163,9 +163,9 @@ export class GenePlotComponent implements OnChanges {
   }
 
   private get svgHeight(): number {
-    const transcriptsCount = (
+    const transcriptsCount =
       this.showTranscripts ?
-        this.genePlotModel.gene.transcripts.length : this.genePlotModel.gene.collapsedTranscripts.length);
+        this.genePlotModel.gene.transcripts.length : this.genePlotModel.gene.collapsedTranscripts.length;
     return this.frequencyPlotHeight
       + this.constants.frequencyPlotPadding
       + this.constants.margin.top

--- a/src/app/gene-plot/gene-plot.component.ts
+++ b/src/app/gene-plot/gene-plot.component.ts
@@ -16,8 +16,12 @@ export class GenePlotComponent implements OnChanges {
   @Input() public readonly variantsArray: SummaryAllelesArray;
   @Input() public readonly frequencyDomain: [number, number];
   @Input() public readonly yAxisLabel: string;
-  @Input() public readonly allVariantsCounts: [number, number];
+  @Input() public readonly summaryVariantsCounts: number;
   @Input() public condenseIntrons: boolean;
+
+  @Input() public downloadInProgressSummary: boolean;
+  @Input() public selectedGene: Gene;
+  @Output() public downloadSummaryVariants: EventEmitter<any> = new EventEmitter();
 
   @Output() public selectedRegion = new EventEmitter<[number, number]>();
   @Output() public selectedFrequencies = new EventEmitter<[number, number]>();
@@ -146,6 +150,10 @@ export class GenePlotComponent implements OnChanges {
     );
 
     this.redraw();
+  }
+
+  public onDownload(): void {
+    this.downloadSummaryVariants.emit();
   }
 
   private get plotWidth(): number {


### PR DESCRIPTION
design and position

## Background

The position of download summary varinats and download family varinats buttons didn't look well and the readability was poor.

## Aim

To change buttons position and design.

## Implementation

Put an icon instead of text on the buttons. Put the buttons next to their relevant counter .

The wireframe
![image](https://user-images.githubusercontent.com/56651698/226893214-de8c833a-b685-4915-9c78-1817412bd08d.png)

