### PR TITLE
Refactor gene browser requests logic

### DIFF
--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -60,8 +60,8 @@ class MockQueryService {
     return of([] as any);
   }
 
-  public getSummaryVariants(): SummaryAllelesArray {
-    return new SummaryAllelesArray();
+  public getSummaryVariants(): Observable<Object> {
+    return of([]);
   }
 
   public downloadVariants(filter: object): Observable<HttpResponse<Blob>> {

--- a/src/app/query/query.service.ts
+++ b/src/app/query/query.service.ts
@@ -4,19 +4,18 @@ import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 // eslint-disable-next-line no-restricted-imports
 import { Observable, Subject } from 'rxjs';
-const oboe = require('oboe');
 import { environment } from 'environments/environment';
 import { ConfigService } from '../config/config.service';
 import { GenotypePreviewVariantsArray } from '../genotype-preview-model/genotype-preview';
-import { SummaryAllelesArray } from '../gene-browser/summary-variants';
 import { map } from 'rxjs/operators';
 import { Dataset } from 'app/datasets/datasets';
 import { AuthService } from 'app/auth.service';
+const oboe = require('oboe');
 
 @Injectable()
 export class QueryService {
   private readonly genotypePreviewVariantsUrl = 'genotype_browser/query';
-  private readonly geneViewVariants = 'gene_view/query_summary_variants';
+  private readonly geneViewVariantsUrl = 'gene_view/query_summary_variants';
   private readonly saveQueryEndpoint = 'query_state/save';
   private readonly loadQueryEndpoint = 'query_state/load';
   private readonly deleteQueryEndpoint = 'query_state/delete';
@@ -28,7 +27,7 @@ export class QueryService {
   private oboeInstance = null;
   private summaryOboeInstance = null;
   public streamingSubject = new Subject();
-  public summaryStreamingSubject = new Subject();
+  public summaryStreamingSubject = new Subject<object>();
   public streamingFinishedSubject = new Subject();
   public summaryStreamingFinishedSubject = new Subject();
 
@@ -84,7 +83,7 @@ export class QueryService {
     }
   }
 
-  public summaryStreamPost(url: string, filter): Subject<unknown> {
+  public summaryStreamPost(url: string, filter): Subject<object> {
     if (this.summaryOboeInstance) {
       this.summaryOboeInstance.abort();
       this.summaryOboeInstance = null;
@@ -146,12 +145,8 @@ export class QueryService {
     return genotypePreviewVariantsArray;
   }
 
-  public getSummaryVariants(filter): SummaryAllelesArray {
-    const summaryVariantsArray = new SummaryAllelesArray();
-    this.summaryStreamPost(this.geneViewVariants, filter).subscribe((variant: string[]) => {
-      summaryVariantsArray.addSummaryRow(variant);
-    });
-    return summaryVariantsArray;
+  public getSummaryVariants(filter: object): Observable<object> {
+    return this.http.post(this.config.baseUrl + this.geneViewVariantsUrl, filter);
   }
 
   public saveQuery(queryData: {}, page: string): Observable<object> {


### PR DESCRIPTION
Gene browser requests logic was over-complicated and incorrect due to the requirement of having the summary variants be streaming, which introduced desync between the summary and the family variants. The requirement of summary variants to be streaming was dropped, allowing the logic for requests to be fixed and cleaned up.