### PR TITLE
Fix unique family filters being always selected #845

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -124,7 +124,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.location.replaceState(`datasets/${this.selectedDatasetId}/gene-browser`);
       this.interruptSummaryVariants$.next(true);
     });
-    if (this.selectedDataset.studies?.length > 1) {
+
+    if (this.selectedDataset.studies?.length) {
       this.isUniqueFamilyFilterEnabled = true;
     }
   }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -30,7 +30,7 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
-    if (this.datasetService.getSelectedDataset().studies?.length > 1) {
+    if (this.datasetService.getSelectedDataset().studies?.length) {
       this.isVisible = true;
     }
   }


### PR DESCRIPTION
This branch fixes the always-shown unique family variants due to studies having undefined children.