### PR TITLE
Filter state restore now handles different types accordingly #801

### DIFF
--- a/src/app/multi-continuous-filter/multi-continuous-filter.component.ts
+++ b/src/app/multi-continuous-filter/multi-continuous-filter.component.ts
@@ -39,14 +39,16 @@ export class MultiContinuousFilterComponent extends StatefulComponent implements
     }
     const filters = state['personFiltersState'][this.isFamilyFilter ? 'familyFilters' : 'personFilters'];
     filters.forEach(async(filter) => {
-      const selection = {
-        name: filter.source,
-        min: filter['selection']['min'],
-        max: filter['selection']['max']
-      };
-      this.selectedMeasure = selection;
-      await this.waitForSelectorComponent();
-      this.measureSelectorComponent.selectMeasure(this.selectedMeasure);
+      if (filter['sourceType'] === 'continuous') {
+        const selection = {
+          name: filter.source,
+          min: filter['selection']['min'],
+          max: filter['selection']['max']
+        };
+        this.selectedMeasure = selection;
+        await this.waitForSelectorComponent();
+        this.measureSelectorComponent.selectMeasure(this.selectedMeasure);
+      }
     });
   }
 


### PR DESCRIPTION
## Background

Person filter states are wrong when a query is loaded with at least one categorical and one continuous filter.

## Aim

The aim is to remove the issue and maybe optimize the code(another issue should be created because the code is very old and unoptimized for - person filters component).


## Implementation

Additional checks are performed in order to deliver more accurate data to the other front-end services.
