### PR TITLE
Minor change to follow the old visualization when the variants count is beyond it's set default value

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -320,7 +320,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       uniqueFamilyVariants: this.uniqueFamilyVariants,
     };
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
-      this.selectedDataset, params, this.maxFamilyVariants, () => {
+      this.selectedDataset, params, this.maxFamilyVariants + 1, () => {
         this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(this.maxFamilyVariants);
       }
     );

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -133,8 +133,12 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
 
     this.patchState();
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
-      this.selectedDataset, this.genotypeBrowserState,
-      this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount, () => {
+      this.selectedDataset,
+      this.genotypeBrowserState,
+      this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount !== undefined
+        ? this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount + 1
+        : undefined,
+      () => {
         this.variantsCountDisplay = this.genotypePreviewVariantsArray.getVariantsCount(
           this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount
         );


### PR DESCRIPTION
## Background

The variant counts displayed in the genotype browser are meant to inform the user how many variants match their filter criteria and how many are shown in the table. However, there is a bug that causes the variant counts to stay at “1000 variants selected” even when the user selects more than 1000 variants. This is misleading and inconsistent with the expected behavior.

## Aim

The aim is to fix the bug and display the correct variant counts in the genotype browser. The expected behavior is to show “more than 1000 variants selected (1000 variants shown)” when the user filters data that contains more than 1000 variants, and to show the exact number of variants selected and shown when it is less than or equal to 1000 without excessive function calls.