### PR TITLE
Update federation token

### DIFF
--- a/src/app/federation-credentials/federation-credentials.component.css
+++ b/src/app/federation-credentials/federation-credentials.component.css
@@ -1,5 +1,6 @@
 .grid-container {
-  grid-template-columns: 25% 25% 25% 25%;
+  grid-template-columns: 25% 35% 25%;
+  margin-left: 120px;
 }
 
 .table-toolbar {
@@ -65,4 +66,44 @@ input:invalid:focus {
 
 #copy-credentials-button {
   margin-right: 20px;
+}
+
+#cancel-button {
+  background-color: transparent;
+  border: none;
+}
+
+#cancel-button > i {
+  color: red;
+}
+
+#cancel-button > i:hover {
+  color: rgb(255, 110, 110);
+}
+
+#edit-icon {
+  font-size: 12px;
+  padding-bottom: 5px;
+}
+
+#edit-icon:hover {
+  cursor: pointer;
+}
+
+#edit-wrapper {
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+}
+
+#add-description {
+  font-style: italic;
+  opacity: 50%;
+  margin-right: 5px;
+}
+
+.description-field {
+  font-size: 15px;
+  height: 75px;
+  border-radius: 0.375rem;
 }

--- a/src/app/federation-credentials/federation-credentials.component.css
+++ b/src/app/federation-credentials/federation-credentials.component.css
@@ -98,3 +98,8 @@ input:invalid:focus {
   justify-content: center;
   flex-direction: row;
 }
+
+#rename-error {
+  color: red;
+  margin-bottom: 5px;
+}

--- a/src/app/federation-credentials/federation-credentials.component.css
+++ b/src/app/federation-credentials/federation-credentials.component.css
@@ -1,10 +1,13 @@
 .grid-container {
-  grid-template-columns: 25% 35% 25%;
-  margin-left: 120px;
+  grid-template-columns: 80% 20%;
+  margin: 2rem;
+  margin-top: 0;
+  justify-content: center;
 }
 
 .table-toolbar {
   padding-top: 15px;
+  margin-left: 22px;
   display: flex;
   justify-content: start;
 }
@@ -14,7 +17,7 @@
   border-radius: 0;
 }
 
-#credential-name-box {
+#new-credential-name-box {
   width: 250px;
 }
 
@@ -83,7 +86,7 @@ input:invalid:focus {
 
 #edit-icon {
   font-size: 12px;
-  padding-bottom: 5px;
+  padding: 2px 5px;
 }
 
 #edit-icon:hover {
@@ -94,16 +97,4 @@ input:invalid:focus {
   display: flex;
   justify-content: center;
   flex-direction: row;
-}
-
-#add-description {
-  font-style: italic;
-  opacity: 50%;
-  margin-right: 5px;
-}
-
-.description-field {
-  font-size: 15px;
-  height: 75px;
-  border-radius: 0.375rem;
 }

--- a/src/app/federation-credentials/federation-credentials.component.html
+++ b/src/app/federation-credentials/federation-credentials.component.html
@@ -3,7 +3,7 @@
     #credentialNameBox
     placeholder="New credential"
     autocomplete="off"
-    id="credential-name-box"
+    id="new-credential-name-box"
     class="search-input form-control my-0 py-1"
     type="search"
     pattern=".{3,}"
@@ -31,16 +31,13 @@
 
 <div class="grid-container" *ngIf="credentials">
   <div class="grid-header">Name</div>
-  <div class="grid-header">Description</div>
   <div class="grid-header">Actions</div>
   <ng-container *ngFor="let credential of credentials">
-    <div class="grid-cell" [attr.id]="credential.name + '-name-cell'">{{ credential.name }}</div>
-
-    <div class="grid-cell" [attr.id]="credential.name + '-description-cell'">
+    <div class="grid-cell" [attr.id]="credential.name + '-name-cell'">
       <div>
-        <!-- <span *ngIf="credential.description === '' && currentCredentialEdit !== credential.name" id="add-description">Add description</span> -->
-        <!-- <span *ngIf="credential.description !== '' && currentCredentialEdit !== credential.name" id="description">{{ credential.description }}</span> -->
-        <span *ngIf="currentCredentialEdit !== credential.name" id="add-description">Add description</span>
+        <span *ngIf="credential.name !== '' && currentCredentialEdit !== credential.name" id="credential-name">{{
+          credential.name
+        }}</span>
         <i
           *ngIf="currentCredentialEdit !== credential.name"
           (click)="currentCredentialEdit = credential.name"
