### PR TITLE
Fix management groups

### DIFF
--- a/src/app/groups-table/groups-table.component.ts
+++ b/src/app/groups-table/groups-table.component.ts
@@ -29,7 +29,12 @@ export class GroupsTableComponent {
     this.usersGroupsService.removeUser(userEmail, group.name).pipe(
       mergeMap(() => this.usersGroupsService.getGroups(1, group.name))
     ).subscribe(updatedGroups => {
-      group.users = updatedGroups.find(g => g.name === group.name).users;
+      const updatedGroup = updatedGroups.find(g => g.name === group.name);
+      if (!updatedGroup) {
+        group.users = [];
+      } else {
+        group.users = updatedGroup.users;
+      }
     });
   }
 
@@ -45,7 +50,12 @@ export class GroupsTableComponent {
     this.usersGroupsService.revokePermissionToDataset(group.id, datasetId).pipe(
       mergeMap(() => this.usersGroupsService.getGroups(1, group.name))
     ).subscribe(updatedGroups => {
-      group.datasets = updatedGroups.find(g => g.name === group.name).datasets;
+      const updatedGroup = updatedGroups.find(g => g.name === group.name);
+      if (!updatedGroup) {
+        group.datasets = [];
+      } else {
+        group.datasets = updatedGroup.datasets;
+      }
     });
   }
 

--- a/src/app/users-groups/users-groups.service.ts
+++ b/src/app/users-groups/users-groups.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { UserGroup } from './users-groups';
-import { Dataset } from '../datasets/datasets';
 import { ConfigService } from '../config/config.service';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';


### PR DESCRIPTION
## Background

Error occurs when removing the only added user or dataset in groups.

## Aim

To handle the error.

## Implementation

Add if logic when assigning the updated list of users or datasets of a group. 