### PR TITLE
Optimize loading spinner variant count calls #681

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -220,7 +220,7 @@
           <gpf-loading-spinner
             *ngIf="selectedGene"
             [loadingFinished]="familyLoadingFinished"
-            [count]="genotypePreviewVariantsArray?.getVariantsCount(maxFamilyVariants)">
+            [count]="variantsCountDisplay">
           </gpf-loading-spinner>
         </div>
       </div>

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -70,7 +70,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     private loadingService: FullscreenLoadingService,
   ) { }
 
-  private variantsCount: number;
   public variantsCountDisplay: string;
 
   public ngOnInit(): void {
@@ -181,6 +180,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     );
 
     this.showResults = false;
+    this.variantsCountDisplay = 'Loading variants...';
     this.loadingService.setLoadingStart();
     this.genotypePreviewVariantsArray = null;
 
@@ -333,8 +333,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
 
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
       this.selectedDataset, requestParams, this.maxFamilyVariants, () => {
-        this.variantsCount += 1;
-        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.variantsCount);
+        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.maxFamilyVariants);
       }
     );
   }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -70,6 +70,9 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     private loadingService: FullscreenLoadingService,
   ) { }
 
+  private variantsCount: number;
+  public variantsCountDisplay: string;
+
   public ngOnInit(): void {
     this.selectedDataset = this.datasetsService.getSelectedDataset();
     this.legend = this.selectedDataset.personSetCollections.getLegend(this.selectedDataset.defaultPersonSetCollection);
@@ -329,7 +332,10 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     };
 
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
-      this.selectedDataset, requestParams
+      this.selectedDataset, requestParams, this.maxFamilyVariants, () => {
+        this.variantsCount += 1;
+        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.variantsCount);
+      }
     );
   }
 

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -44,8 +44,9 @@
 <div class="genotype-browser-results" *ngIf="genotypePreviewVariantsArray">
   <hr />
   <gpf-loading-spinner
+    *ngIf="variantsCountDisplay"
     [loadingFinished]="loadingFinished"
-    [count]="genotypePreviewVariantsArray.getVariantsCount(selectedDataset?.genotypeBrowserConfig?.maxVariantsCount)"
+    [count]="variantsCountDisplay"
     [verboseMode]="true">
   </gpf-loading-spinner>
 

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -37,7 +37,6 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public genotypeBrowserState: object;
   public loadingFinished: boolean;
 
-  private variantsCount: number;
   public variantsCountDisplay: string;
 
   @Select(GenotypeBrowserComponent.genotypeBrowserStateSelector) private state$: Observable<any[]>;
@@ -115,7 +114,6 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public submitQuery(): void {
     this.loadingFinished = false;
     this.showTable = false;
-    this.variantsCount = 0;
     this.variantsCountDisplay = 'Loading variants...';
     this.loadingService.setLoadingStart();
 
@@ -134,12 +132,12 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
     });
 
     this.patchState();
-    this.variantsCount = 0;
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
       this.selectedDataset, this.genotypeBrowserState,
       this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount, () => {
-        this.variantsCount += 1;
-        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.variantsCount);
+        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(
+          this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount
+        );
       }
     );
   }

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -37,6 +37,9 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public genotypeBrowserState: object;
   public loadingFinished: boolean;
 
+  private variantsCount: number;
+  public variantsCountDisplay: string;
+
   @Select(GenotypeBrowserComponent.genotypeBrowserStateSelector) private state$: Observable<any[]>;
   @Select(ErrorsState) private errorsState$: Observable<ErrorsModel>;
 
@@ -112,6 +115,8 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public submitQuery(): void {
     this.loadingFinished = false;
     this.showTable = false;
+    this.variantsCount = 0;
+    this.variantsCountDisplay = 'Loading variants...';
     this.loadingService.setLoadingStart();
 
     this.genotypePreviewVariantsArray = null;
@@ -129,8 +134,13 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
     });
 
     this.patchState();
+    this.variantsCount = 0;
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
-      this.selectedDataset, this.genotypeBrowserState
+      this.selectedDataset, this.genotypeBrowserState,
+      this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount, () => {
+        this.variantsCount += 1;
+        this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.variantsCount);
+      }
     );
   }
 

--- a/src/app/query/query.service.ts
+++ b/src/app/query/query.service.ts
@@ -117,7 +117,8 @@ export class QueryService {
   }
 
   public getGenotypePreviewVariantsByFilter(
-    dataset: Dataset, filter, maxVariantsCount: number = 1001
+    dataset: Dataset, filter, maxVariantsCount: number = 1001,
+    callback?: () => void,
   ): GenotypePreviewVariantsArray {
     const genotypePreviewVariantsArray = new GenotypePreviewVariantsArray();
     const queryFilter = { ...filter };
@@ -128,6 +129,10 @@ export class QueryService {
         <Array<string>> variant,
         dataset.genotypeBrowserConfig.columnIds
       );
+
+      if (callback !== undefined) {
+        callback();
+      }
 
       if (variant) {
         // Attach the genome version to each variant


### PR DESCRIPTION
## Background

The current code in the GPFJS repository contains numerous tedious template calls. This pull request aims to optimize the variant count by reducing the frequency of these calls. Previously, the variants count was called on every change detection cycle. With this change, the variants count will only be called when necessary, specifically when the call to fill the variants is made. Additionally, a new feature has been added to enhance the user experience. When a request is made, the UI will display "Loading variants..." instead of the previous behavior, which showed "0 variants selected" until the first variant arrived.

## Aim

The aim of this PR is to improve the performance of the GPFJS repository by reducing the frequency of template calls and enhancing the user experience during variant loading. By optimizing the variant count and displaying the loading status, we aim to provide a smoother and more efficient experience for users.

## Implementation

In this PR, the frequency of template calls for variant count has been optimized. Previously, these calls were made on every change detection cycle, but now they are triggered only when the request to fill the variants is made. This change improves performance by reducing unnecessary calls.