@@ -48,14 +45,16 @@
           class="fa fa-pencil fa-lg"
           title="Edit"></i>
         <div *ngIf="currentCredentialEdit === credential.name" id="edit-wrapper">
-          <textarea
-            #descriptionBox
+          <input
+            #newName
             type="text"
-            [value]="credential.description"
-            class="description-field search-input form-control my-0 py-1"
+            [value]="credential.name"
+            spellcheck="false"
+            required
+            class="name-field search-input form-control my-0 py-1"
             [attr.id]="credential.name + '-new-name-input'"
-            (keydown.escape)="currentCredentialEdit = ''">
-          </textarea>
+            (keydown.enter)="edit(credential, newName.value)"
+            (keydown.escape)="currentCredentialEdit = ''" />
           <button id="cancel-button" (click)="currentCredentialEdit = ''" title="Cancel">
             <i class="fa fa-thin fa-times" aria-hidden="true"></i
           ></button>

--- a/src/app/federation-credentials/federation-credentials.component.html
+++ b/src/app/federation-credentials/federation-credentials.component.html
@@ -44,20 +44,23 @@
           id="edit-icon"
           class="fa fa-pencil fa-lg"
           title="Edit"></i>
-        <div *ngIf="currentCredentialEdit === credential.name" id="edit-wrapper">
-          <input
-            #newName
-            type="text"
-            [value]="credential.name"
-            spellcheck="false"
-            required
-            class="name-field search-input form-control my-0 py-1"
-            [attr.id]="credential.name + '-new-name-input'"
-            (keydown.enter)="edit(credential, newName.value)"
-            (keydown.escape)="currentCredentialEdit = ''" />
-          <button id="cancel-button" (click)="currentCredentialEdit = ''" title="Cancel">
-            <i class="fa fa-thin fa-times" aria-hidden="true"></i
-          ></button>
+        <div *ngIf="currentCredentialEdit === credential.name">
+          <div *ngIf="renameError" id="rename-error">{{ renameError }}</div>
+          <div id="edit-wrapper">
+            <input
+              #credentialRename
+              type="text"
+              [value]="credential.name"
+              spellcheck="false"
+              required
+              class="name-field search-input form-control my-0 py-1"
+              [attr.id]="credential.name + '-new-name-input'"
+              (keydown.enter)="edit(credential, credentialRename.value)"
+              (keydown.escape)="currentCredentialEdit = ''" />
+            <button id="cancel-button" (click)="currentCredentialEdit = ''" title="Cancel">
+              <i class="fa fa-thin fa-times" aria-hidden="true"></i
+            ></button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/federation-credentials/federation-credentials.component.html
+++ b/src/app/federation-credentials/federation-credentials.component.html
@@ -10,9 +10,7 @@
     (focusout)="creationError = ''"
     required
     spellcheck="false" />
-  <button id="create-credential-button" class="btn btn-primary" (click)="createCredential(credentialNameBox.value)"
-    >Create</button
-  >
+  <button #createButton id="create-credential-button" class="btn btn-primary">Create</button>
   <div *ngIf="creationError" class="creation-error alert alert-danger">{{ creationError }}</div>
 </div>
 
@@ -33,15 +31,37 @@
 
 <div class="grid-container" *ngIf="credentials">
   <div class="grid-header">Name</div>
-  <div class="grid-header">Client Id</div>
-  <div class="grid-header">Client Secret</div>
+  <div class="grid-header">Description</div>
   <div class="grid-header">Actions</div>
   <ng-container *ngFor="let credential of credentials">
     <div class="grid-cell" [attr.id]="credential.name + '-name-cell'">{{ credential.name }}</div>
 
