### PR TITLE
Fix for the AGP not loading single views with lowercase letters and s…

### DIFF
--- a/src/app/autism-gene-profiles-single-view-wrapper/autism-gene-profiles-single-view-wrapper.component.spec.ts
+++ b/src/app/autism-gene-profiles-single-view-wrapper/autism-gene-profiles-single-view-wrapper.component.spec.ts
@@ -10,7 +10,7 @@ class MockActivatedRoute {
   public params = {dataset: 'testDatasetId', get: (): string => ''};
   public parent = {params: of(this.params)};
   public queryParamMap = of(this.params);
-  public snapshot = {params: {genes: 'abc1,def2,'}};
+  public snapshot = {params: {genes: 'ABC1,dEf2,'}};
 }
 
 class MockAutismGeneProfilesService {
@@ -51,6 +51,6 @@ describe('AutismGeneProfileSingleViewWrapperComponent', () => {
   it('should set gene symbols after view initialization', () => {
     expect(component.geneSymbols).toStrictEqual(new Set<string>());
     component.ngAfterViewInit();
-    expect(component.geneSymbols).toStrictEqual(new Set<string>(['ABC1', 'DEF2']));
+    expect(component.geneSymbols).toStrictEqual(new Set<string>(['ABC1', 'dEf2']));
   });
 });

--- a/src/app/autism-gene-profiles-single-view-wrapper/autism-gene-profiles-single-view-wrapper.component.ts
+++ b/src/app/autism-gene-profiles-single-view-wrapper/autism-gene-profiles-single-view-wrapper.component.ts
@@ -29,7 +29,7 @@ export class AutismGeneProfileSingleViewWrapperComponent implements OnInit, Afte
       (this.route.snapshot.params.genes as string)
         .split(',')
         .filter(p => p)
-        .map(p => p.trim().toUpperCase())
+        .map(p => p.trim())
     );
     this.location.replaceState('autism-gene-profiles/' + Array.from(this.geneSymbols).toString());
   }

--- a/src/app/autism-gene-profiles-single-view/autism-gene-profile-single-view.component.ts
+++ b/src/app/autism-gene-profiles-single-view/autism-gene-profile-single-view.component.ts
@@ -186,8 +186,9 @@ export class AutismGeneProfileSingleViewComponent implements OnInit {
   ): void {
     const effectTypes = {
       lgds: EffectTypes['LGDS'],
-      intron: ['Intron'],
-      missense: ['Missense'],
+      intron: ['intron'],
+      missense: ['missense'],
+      synonymous: ['synonymous'],
     };
     const newWindow = window.open('', '_blank');
 


### PR DESCRIPTION
…ingle view state load in genotype browser #863 #864

This branch addresses the current issues in the AGP single view with the gene symbols being always carried as an upper case(when AGP opens a single view with such gene symbols) and the issue with the incorrect genotype redirecting from the single view with the state having missense or synonymous.

Closes #863.

