### PR TITLE
Now unique family variants work as expected, even with multiple child…

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -124,7 +124,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.location.replaceState(`datasets/${this.selectedDatasetId}/gene-browser`);
       this.interruptSummaryVariants$.next(true);
     });
-    if (this.selectedDataset.studies?.length > 1) {
+
+    if (this.selectedDataset.studies?.length !== 0) {
       this.isUniqueFamilyFilterEnabled = true;
     }
   }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -30,7 +30,7 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
-    if (this.datasetService.getSelectedDataset().studies?.length > 1) {
+    if (this.datasetService.getSelectedDataset().studies?.length !== 0) {
       this.isVisible = true;
     }
   }


### PR DESCRIPTION
… datasets without other studies #845

## Background

The current state in the gene browser is that if there are multiple child datasets without other studies it doesn't take them into account, making unique family variants uncheckable.

## Aim

The aim is to take into account that there is a dynamic treelist-like structure of datasets and studies and therefore there are corner cases in which the current value breaks.

## Implementation

Closes #845