-    <div class="grid-cell" [attr.id]="credential.name + '-id-cell'">{{ credential.clientId }}</div>
-
-    <div class="grid-cell" [attr.id]="credential.name + '-secret-cell'">{{ credential.clientSecret }}</div>
+    <div class="grid-cell" [attr.id]="credential.name + '-description-cell'">
+      <div>
+        <!-- <span *ngIf="credential.description === '' && currentCredentialEdit !== credential.name" id="add-description">Add description</span> -->
+        <!-- <span *ngIf="credential.description !== '' && currentCredentialEdit !== credential.name" id="description">{{ credential.description }}</span> -->
+        <span *ngIf="currentCredentialEdit !== credential.name" id="add-description">Add description</span>
+        <i
+          *ngIf="currentCredentialEdit !== credential.name"
+          (click)="currentCredentialEdit = credential.name"
+          id="edit-icon"
+          class="fa fa-pencil fa-lg"
+          title="Edit"></i>
+        <div *ngIf="currentCredentialEdit === credential.name" id="edit-wrapper">
+          <textarea
+            #descriptionBox
+            type="text"
+            [value]="credential.description"
+            class="description-field search-input form-control my-0 py-1"
+            [attr.id]="credential.name + '-new-name-input'"
+            (keydown.escape)="currentCredentialEdit = ''">
+          </textarea>
+          <button id="cancel-button" (click)="currentCredentialEdit = ''" title="Cancel">
+            <i class="fa fa-thin fa-times" aria-hidden="true"></i
+          ></button>
+        </div>
+      </div>
+    </div>
 
     <div class="grid-cell" [attr.id]="credential.name + '-actions-cell'">
       <gpf-confirm-button

--- a/src/app/federation-credentials/federation-credentials.component.spec.ts
+++ b/src/app/federation-credentials/federation-credentials.component.spec.ts
@@ -109,9 +109,24 @@ describe('FederationCredentialsComponent', () => {
   });
 
   it('should rename credential', () => {
+    fixture.detectChanges();
     const credential = new FederationCredential('rename');
     component.edit(credential, 'newName');
     fixture.detectChanges();
     expect(credential.name).toBe('newName');
+  });
+
+  it('should not rename credential', () => {
+    fixture.detectChanges();
+    const credential = new FederationCredential('rename');
+    component.edit(credential, '  ');
+    fixture.detectChanges();
+    expect(component.renameError).toBe('Please fill the field!');
+    expect(credential.name).toBe('rename');
+
+    component.edit(credential, 'name1');
+    fixture.detectChanges();
+    expect(component.renameError).toBe('Credential with such name already exists!');
+    expect(credential.name).toBe('rename');
   });
 });

--- a/src/app/federation-credentials/federation-credentials.component.spec.ts
+++ b/src/app/federation-credentials/federation-credentials.component.spec.ts
@@ -8,9 +8,9 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 class MockUsersService {
   private credentials = [
-    new FederationCredential('id1', 'secret1', 'name1'),
-    new FederationCredential('id2', 'secret2', 'name2'),
-    new FederationCredential('id3', 'secret3', 'name3')
+    new FederationCredential('name1'),
+    new FederationCredential('name2'),
+    new FederationCredential('name3')
   ];
 
   public getFederationCredentials(): Observable<FederationCredential[]> {
@@ -24,9 +24,12 @@ class MockUsersService {
   }
 
   public createFederationCredentials(name: string): Observable<string> {
-    const num = this.credentials.length + 1;
-    this.credentials.push(new FederationCredential(`id${num}`, `secret${num}`, name));
+    this.credentials.push(new FederationCredential(name));
     return of('secret new credential');
+  }
+
+  public updateFederationCredentials(oldName: string, newName: string): Observable<string> {
+    return of(newName);
   }
 }
 
@@ -57,51 +60,58 @@ describe('FederationCredentialsComponent', () => {
     expect(component.credentials).toBeUndefined();
     component.ngOnInit();
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id2', 'secret2', 'name2'),
-      new FederationCredential('id3', 'secret3', 'name3')
+      new FederationCredential('name1'),
+      new FederationCredential('name2'),
+      new FederationCredential('name3')
     ]);
   });
 
   it('should delete credentials', () => {
     fixture.detectChanges();
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id2', 'secret2', 'name2'),
-      new FederationCredential('id3', 'secret3', 'name3')
+      new FederationCredential('name1'),
+      new FederationCredential('name2'),
+      new FederationCredential('name3')
     ]);
 
     component.deleteCredential('name2');
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id3', 'secret3', 'name3')
+      new FederationCredential('name1'),
+      new FederationCredential('name3')
     ]);
   });
 
   it('should create credential', () => {
     fixture.detectChanges();
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id2', 'secret2', 'name2'),
-      new FederationCredential('id3', 'secret3', 'name3')
+      new FederationCredential('name1'),
+      new FederationCredential('name2'),
+      new FederationCredential('name3')
     ]);
 
     component.createCredential('');
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id2', 'secret2', 'name2'),
-      new FederationCredential('id3', 'secret3', 'name3')
+      new FederationCredential('name1'),
+      new FederationCredential('name2'),
+      new FederationCredential('name3')
     ]);
 
     component.createCredential('name4');
     fixture.detectChanges();
     expect(component.credentials).toStrictEqual([
-      new FederationCredential('id1', 'secret1', 'name1'),
-      new FederationCredential('id2', 'secret2', 'name2'),
-      new FederationCredential('id3', 'secret3', 'name3'),
-      new FederationCredential('id4', 'secret4', 'name4')
+      new FederationCredential('name1'),
+      new FederationCredential('name2'),
+      new FederationCredential('name3'),
+      new FederationCredential('name4')
     ]);
     expect(component.temporaryShownCredentials).toBe('secret new credential');
     expect(document.getElementById('credential-modal-content').textContent).toBe('secret new credential');
