### PR TITLE
Utilise Sentry to report errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "prettier": "2.8.3",
     "stylelint": "14.16.1",
     "stylelint-config-standard": "29.0.0",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "@sentry/angular-ivy": "7.41.0",
+    "@sentry/tracing": "7.41.0"
   },
   "browserslist": [
     "defaults",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, ErrorHandler } from '@angular/core';
+import { NgModule, ErrorHandler, APP_INITIALIZER } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -55,7 +55,7 @@ import { EnrichmentTableRowComponent } from './enrichment-table/enrichment-table
 import { FullscreenLoadingComponent } from './fullscreen-loading/fullscreen-loading.component';
 import { FullscreenLoadingService } from './fullscreen-loading/fullscreen-loading.service';
 import { EncodeUriComponentPipe } from './utils/encode-uri-component.pipe';
-import { RouterModule, Routes, UrlSerializer } from '@angular/router';
+import { Router, RouterModule, Routes, UrlSerializer } from '@angular/router';
 import { PersonFiltersComponent } from './person-filters/person-filters.component';
 import { PersonFiltersState } from './person-filters/person-filters.state';
 import { FamilyFiltersBlockComponent } from './family-filters-block/family-filters-block.component';
@@ -175,6 +175,7 @@ import { BackgroundColorEnrichmentPipe } from './utils/background-color-enrichme
 import { ContrastAdjustPipe } from './utils/contrast-adjust.pipe';
 import { ItemAddMenuComponent } from './item-add-menu/item-add-menu.component';
 import { ConfirmButtonComponent } from './confirm-button/confirm-button.component';
+import * as Sentry from '@sentry/angular-ivy';
 
 const appRoutes: Routes = [
   {
@@ -438,7 +439,23 @@ const appRoutes: Routes = [
     {
       provide: UrlSerializer,
       useClass: CustomUrlSerializer
-    }
+    },
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler({
+        showDialog: false,
+      }),
+    },
+    {
+      provide: Sentry.TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [Sentry.TraceService],
+      multi: true,
+    },
   ],
 
   bootstrap: [AppComponent]

--- a/src/environments/environment.conda.ts
+++ b/src/environments/environment.conda.ts
@@ -5,5 +5,6 @@ export const environment = {
   basePath: '',
   apiPath: basePath + 'api/v3/',
   imgPathPrefix: basePath + 'static/gpfjs/gpfjs/assets/',
+  sentryTunnel: '',
   oauthClientId: 'gpfjs'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,5 +5,6 @@ export const environment = {
   basePath: basePath,
   apiPath: basePath + 'api/v3/',
   imgPathPrefix: 'assets/',
+  sentryTunnel: 'sentry/',
   oauthClientId: 'gpfjs'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,5 +9,6 @@ export const environment = {
   basePath: basePath,
   apiPath: basePath + '/api/v3/',
   imgPathPrefix: 'assets/',
+  sentryTunnel: '',
   oauthClientId: 'gpfjs'
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,17 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import * as Sentry from '@sentry/angular-ivy';
 
+Sentry.init({
+  dsn: 'https://0@0.ingest.sentry.io/0', // wdae/sentry/views.py
+  tunnel: 'http://localhost:8000/api/v3/sentry/',
+  tracesSampleRate: 1.0,
+});
 
 if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+platformBrowserDynamic().bootstrapModule(AppModule).catch(err => console.log(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,14 +4,14 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 import * as Sentry from '@sentry/angular-ivy';
 
-Sentry.init({
-  dsn: 'https://0@0.ingest.sentry.io/0', // wdae/sentry/views.py
-  tunnel: 'http://localhost:8000/api/v3/sentry/',
-  tracesSampleRate: 1.0,
-});
-
 if (environment.production) {
   enableProdMode();
+
+  Sentry.init({
+    dsn: 'https://0@0.ingest.sentry.io/0', // wdae/sentry/views.py
+    tunnel: environment.apiPath + environment.sentryTunnel,
+    tracesSampleRate: 1.0,
+  });
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule).catch(err => console.log(err));


### PR DESCRIPTION
## Background and implementation

We wish to use Sentry to aggregate and report errors, but without revealing our DSN. To this end, we tunnel our Sentry requests through to our backend using a dummy DSN, which is substituted on the backend with our real DSN and re-sent towards Sentry.