### PR TITLE
Families by pedigree tags

### DIFF
--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -161,6 +161,7 @@ h5 {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: 15px;
 }
 
 #open-modal-button {
@@ -169,6 +170,15 @@ h5 {
   border-radius: 0.375rem;
   padding: 6px 12px;
   flex-shrink: 0;
+}
+
+::ng-deep .modal-dialog-centered {
+  justify-content: center;
+}
+
+::ng-deep .modal-content {
+  width: fit-content;
+  overflow: auto;
 }
 
 #selected-tags-list {
@@ -193,104 +203,16 @@ h5 {
 
 #uncheck-button {
   white-space: nowrap;
+  color: #2a6395;
+}
+
+#uncheck-button:hover {
+  cursor: pointer;
+  color: #163d5f;
 }
 
 #tag-label {
   margin-left: 5px;
-}
-
-#nothing-found {
-  height: 43px;
-  line-height: 43px;
-  font-style: italic;
-  padding-left: 12px;
-  opacity: 75%;
-  font-weight: normal;
-}
-
-/* stylelint-disable-next-line selector-class-pattern */
-:host::ng-deep.dropdown-multiselect__caret {
-  display: none !important;
-}
-
-:host::ng-deep.selected-item {
-  color: black !important;
-  background-color: #eee !important;
-  border: 1px solid #ddd !important;
-  box-shadow: none !important;
-  max-width: unset !important;
-  margin: 2px !important;
-  text-align: center;
-  width: 200px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  height: 28px;
-  display: flex;
-}
-
-:host::ng-deep.selected-item a {
-  color: black !important;
-  opacity: 50% !important;
-  float: right;
-}
-
-:host::ng-deep.dropdown-btn {
-  min-height: 44px !important;
-  padding: 5px 12px !important;
-  display: flex !important;
-  flex-wrap: wrap !important;
-  align-content: center !important;
-  border: 1px solid #ced4da !important;
-  width: 447px !important;
-}
-
-:host::ng-deep.multiselect-item-checkbox div::before {
-  border: 1px solid black !important;
-  animation: none !important;
-  transition: none !important;
-}
-
-:host::ng-deep.item1 {
-  border-top: 1px solid #ccc !important;
-}
-
-:host::ng-deep.dropdown-list {
-  display: flex;
-  flex-direction: column-reverse !important;
-  top: -211px !important;
-  box-shadow: none !important;
-  border-bottom: 0 !important;
-  width: 447px !important;
-  height: 198px;
-}
-
-:host::ng-deep.item1 .multiselect-item-checkbox {
-  display: none;
-}
-
-:host::ng-deep input[aria-label="multiselect-search"] {
-  padding: 0 !important;
-}
-
-:host::ng-deep.filter-textbox {
-  padding: 7px 10px !important;
-}
-
-:host::ng-deep.no-filtered-data h5 {
-  visibility: hidden;
-  margin-bottom: 0;
-}
-
-:host::ng-deep.no-filtered-data h5::after {
-  content: "Nothing found";
-  visibility: visible;
-  font-size: 16px;
-  font-weight: normal;
-  font-style: italic;
-  opacity: 75%;
-  float: left;
-  margin-bottom: 0;
 }
 
 .download-link {
@@ -303,16 +225,11 @@ h5 {
   justify-content: center;
 }
 
-#tags-dropdown-wrapper {
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-#tags-dropdown-wrapper .select-dropdown-icon {
-  position: absolute;
-  right: 10px;
-  transform: rotate(180deg);
-  pointer-events: none;
+#nothing-found {
+  height: 43px;
+  line-height: 43px;
+  font-style: italic;
+  padding-left: 12px;
+  opacity: 75%;
+  font-weight: normal;
 }

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -128,14 +128,14 @@ table {
   margin-right: -10px;
 }
 
-#total-number-of-families {
-  position: absolute;
-  right: 0;
-  padding: 16px;
+#download-total-families {
+  float: right;
+  margin-bottom: 10px;
 }
 
 #families-by-number {
   padding-bottom: 55px;
+  margin-top: 10px;
 }
 
 #families-by-pedigree {
@@ -198,6 +198,10 @@ h5 {
   column-gap: 20px;
   align-items: baseline;
   margin-bottom: 10px;
+}
+
+.search-input {
+  padding-right: 5px;
 }
 
 #uncheck-button {

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -139,7 +139,7 @@ table {
 }
 
 #families-by-pedigree {