+  });
+
+  it('should rename credential', () => {
+    const credential = new FederationCredential('rename');
+    component.edit(credential, 'newName');
+    fixture.detectChanges();
+    expect(credential.name).toBe('newName');
   });
 });

--- a/src/app/federation-credentials/federation-credentials.component.ts
+++ b/src/app/federation-credentials/federation-credentials.component.ts
@@ -17,7 +17,6 @@ export class FederationCredentialsComponent implements OnInit {
   @ViewChild('credentialModal') public credentialModal: ElementRef;
   @ViewChild('credentialNameBox') public newCredentialName: ElementRef;
   @ViewChild('createButton') public createButton: ElementRef;
-  @ViewChild('descriptionBox') private descriptionBox: ElementRef;
   public currentCredentialEdit = '';
 
   public constructor(
@@ -78,14 +77,11 @@ export class FederationCredentialsComponent implements OnInit {
     );
   }
 
-  // public edit(credential: FederationCredential, desc: string): void {
-  //   credential.description = desc;
-  //   this.usersService.updateFederationCredentials(credential)
-  //     .pipe(take(1))
-  //     .subscribe(() => {
-  //       credential.description = desc;
-  //     });
-
-  //   this.currentCredentialEdit = '';
-  // }
+  public edit(credential: FederationCredential, newName: string): void {
+    this.usersService.updateFederationCredentials(credential.name, newName)
+      .subscribe((res: string) => {
+        credential.name = res;
+      });
+    this.currentCredentialEdit = '';
+  }
 }

--- a/src/app/federation-credentials/federation-credentials.component.ts
+++ b/src/app/federation-credentials/federation-credentials.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { UsersService } from 'app/users/users.service';
 import { FederationCredential } from './federation-credentials';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { concatMap, of, zip } from 'rxjs';
+import { concatMap, debounceTime, fromEvent, of, tap, zip } from 'rxjs';
 
 @Component({
   selector: 'gpf-federation-credentials',
@@ -16,6 +16,9 @@ export class FederationCredentialsComponent implements OnInit {
   public temporaryShownCredentials = '';
   @ViewChild('credentialModal') public credentialModal: ElementRef;
   @ViewChild('credentialNameBox') public newCredentialName: ElementRef;
+  @ViewChild('createButton') public createButton: ElementRef;
+  @ViewChild('descriptionBox') private descriptionBox: ElementRef;
+  public currentCredentialEdit = '';
 
   public constructor(
     private usersService: UsersService,
@@ -25,6 +28,13 @@ export class FederationCredentialsComponent implements OnInit {
   public ngOnInit(): void {
     this.usersService.getFederationCredentials().subscribe(res => {
       this.credentials = res;
+
+      fromEvent(this.createButton.nativeElement, 'click').pipe(
+        debounceTime(250),
+        tap(() => {
+          this.createCredential(this.newCredentialName.nativeElement.value);
+        })
+      ).subscribe();
     });
   }
 
@@ -67,4 +77,15 @@ export class FederationCredentialsComponent implements OnInit {
       {animation: false, centered: true, size: 'lg', windowClass: 'credential-modal'}
     );
   }
+
+  // public edit(credential: FederationCredential, desc: string): void {
+  //   credential.description = desc;
+  //   this.usersService.updateFederationCredentials(credential)
+  //     .pipe(take(1))
+  //     .subscribe(() => {
+  //       credential.description = desc;
+  //     });
+
+  //   this.currentCredentialEdit = '';
+  // }
 }

--- a/src/app/federation-credentials/federation-credentials.component.ts
+++ b/src/app/federation-credentials/federation-credentials.component.ts
@@ -12,10 +12,12 @@ import { concatMap, debounceTime, fromEvent, of, tap, zip } from 'rxjs';
 export class FederationCredentialsComponent implements OnInit {
   public credentials: FederationCredential[];
   public creationError = '';
+  public renameError = '';
   public modal: NgbModalRef;
   public temporaryShownCredentials = '';
   @ViewChild('credentialModal') public credentialModal: ElementRef;
   @ViewChild('credentialNameBox') public newCredentialName: ElementRef;
+  @ViewChild('credentialRename') public credentialRename: ElementRef;
   @ViewChild('createButton') public createButton: ElementRef;
   public currentCredentialEdit = '';
 
@@ -78,6 +80,14 @@ export class FederationCredentialsComponent implements OnInit {
   }
 
   public edit(credential: FederationCredential, newName: string): void {
+    if (this.credentials.find(cred => cred.name === newName) !== undefined) {
+      this.renameError = 'Credential with such name already exists!';
+      return;
+    }
+    if (!newName.trim()) {
+      this.renameError = 'Please fill the field!';
+      return;
+    }
     this.usersService.updateFederationCredentials(credential.name, newName)
       .subscribe((res: string) => {
         credential.name = res;

--- a/src/app/federation-credentials/federation-credentials.ts
+++ b/src/app/federation-credentials/federation-credentials.ts
@@ -1,8 +1,5 @@
 export interface FederationJson {
-  /* eslint-disable  @typescript-eslint/naming-convention */
-  description: string;
   name: string;
-  // eslint-enable
 }
 
 export class FederationCredential {
@@ -12,14 +9,11 @@ export class FederationCredential {
 
   public static fromJson(json: FederationJson): FederationCredential {
     return new FederationCredential(
-      json['description'],
       json['name']
     );
   }
 
-  public constructor(
-    public description: string,
-    public name: string) {}
+  public constructor(public name: string) {}
 }
 
 

--- a/src/app/federation-credentials/federation-credentials.ts
+++ b/src/app/federation-credentials/federation-credentials.ts
@@ -1,7 +1,6 @@
 export interface FederationJson {
   /* eslint-disable  @typescript-eslint/naming-convention */
-  client_id: string;
-  client_secret: string;
+  description: string;
   name: string;
   // eslint-enable
 }
@@ -13,15 +12,13 @@ export class FederationCredential {
 
   public static fromJson(json: FederationJson): FederationCredential {
     return new FederationCredential(
-      json['client_id'],
-      json['client_secret'],
+      json['description'],
       json['name']
     );
   }
 
   public constructor(
-    public clientId: string,
-    public clientSecret: string,
+    public description: string,
     public name: string) {}
 }
 

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -205,19 +205,17 @@ export class UsersService {
       );
   }
 
-  // public updateFederationCredentials(credentialName: string): Observable<string> {
-    // const options = { withCredentials: true };
+  public updateFederationCredentials(oldCredentialName: string, newCredentialName: string): Observable<string> {
+    const options = { withCredentials: true };
 
-    // return this.http.post(this.config.baseUrl + 'users/federation_credentials', {name: credentialName}, options)
-    //   .pipe(
-    //     map(res => {
-    //       if (typeof (res as {credentials: string}).credentials === 'string') {
-    //         return (res as {credentials: string}).credentials;
-    //       }
-    //       return 'Error showing created credentials';
-    //     })
-    //   );
-  // }
+    return this.http.put(this.config.baseUrl + 'users/federation_credentials',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      {name: oldCredentialName, new_name: newCredentialName}, options)
+      .pipe(
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        map((res: {new_name: string}) => res.new_name)
+      );
+  }
 
   public deleteFederationCredentials(credentialName: string): Observable<object> {
     const options = { withCredentials: true, body: { name: credentialName }};

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -205,6 +205,20 @@ export class UsersService {
       );
   }
 
+  // public updateFederationCredentials(credentialName: string): Observable<string> {
+    // const options = { withCredentials: true };
+
+    // return this.http.post(this.config.baseUrl + 'users/federation_credentials', {name: credentialName}, options)
+    //   .pipe(
+    //     map(res => {
+    //       if (typeof (res as {credentials: string}).credentials === 'string') {
+    //         return (res as {credentials: string}).credentials;
+    //       }
+    //       return 'Error showing created credentials';
+    //     })
+    //   );
+  // }
+
   public deleteFederationCredentials(credentialName: string): Observable<object> {
     const options = { withCredentials: true, body: { name: credentialName }};
 


### PR DESCRIPTION
## Background

Columns Client id and Client secret in federation tokens table are unnecessary.

## Aim

To remove unnecessary columns and make changing credential names possible.

## Implementation

Removed unnecessary columns. Added rename functionality.