-  padding-bottom: 102px;
+  padding-bottom: 20px;
 }
 
 h5 {
@@ -150,17 +150,6 @@ h5 {
   padding-bottom: 16px;
 }
 
-ng-multiselect-dropdown > span.selected-item {
-  display: block;
-  padding: 3px 26px 3px 5px;
-  width: auto;
-  border: 0;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  max-width: 100%;
-}
-
 #tags-selector {
   padding-bottom: 16px;
   display: flex;
@@ -168,11 +157,50 @@ ng-multiselect-dropdown > span.selected-item {
   align-items: center;
 }
 
-#nothing-found {
-  height: 43px;
+#pedigree-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
 }
 
-#nothing-found span {
+#open-modal-button {
+  background-color: #eee;
+  border: 1px solid #ddd;
+  border-radius: 0.375rem;
+  padding: 6px 12px;
+  flex-shrink: 0;
+}
+
+#selected-tags-list {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#tags-modal-content {
+  padding: 20px;
+  height: fit-content;
+  width: fit-content;
+}
+
+#tags-modal-header {
+  display: flex;
+  column-gap: 20px;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+#uncheck-button {
+  white-space: nowrap;
+}
+
+#tag-label {
+  margin-left: 5px;
+}
+
+#nothing-found {
+  height: 43px;
   line-height: 43px;
   font-style: italic;
   padding-left: 12px;

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -178,7 +178,6 @@ h5 {
 
 ::ng-deep .modal-content {
   width: fit-content;
-  overflow: auto;
 }
 
 #selected-tags-list {

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -93,7 +93,7 @@
 
       <div id="pedigree-toolbar">
         <button (click)="openModal()" id="open-modal-button">Select tags</button>
-        <span [hidden]="!selectedTagsHeader" id="selected-tags-list" [title]="selectedTagsHeader">{{
+        <span *ngIf="!selectedTagsHeader" id="selected-tags-list" [title]="selectedTagsHeader">{{
           selectedTagsHeader
         }}</span>
         <button

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -89,18 +89,10 @@
           <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"></span>
         </div>
       </div>
-      <div *ngIf="dropdownList.length !== 0 && currentPedigreeTable" id="tags-selector">
-        <div id="tags-dropdown-wrapper">
-          <ng-multiselect-dropdown
-            [placeholder]="'Select tags'"
-            [settings]="dropdownSettings"
-            [data]="dropdownList"
-            [(ngModel)]="selectedItems"
-            (onSelect)="updateTagFilters()"
-            (onDeSelect)="updateTagFilters()">
-          </ng-multiselect-dropdown>
-          <span class="select-dropdown-icon" [style.content]="'url(' + imgPathPrefix + 'dropdown_icon.png)'"></span>
-        </div>
+
+      <div id="pedigree-toolbar">
+        <button (click)="openModal()">Select tags</button>
+        <span [hidden]="!selectedTagsHeader" id="selectedTagsList">{{ selectedTagsHeader }}</span>
         <button
           [disabled]="currentPedigreeTable.pedigrees.length === 0"
           id="download-button"
@@ -109,30 +101,49 @@
           >Download</button
         >
       </div>
-
-      <div *ngIf="currentPedigreeTable" id="families-by-pedigree-div" class="row">
-        <div class="col-12">
-          <table class="gpf-basic-table">
-            <colgroup *ngIf="currentPedigreeTable.pedigrees.length !== 0">
-              <col />
-              <col />
-              <col />
-              <col />
-            </colgroup>
-            <tbody *ngIf="currentPedigreeTable.pedigrees.length !== 0">
-              <ng-template ngFor let-pedigreeGroup [ngForOf]="currentPedigreeTable.pedigrees">
-                <tr gpf-common-reports-row [pedigreeGroup]="pedigreeGroup"></tr>
-              </ng-template>
-            </tbody>
-            <th *ngIf="currentPedigreeTable.pedigrees.length === 0" id="nothing-found" class="table-row table-body-row">
-              <span>Nothing found</span>
-            </th>
-          </table>
+      <ng-template #tagsModal id="tags-modal">
+        <div id="modal-content">
+          <input
+            #searchTag
+            (search)="search(searchTag.value)"
+            (keyup)="search(searchTag.value)"
+            id="search-tags"
+            class="search-input form-control my-0 py-1"
+            type="search"
+            [ngModel]="searchTagText"
+            placeholder="Search tags"
+            autocomplete="off" />
+          <span *ngIf="!modalTagsList.length" id="nothing-found">Nothing found</span>
+          <div *ngFor="let tag of modalTagsList" id="tags">
+            <input type="checkbox" [checked]="selectedItems.includes(tag)" (change)="selectedTags(tag)" />
+            <span>{{ tag }}</span>
+          </div>
         </div>
+      </ng-template>
+    </div>
+
+    <div *ngIf="currentPedigreeTable" id="families-by-pedigree-div" class="row">
+      <div class="col-12">
+        <table class="gpf-basic-table">
+          <colgroup *ngIf="currentPedigreeTable.pedigrees.length !== 0">
+            <col />
+            <col />
+            <col />
+            <col />
+          </colgroup>
+          <tbody *ngIf="currentPedigreeTable.pedigrees.length !== 0">
+            <ng-template ngFor let-pedigreeGroup [ngForOf]="currentPedigreeTable.pedigrees">
+              <tr gpf-common-reports-row [pedigreeGroup]="pedigreeGroup"></tr>
+            </ng-template>
+          </tbody>
+          <th *ngIf="currentPedigreeTable.pedigrees.length === 0" id="nothing-found" class="table-row table-body-row">
+            <span>Nothing found</span>
+          </th>
+        </table>
       </div>
-      <div *ngIf="currentPedigreeTable" id="legend-wrapper">
-        <gpf-legend [legendItems]="currentPedigreeTable.legend.legendItems"></gpf-legend>
-      </div>
+    </div>
+    <div *ngIf="currentPedigreeTable" id="legend-wrapper">
+      <gpf-legend [legendItems]="currentPedigreeTable.legend.legendItems"></gpf-legend>
     </div>
   </ng-template>
 

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -103,7 +103,7 @@
           >Download</button
         >
       </div>
-      <ng-template #tagsModal id="tags-modal">
+      <ng-template #tagsModal class="tags-modal">
         <div id="tags-modal-content">
           <div id="tags-modal-header">
             <input
@@ -117,7 +117,7 @@
               autocomplete="off" />
             <a (click)="uncheckAll()" id="uncheck-button">Uncheck all</a>
           </div>
-          <span *ngIf="!modalTagsList.length" id="nothing-found">Nothing found</span>
+
           <div
             id="tag-list"
             [ngStyle]="{
@@ -126,13 +126,19 @@
               'grid-template-rows': 'repeat(' + tagsModalsNumberOfRows + ', 30px)',
               'column-gap': '16px'
             }">
-            <div *ngFor="let tag of modalTagsList">
+            <div *ngFor="let tag of orderedTagList">
               <input
+                [disabled]="!tag.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase())"
                 type="checkbox"
-                [attr.id]="tag + '-tag'"
+                [id]="tag + '-tag'"
                 [checked]="selectedItems.includes(tag)"
                 (change)="selectedTags(tag)" />
-              <label [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</label>
+              <label
+                [attr.for]="tag + '-tag'"
+                id="tag-label"
+                [ngStyle]="!tag.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) && { opacity: '30%' }"
+                >{{ tag }}</label
+              >
             </div>
           </div>
         </div>

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -7,14 +7,14 @@
       style="justify-content: flex-start; margin-bottom: 16px"
       [destroyOnHide]="false">
       <li ngbNavItem>
-        <a ngbNavLink>Families by number</a>
+        <a ngbNavLink (click)="isFamiliesByNumberVisible = true">Families by number</a>
         <ng-template ngbNavContent>
           <ng-container *ngTemplateOutlet="familiesByNumber"></ng-container>
         </ng-template>
       </li>
 
       <li ngbNavItem>
-        <a ngbNavLink>Families by pedigree</a>
+        <a ngbNavLink (click)="isFamiliesByNumberVisible = false">Families by pedigree</a>
         <ng-template ngbNavContent>
           <ng-container *ngTemplateOutlet="familiesByPedigree"></ng-container>
         </ng-template>
@@ -29,7 +29,7 @@
     </ul>
     <div [ngbNavOutlet]="nav" class="card-block"></div>
 
-    <h5 id="total-number-of-families">
+    <h5 *ngIf="isFamiliesByNumberVisible" id="total-number-of-families">
       <span>Total number of families: {{ variantReport.familyReport.familiesTotal }}</span>
       <span style="padding-left: 5px">(<a class="download-link" [href]="getDownloadLink()" download>Download</a>)</span>
     </h5>

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -91,8 +91,10 @@
       </div>
 
       <div id="pedigree-toolbar">
-        <button (click)="openModal()">Select tags</button>
-        <span [hidden]="!selectedTagsHeader" id="selectedTagsList">{{ selectedTagsHeader }}</span>
+        <button (click)="openModal()" id="open-modal-button">Select tags</button>
+        <span [hidden]="!selectedTagsHeader" id="selected-tags-list" [title]="selectedTagsHeader">{{
+          selectedTagsHeader
+        }}</span>
         <button
           [disabled]="currentPedigreeTable.pedigrees.length === 0"
           id="download-button"
@@ -102,21 +104,36 @@
         >
       </div>
       <ng-template #tagsModal id="tags-modal">
-        <div id="modal-content">
-          <input
-            #searchTag
-            (search)="search(searchTag.value)"
-            (keyup)="search(searchTag.value)"
-            id="search-tags"
-            class="search-input form-control my-0 py-1"
-            type="search"
-            [ngModel]="searchTagText"
-            placeholder="Search tags"
-            autocomplete="off" />
+        <div id="tags-modal-content">
+          <div id="tags-modal-header">
+            <input
+              #searchTag
+              (search)="search(searchTag.value)"
+              (keyup)="search(searchTag.value)"
+              id="search-tags"
+              class="search-input form-control my-0 py-1"
+              type="search"
+              placeholder="Search tags"
+              autocomplete="off" />
+            <a (click)="uncheckAll()" id="uncheck-button">Uncheck all</a>
+          </div>
           <span *ngIf="!modalTagsList.length" id="nothing-found">Nothing found</span>
-          <div *ngFor="let tag of modalTagsList" id="tags">
-            <input type="checkbox" [checked]="selectedItems.includes(tag)" (change)="selectedTags(tag)" />
-            <span>{{ tag }}</span>
+          <div
+            id="tag-list"
+            [ngStyle]="{
+              display: 'grid',
+              'grid-template-columns': 'repeat(' + tagsModalsNumberOfCols + ', max-content)',
+              'grid-template-rows': 'repeat(' + tagsModalsNumberOfRows + ', 30px)',
+              'column-gap': '16px'
+            }">
+            <div *ngFor="let tag of modalTagsList">
+              <input
+                type="checkbox"
+                [attr.id]="tag + '-tag'"
+                [checked]="selectedItems.includes(tag)"
+                (change)="selectedTags(tag)" />
+              <label [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</label>
+            </div>
           </div>
         </div>
       </ng-template>

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -4,17 +4,17 @@
       ngbNav
       #nav="ngbNav"
       class="navbar bg-light nav-pills nav"
-      style="justify-content: flex-start; margin-bottom: 16px"
+      style="justify-content: flex-start; margin-bottom: 10px"
       [destroyOnHide]="false">
       <li ngbNavItem>
-        <a ngbNavLink (click)="isFamiliesByNumberVisible = true">Families by number</a>
+        <a ngbNavLink>Families by number</a>
         <ng-template ngbNavContent>
           <ng-container *ngTemplateOutlet="familiesByNumber"></ng-container>
         </ng-template>
       </li>
 
       <li ngbNavItem>
-        <a ngbNavLink (click)="isFamiliesByNumberVisible = false">Families by pedigree</a>
+        <a ngbNavLink>Families by pedigree</a>
         <ng-template ngbNavContent>
           <ng-container *ngTemplateOutlet="familiesByPedigree"></ng-container>
         </ng-template>
@@ -28,14 +28,15 @@
       </li>
     </ul>
     <div [ngbNavOutlet]="nav" class="card-block"></div>
-
-    <h5 *ngIf="isFamiliesByNumberVisible" id="total-number-of-families">
-      <span>Total number of families: {{ variantReport.familyReport.familiesTotal }}</span>
-      <span style="padding-left: 5px">(<a class="download-link" [href]="getDownloadLink()" download>Download</a>)</span>
-    </h5>
   </div>
 
   <ng-template #familiesByNumber>
+    <div id="download-total-families">
+      <a class="download-link" [href]="getDownloadLink()" download
+        >Download all families ({{ variantReport.familyReport.familiesTotal }})</a
+      >
+    </div>
+    <br />
     <div id="families-by-number">
       <div *ngIf="variantReport.peopleReport.peopleCounters.length > 1" class="variants-report-selector">
         <div class="select-wrapper">

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -132,7 +132,7 @@
                 type="checkbox"
                 [id]="tag + '-tag'"
                 [checked]="selectedItems.includes(tag)"
-                (change)="selectedTags(tag)" />
+                (change)="updateSelectedTags(tag)" />
               <label
                 [attr.for]="tag + '-tag'"
                 id="tag-label"

--- a/src/app/variant-reports/variant-reports.component.spec.ts
+++ b/src/app/variant-reports/variant-reports.component.spec.ts
@@ -347,12 +347,12 @@ describe('VariantReportsComponent', () => {
 
     component.updateSelectedTags('tag6');
     expect(component.selectedItems).toStrictEqual(['tag1', 'tag2', 'tag3', 'tag4', 'tag5', 'tag6']);
-    expect(component.selectedTagsHeader).toBe('tag1,tag2,tag3,tag4,tag5,tag6');
+    expect(component.selectedTagsHeader).toBe('tag1, tag2, tag3, tag4, tag5, tag6');
     expect(updatePedigreesTable).toHaveBeenCalledWith();
 
     component.updateSelectedTags('tag3');
     expect(component.selectedItems).toStrictEqual(['tag1', 'tag2', 'tag4', 'tag5', 'tag6']);
-    expect(component.selectedTagsHeader).toBe('tag1,tag2,tag4,tag5,tag6');
+    expect(component.selectedTagsHeader).toBe('tag1, tag2, tag4, tag5, tag6');
     expect(updatePedigreesTable).toHaveBeenCalledWith();
   });
 
@@ -395,7 +395,7 @@ describe('VariantReportsComponent', () => {
     const updatePedigreesTable = jest.spyOn(component, 'updateTagFilters')
       .mockImplementation(() => null);
     component.selectedItems = ['tag1', 'tag2', 'tag3'];
-    component.selectedTagsHeader = 'tag1,tag2,tag3';
+    component.selectedTagsHeader = 'tag1, tag2, tag3';
     component.uncheckAll();
 
     expect(component.selectedItems).toHaveLength(0);

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -107,7 +107,7 @@ export class VariantReportsComponent implements OnInit {
     );
   }
 
-  public selectedTags(tag: string): void {
+  public updateSelectedTags(tag: string): void {
     if (!this.selectedItems.includes(tag)) {
       this.selectedItems.push(tag);
     } else {
@@ -138,7 +138,7 @@ export class VariantReportsComponent implements OnInit {
     this.searchValue = searchValue.trim();
     this.orderedTagList = [
       ...new Set(
-        this.tags.filter(el => el.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()))
+        this.tags.filter(el => el.toLocaleLowerCase().includes(this.searchValue.toLocaleLowerCase()))
           .concat(this.tags)
       )
     ];

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -129,7 +129,7 @@ export class VariantReportsComponent implements OnInit {
 
   public search(searchValue: string): void {
     if (searchValue!==' ') {
-      this.modalTagsList = this.tags.filter(el => el.includes(searchValue));
+      this.modalTagsList = this.tags.filter(el => el.includes(searchValue.toLocaleLowerCase()));
     }
   }
 

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -30,7 +30,6 @@ export class VariantReportsComponent implements OnInit {
   public currentPeopleCounter: PeopleCounter;
   public currentPedigreeTable: PedigreeTable;
   public currentDenovoReport: EffectTypeTable;
-  public isFamiliesByNumberVisible = false;
   public selectedTagsHeader = '';
 
   public modal: NgbModalRef;
@@ -96,7 +95,6 @@ export class VariantReportsComponent implements OnInit {
         this.tagsModalsNumberOfRows = Math.ceil(this.tags.length / this.tagsModalsNumberOfCols);
       });
     }
-    this.isFamiliesByNumberVisible = true;
   }
 
   private copyOriginalPedigreeCounters(): Record<string, PedigreeCounter[]> {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -113,7 +113,7 @@ export class VariantReportsComponent implements OnInit {
       this.selectedItems.splice(index, 1);
     }
     if (this.selectedItems.length > 0) {
-      this.selectedTagsHeader = this.selectedItems.join(',');
+      this.selectedTagsHeader = this.selectedItems.join(', ');
     } else {
       this.selectedTagsHeader = '';
     }
@@ -136,8 +136,7 @@ export class VariantReportsComponent implements OnInit {
     this.searchValue = searchValue.trim();
     this.orderedTagList = [
       ...new Set(
-        this.tags.filter(el => el.toLocaleLowerCase().includes(this.searchValue.toLocaleLowerCase()))
-          .concat(this.tags)
+        this.tags.filter(el => el.toLocaleLowerCase().includes(this.searchValue.toLocaleLowerCase())).concat(this.tags)
       )
     ];
   }

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -37,6 +37,7 @@ export class VariantReportsComponent implements OnInit {
   @ViewChild('tagsModal') public tagsModal: ElementRef;
 
   @ViewChild('searchTag') private searchTag: ElementRef;
+  public searchValue = '';
 
   public tagsModalsNumberOfRows = 9;
   public tagsModalsNumberOfCols = 2;
@@ -48,7 +49,7 @@ export class VariantReportsComponent implements OnInit {
   public selectedDataset: Dataset;
 
   public imgPathPrefix = environment.imgPathPrefix;
-  public modalTagsList = [];
+  public orderedTagList = [];
   public selectedItems: string[] = [];
 
   public denovoVariantsTableWidth: number;
@@ -88,17 +89,7 @@ export class VariantReportsComponent implements OnInit {
       this.variantReportsService.getTags().subscribe(data => {
         Object.values(data).forEach((tag: string) => {
           this.tags.push(tag);
-          this.tags.push(tag);
-          this.tags.push(tag);
-          this.modalTagsList.push(tag);
-          this.modalTagsList.push(tag);
-          this.modalTagsList.push(tag);
-          this.tags.push(tag);
-          this.tags.push(tag);
-          this.tags.push(tag);
-          this.modalTagsList.push(tag);
-          this.modalTagsList.push(tag);
-          this.modalTagsList.push(tag);
+          this.orderedTagList.push(tag);
         });
         // Calculate square looking grid for the tags (1 column width === ~5 tags height)
         this.tagsModalsNumberOfCols = Math.ceil(Math.sqrt(Math.ceil(this.tags.length / 5)));
@@ -132,7 +123,8 @@ export class VariantReportsComponent implements OnInit {
   }
 
   public openModal(): void {
-    this.modalTagsList = this.tags;
+    this.orderedTagList = this.tags;
+    this.searchValue = '';
     if (this.modalService.hasOpenModals()) {
       return;
     }
@@ -143,8 +135,13 @@ export class VariantReportsComponent implements OnInit {
   }
 
   public search(searchValue: string): void {
-    searchValue = searchValue.trim();
-    this.modalTagsList = this.tags.filter(el => el.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()));
+    this.searchValue = searchValue.trim();
+    this.orderedTagList = [
+      ...new Set(
+        this.tags.filter(el => el.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()))
+          .concat(this.tags)
+      )
+    ];
   }
 
   public uncheckAll(): void {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener, Pipe, PipeTransform, Input, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, HostListener, Pipe, PipeTransform, ViewChild, ElementRef } from '@angular/core';
 import { VariantReportsService } from './variant-reports.service';
 import {
   VariantReport, FamilyCounter, PedigreeCounter, EffectTypeTable, DeNovoData, PedigreeTable, PeopleCounter
@@ -30,14 +30,16 @@ export class VariantReportsComponent implements OnInit {
   public currentPeopleCounter: PeopleCounter;
   public currentPedigreeTable: PedigreeTable;
   public currentDenovoReport: EffectTypeTable;
-  @Input() public isFamiliesByNumberVisible = false;
-  @Input() public selectedTagsHeader = '';
+  public isFamiliesByNumberVisible = false;
+  public selectedTagsHeader = '';
 
   public modal: NgbModalRef;
   @ViewChild('tagsModal') public tagsModal: ElementRef;
 
   @ViewChild('searchTag') private searchTag: ElementRef;
-  @Input() public searchTagText = '';
+
+  public tagsModalsNumberOfRows = 9;
+  public tagsModalsNumberOfCols = 2;
 
   public variantReport: VariantReport;
   public familiesCounters: FamilyCounter[];
@@ -47,7 +49,7 @@ export class VariantReportsComponent implements OnInit {
 
   public imgPathPrefix = environment.imgPathPrefix;
   public modalTagsList = [];
-  public selectedItems: Array<string> = new Array<string>();
+  public selectedItems: string[] = [];
 
   public denovoVariantsTableWidth: number;
   private denovoVariantsTableColumnWidth = 140;
@@ -86,8 +88,21 @@ export class VariantReportsComponent implements OnInit {
       this.variantReportsService.getTags().subscribe(data => {
         Object.values(data).forEach((tag: string) => {
           this.tags.push(tag);
+          this.tags.push(tag);
+          this.tags.push(tag);
+          this.modalTagsList.push(tag);
+          this.modalTagsList.push(tag);
+          this.modalTagsList.push(tag);
+          this.tags.push(tag);
+          this.tags.push(tag);
+          this.tags.push(tag);
+          this.modalTagsList.push(tag);
+          this.modalTagsList.push(tag);
           this.modalTagsList.push(tag);
         });
+        // Calculate square looking grid for the tags (1 column width === ~5 tags height)
+        this.tagsModalsNumberOfCols = Math.ceil(Math.sqrt(Math.ceil(this.tags.length / 5)));
+        this.tagsModalsNumberOfRows = Math.ceil(this.tags.length / this.tagsModalsNumberOfCols);
       });
     }
     this.isFamiliesByNumberVisible = true;
@@ -109,7 +124,7 @@ export class VariantReportsComponent implements OnInit {
       this.selectedItems.splice(index, 1);
     }
     if (this.selectedItems.length > 0) {
-      this.selectedTagsHeader = 'Selected tags: ' + this.selectedItems.join(',');
+      this.selectedTagsHeader = this.selectedItems.join(',');
     } else {
       this.selectedTagsHeader = '';
     }
@@ -123,14 +138,19 @@ export class VariantReportsComponent implements OnInit {
     }
     this.modal = this.modalService.open(
       this.tagsModal,
-      {animation: false, centered: true, size: 'lg', windowClass: 'tags-modal'}
+      {animation: false, centered: true, windowClass: 'tags-modal'}
     );
   }
 
   public search(searchValue: string): void {
-    if (searchValue!==' ') {
-      this.modalTagsList = this.tags.filter(el => el.includes(searchValue.toLocaleLowerCase()));
-    }
+    searchValue = searchValue.trim();
+    this.modalTagsList = this.tags.filter(el => el.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()));
+  }
+
+  public uncheckAll(): void {
+    this.selectedItems = [];
+    this.selectedTagsHeader = '';
+    this.updateTagFilters();
   }
 
   public updatePedigrees(newCounters: Dictionary<PedigreeCounter[]>): void {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener, Pipe, PipeTransform } from '@angular/core';
+import { Component, OnInit, HostListener, Pipe, PipeTransform, Input } from '@angular/core';
 import { VariantReportsService } from './variant-reports.service';
 import {
   VariantReport, FamilyCounter, PedigreeCounter, EffectTypeTable, DeNovoData, PedigreeTable, PeopleCounter
@@ -30,6 +30,7 @@ export class VariantReportsComponent implements OnInit {
   public currentPeopleCounter: PeopleCounter;
   public currentPedigreeTable: PedigreeTable;
   public currentDenovoReport: EffectTypeTable;
+  @Input() public isFamiliesByNumberVisible = false;
 
   public variantReport: VariantReport;
   public familiesCounters: FamilyCounter[];
@@ -92,6 +93,7 @@ export class VariantReportsComponent implements OnInit {
       allowSearchFilter: true,
       maxHeight: 150
     };
+    this.isFamiliesByNumberVisible = true;
   }
 
   private copyOriginalPedigreeCounters(): Record<string, PedigreeCounter[]> {


### PR DESCRIPTION
## Background

Families by pedigree in Dataset Statistics need design improvements for selecting and listing tags.

## Aim

To make the design better.

## Implementation

Using modal where the tags are listed and the selected tags' names are visible as a header above the table with pedigrees.

Also made "Total number of families" with download button visible only in tab Families by number.
