### PR TITLE
Dataset treelist helper service added #845

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -179,6 +179,7 @@ import * as Sentry from '@sentry/angular-ivy';
 import { FederationCredentialsComponent } from './federation-credentials/federation-credentials.component';
 import { StudyFiltersTreeComponent } from './treelist-checkbox/treelist-checkbox.component';
 import { LoginComponent } from './login/login.component';
+import { DatasetsTreeService } from './datasets/datasets-tree.service';
 
 const appRoutes: Routes = [
   {
@@ -419,6 +420,7 @@ const appRoutes: Routes = [
     CookieService,
     ConfigService,
     DatasetsService,
+    DatasetsTreeService,
     QueryService,
     GeneScoresService,
     GeneSetsService,

--- a/src/app/datasets/datasets-tree.service.spec.ts
+++ b/src/app/datasets/datasets-tree.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ConfigService } from 'app/config/config.service';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { UsersService } from 'app/users/users.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NgxsModule } from '@ngxs/store';
+import { APP_BASE_HREF } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs/internal/lastValueFrom';
+import { of } from 'rxjs/internal/observable/of';
+import { Dataset } from './datasets';
+import { DatasetNode } from 'app/dataset-node/dataset-node';
+
+const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
+  null, null, ['id11', 'id12'], null, null, null, null, null,
+  null, null, null, null, null, null, null, null, null, null, null
+), [
+  new Dataset(
+    'id2',
+    null, null, ['id1', 'parent2'], null, null, null, null, null,
+    null, null, null, null, null, null, null, null, null, null, null
+  ),
+  new Dataset(
+    'id3',
+    null, null, ['id1', 'parent3'], null, null, null, null, null,
+    null, null, null, null, null, null, null, null, null, null, null
+  ),
+  new Dataset(
+    'id4',
+    null, null, ['id4', 'parent4'], null, null, null, null, null,
+    null, null, null, null, null, null, null, null, null, null, null
+  )
+]);
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const hierarchyMock1 = {
+  data: [
+    {
+      dataset: 'dataset1', name: 'id1', access_rights: false, children: [
+        {dataset: 'datasetChild1', name: 'id2', access_rights: true, children: null},
+        {
+          dataset: 'datasetChild2', name: 'id3', access_rights: false, children: [
+            {dataset: 'datasetSubChild1', name: 'id4', access_rights: true, children: null},
+          ]
+        },
+      ]
+    }
+  ]
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe('DatasetService', () => {
+  let service: DatasetsTreeService;
+  beforeEach(waitForAsync(() => {
+    const configMock = { baseUrl: 'testUrl/' };
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([], {developmentMode: true}), RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        DatasetsTreeService,
+        UsersService,
+        {provide: ConfigService, useValue: configMock},
+        { provide: APP_BASE_HREF, useValue: '' }
+      ],
+      declarations: [],
+    }).compileComponents();
+
+    service = TestBed.inject(DatasetsTreeService);
+  }));
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should test get datasets hierarchy', async() => {
+    const httpGetSpy = jest.spyOn(HttpClient.prototype, 'get');
+    httpGetSpy.mockReturnValue(of(hierarchyMock1));
+
+    const response = await lastValueFrom(service.getDatasetHierarchy());
+    expect(httpGetSpy.mock.calls.toString()).toBe('testUrl/datasets/hierarchy');
+    expect(response).toStrictEqual({
+      data: [
+        {
+          dataset: 'dataset1', children: [
+            {dataset: 'datasetChild1', children: null},
+            {dataset: 'datasetChild2', children: [
+              {dataset: 'datasetSubChild1', children: null},
+            ]},
+          ]
+        }
+      ]
+    });
+  });
+
+  it('should test find node by id', () => {
+    expect(service.findNodeById(datasetNodeMock1, 'id3')).toStrictEqual(new DatasetNode(
+      new Dataset(
+        'id3',
+        null, null, ['id1', 'parent3'], null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null
+      ), [
+        new Dataset(
+          'id2',
+          null, null, ['id1', 'parent2'], null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null
+        ),
+        new Dataset(
+          'id3',
+          null, null, ['id1', 'parent3'], null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null
+        ),
+        new Dataset(
+          'id4',
+          null, null, ['id4', 'parent4'], null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null
+        )]
+    ));
+  });
+});

--- a/src/app/datasets/datasets-tree.service.spec.ts
+++ b/src/app/datasets/datasets-tree.service.spec.ts
@@ -6,9 +6,6 @@ import { UsersService } from 'app/users/users.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgxsModule } from '@ngxs/store';
 import { APP_BASE_HREF } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { lastValueFrom } from 'rxjs/internal/lastValueFrom';
-import { of } from 'rxjs/internal/observable/of';
 import { Dataset } from './datasets';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 
@@ -33,23 +30,6 @@ const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
   )
 ]);
 
-/* eslint-disable @typescript-eslint/naming-convention */
-const hierarchyMock1 = {
-  data: [
-    {
-      dataset: 'dataset1', name: 'id1', access_rights: false, children: [
-        {dataset: 'datasetChild1', name: 'id2', access_rights: true, children: null},
-        {
-          dataset: 'datasetChild2', name: 'id3', access_rights: false, children: [
-            {dataset: 'datasetSubChild1', name: 'id4', access_rights: true, children: null},
-          ]
-        },
-      ]
-    }
-  ]
-};
-/* eslint-enable @typescript-eslint/naming-convention */
-
 describe('DatasetService', () => {
   let service: DatasetsTreeService;
   beforeEach(waitForAsync(() => {
@@ -71,30 +51,6 @@ describe('DatasetService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
-
-  /* eslint-disable @typescript-eslint/naming-convention */
-  it('should test get datasets hierarchy', async() => {
-    const httpGetSpy = jest.spyOn(HttpClient.prototype, 'get');
-    httpGetSpy.mockReturnValue(of(hierarchyMock1));
-
-    const response = await lastValueFrom(service.getDatasetHierarchy());
-    expect(httpGetSpy.mock.calls.toString()).toBe('testUrl/datasets/hierarchy');
-    expect(response).toStrictEqual({
-      data: [
-        {
-          dataset: 'dataset1', name: 'id1', access_rights: false, children: [
-            {dataset: 'datasetChild1', name: 'id2', access_rights: true, children: null},
-            {
-              dataset: 'datasetChild2', name: 'id3', access_rights: false, children: [
-                {dataset: 'datasetSubChild1', name: 'id4', access_rights: true, children: null},
-              ]
-            },
-          ]
-        }
-      ]
-    });
-  });
-  /* eslint-disable @typescript-eslint/naming-convention */
 
   it('should test find node by id', () => {
     expect(service.findNodeById(datasetNodeMock1, 'id3')).toStrictEqual(new DatasetNode(

--- a/src/app/datasets/datasets-tree.service.spec.ts
+++ b/src/app/datasets/datasets-tree.service.spec.ts
@@ -72,6 +72,7 @@ describe('DatasetService', () => {
     expect(service).toBeTruthy();
   });
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   it('should test get datasets hierarchy', async() => {
     const httpGetSpy = jest.spyOn(HttpClient.prototype, 'get');
     httpGetSpy.mockReturnValue(of(hierarchyMock1));
@@ -81,16 +82,19 @@ describe('DatasetService', () => {
     expect(response).toStrictEqual({
       data: [
         {
-          dataset: 'dataset1', children: [
-            {dataset: 'datasetChild1', children: null},
-            {dataset: 'datasetChild2', children: [
-              {dataset: 'datasetSubChild1', children: null},
-            ]},
+          dataset: 'dataset1', name: 'id1', access_rights: false, children: [
+            {dataset: 'datasetChild1', name: 'id2', access_rights: true, children: null},
+            {
+              dataset: 'datasetChild2', name: 'id3', access_rights: false, children: [
+                {dataset: 'datasetSubChild1', name: 'id4', access_rights: true, children: null},
+              ]
+            },
           ]
         }
       ]
     });
   });
+  /* eslint-disable @typescript-eslint/naming-convention */
 
   it('should test find node by id', () => {
     expect(service.findNodeById(datasetNodeMock1, 'id3')).toStrictEqual(new DatasetNode(

--- a/src/app/datasets/datasets-tree.service.ts
+++ b/src/app/datasets/datasets-tree.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { ConfigService } from '../config/config.service';
-import { map, tap } from 'rxjs/operators';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 
 @Injectable()
@@ -14,24 +13,14 @@ export class DatasetsTreeService {
     private http: HttpClient,
     private config: ConfigService
   ) {
-    this.getDatasetHierarchy().subscribe(
+    this.http.get(`${this.config.baseUrl}${this.datasetHierarchyUrl}`).subscribe(
       data => {
-        tap(() => {
-          this.datasetTreeNodes$.next(data);
-        });
+        this.datasetTreeNodes$.next(data);
       }
     );
   }
 
-  public getDatasetHierarchy(): Observable<object> {
-    return this.http.get(`${this.config.baseUrl}${this.datasetHierarchyUrl}`).pipe(
-      map(data => {
-        this.datasetTreeNodes$.next(data);
-        return data;
-      })
-    );
-  }
-
+  // This method finds Dataset Node by its id
   public findNodeById(node: DatasetNode, id: string): DatasetNode | undefined {
     if (node.dataset.id === id) {
       return node;
@@ -47,6 +36,7 @@ export class DatasetsTreeService {
     return undefined;
   }
 
+  // This method works with the backend derived treelist data structure and finds it by id
   public findHierarchyNode(node: object, id: string): object | undefined {
     if (node['dataset'] === id) {
       return node;

--- a/src/app/datasets/datasets-tree.service.ts
+++ b/src/app/datasets/datasets-tree.service.ts
@@ -23,26 +23,10 @@ export class DatasetsTreeService {
     );
   }
 
-  public getDatasetHierarchy(onlyChildren = true): Observable<object> {
-    const deleteFields = (obj: object): void => {
-      if (obj === null || obj === undefined) {
-        return;
-      }
-      Object.keys(obj).forEach((key) => {
-        if (key === 'access_rights' || key === 'name') {
-          delete obj[key];
-        } else if (typeof obj[key] === 'object') {
-          deleteFields(obj[key] as object);
-        }
-      });
-    };
-
+  public getDatasetHierarchy(): Observable<object> {
     return this.http.get(`${this.config.baseUrl}${this.datasetHierarchyUrl}`).pipe(
       map(data => {
         this.datasetTreeNodes$.next(data);
-        if (onlyChildren) {
-          deleteFields(data);
-        }
         return data;
       })
     );
@@ -76,10 +60,6 @@ export class DatasetsTreeService {
       }
     }
     return undefined;
-  }
-
-  public getDatasetTreeNodes(): object {
-    return this.datasetTreeNodes$.getValue();
   }
 
   public async getUniqueLeafNodes(dataset: string): Promise<Set<string>> {

--- a/src/app/datasets/datasets-tree.service.ts
+++ b/src/app/datasets/datasets-tree.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ConfigService } from '../config/config.service';
+import { map, tap } from 'rxjs/operators';
+import { DatasetNode } from 'app/dataset-node/dataset-node';
+
+@Injectable()
+export class DatasetsTreeService {
+  private readonly datasetHierarchyUrl = 'datasets/hierarchy';
+  private datasetTreeNodes$: BehaviorSubject<object> = new BehaviorSubject<object>(null);
+
+  public constructor(
+    private http: HttpClient,
+    private config: ConfigService
+  ) {
+    this.getDatasetHierarchy().subscribe(
+      data => {
+        tap(() => {
+          this.datasetTreeNodes$.next(data);
+        });
+      }
+    );
+  }
+
+  public getDatasetHierarchy(onlyChildren = true): Observable<object> {
+    const deleteFields = (obj: object): void => {
+      if (obj === null || obj === undefined) {
+        return;
+      }
+      Object.keys(obj).forEach((key) => {
+        if (key === 'access_rights' || key === 'name') {
+          delete obj[key];
+        } else if (typeof obj[key] === 'object') {
+          deleteFields(obj[key] as object);
+        }
+      });
+    };
+
+    return this.http.get(`${this.config.baseUrl}${this.datasetHierarchyUrl}`).pipe(
+      map(data => {
+        this.datasetTreeNodes$.next(data);
+        if (onlyChildren) {
+          deleteFields(data);
+        }
+        return data;
+      })
+    );
+  }
+
+  public findNodeById(node: DatasetNode, id: string): DatasetNode | undefined {
+    if (node.dataset.id === id) {
+      return node;
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        const foundNode = this.findNodeById(child, id);
+        if (foundNode) {
+          return foundNode;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  public findHierarchyNode(node: object, id: string): object | undefined {
+    if (node['dataset'] === id) {
+      return node;
+    }
+    if (node['children']) {
+      for (const child of node['children']) {
+        const foundNode = this.findHierarchyNode(child as object, id);
+        if (foundNode) {
+          return foundNode;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  public getDatasetTreeNodes(): object {
+    return this.datasetTreeNodes$.getValue();
+  }
+
+  public async getUniqueLeafNodes(dataset: string): Promise<Set<string>> {
+    const uniqueLeafNodes = new Set<string>();
+    const subject = new Set<string>();
+    await new Promise<void>(resolve => {
+      this.datasetTreeNodes$.subscribe(datasetTreeNodes => {
+        if (datasetTreeNodes) {
+          for (const node of datasetTreeNodes['data']) {
+            const matchingNode = this.findHierarchyNode(node as object, dataset);
+            if (matchingNode) {
+              this.addAllLeafNodes(matchingNode, uniqueLeafNodes);
+            }
+          }
+          uniqueLeafNodes.forEach(node => subject.add(node));
+          resolve();
+        }
+      });
+    });
+    return subject;
+  }
+
+  private addAllLeafNodes(node: object, leafNodes: Set<string>): void {
+    if (!node) {
+      return;
+    }
+
+    if (node['children'] && (node['children'] as ArrayLike<object>).length > 0) {
+      for (const child of node['children']) {
+        this.addAllLeafNodes(child as object, leafNodes);
+      }
+    } else {
+      leafNodes.add(node['dataset'] as string);
+    }
+  }
+}

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -20,6 +20,7 @@ import { GenePlotComponent } from 'app/gene-plot/gene-plot.component';
 import { GenotypePreviewTableComponent } from 'app/genotype-preview-table/genotype-preview-table.component';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpResponse } from '@angular/common/http';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 
 jest.mock('../utils/svg-drawing');
 
@@ -95,7 +96,7 @@ describe('GeneBrowserComponent', () => {
         GenotypePreviewTableComponent, SearchableSelectComponent
       ],
       providers: [
-        ConfigService, UsersService, FullscreenLoadingService,
+        ConfigService, UsersService, DatasetsTreeService, FullscreenLoadingService,
         {provide: QueryService, useValue: mockQueryService},
         {provide: ActivatedRoute, useValue: new MockActivatedRoute()},
         {provide: GeneService, useValue: new MockGeneService()},

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -127,8 +127,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.interruptSummaryVariants$.next(true);
     });
 
-    const childleaves = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
-    if (childleaves.size > 1) {
+    const childLeaves = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
+    if (childLeaves.size > 1) {
       this.isUniqueFamilyFilterEnabled = true;
     }
   }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -127,8 +127,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.interruptSummaryVariants$.next(true);
     });
 
-    const childLeafes = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
-    if (childLeafes.size > 1) {
+    const childleaves = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
+    if (childleaves.size > 1) {
       this.isUniqueFamilyFilterEnabled = true;
     }
   }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -16,6 +16,7 @@ import * as d3 from 'd3';
 import * as draw from 'app/utils/svg-drawing';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { LGDS, CNV, OTHER, CODING } from 'app/effect-types/effect-types';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 
 @Component({
   selector: 'gpf-gene-browser',
@@ -68,13 +69,14 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     private geneService: GeneService,
     private datasetsService: DatasetsService,
     private loadingService: FullscreenLoadingService,
-    private router: Router
+    private router: Router,
+    private datasetsTreeService: DatasetsTreeService
   ) {
   }
 
   public variantsCountDisplay: string;
 
-  public ngOnInit(): void {
+  public async ngOnInit(): Promise<void> {
     this.selectedDataset = this.datasetsService.getSelectedDataset();
     this.legend = this.selectedDataset.personSetCollections.getLegend(this.selectedDataset.defaultPersonSetCollection);
     this.geneBrowserConfig = this.selectedDataset.geneBrowser;
@@ -125,7 +127,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.interruptSummaryVariants$.next(true);
     });
 
-    if (this.selectedDataset.studies?.length) {
+    const childLeafes = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
+    if (childLeafes.size > 1) {
       this.isUniqueFamilyFilterEnabled = true;
     }
   }

--- a/src/app/study-filters/study-filters.component.spec.ts
+++ b/src/app/study-filters/study-filters.component.spec.ts
@@ -15,6 +15,7 @@ import { APP_BASE_HREF } from '@angular/common';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { RouterModule } from '@angular/router';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const datasetConfigMock: any = {
@@ -41,7 +42,7 @@ describe('StudyFiltersComponent', () => {
         NgbNavModule, NgbModule, FormsModule,
         {provide: DatasetsComponent, useValue: DatasetsComponentMock},
         UsersService, ConfigService, { provide: APP_BASE_HREF, useValue: '' },
-        DatasetsService
+        DatasetsService, DatasetsTreeService
       ],
       imports: [
         NgbNavModule, NgbModule, FormsModule,

--- a/src/app/study-filters/study-filters.component.ts
+++ b/src/app/study-filters/study-filters.component.ts
@@ -9,8 +9,8 @@ import { SetNotEmpty } from 'app/utils/set.validators';
 import { Validate } from 'class-validator';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 import { DatasetsService } from 'app/datasets/datasets.service';
-import { findNodeById } from 'app/treelist-checkbox/treelist-checkbox.component';
 import { Subscription } from 'rxjs/internal/Subscription';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 
 @Component({
   selector: 'gpf-study-filters-block',
@@ -27,7 +27,9 @@ export class StudyFiltersComponent extends StatefulComponent implements OnInit, 
 
   @ViewChild('nav') public ngbNav: NgbNav;
 
-  public constructor(protected store: Store, public datasets: DatasetsService) {
+  public constructor(
+    protected store: Store, public datasets: DatasetsService, private datasetsTreeService: DatasetsTreeService
+  ) {
     super(store, StudyFiltersState, 'studyFilters');
   }
 
@@ -42,7 +44,7 @@ export class StudyFiltersComponent extends StatefulComponent implements OnInit, 
         datasetTrees.push(new DatasetNode(d, datasets));
       });
       for (const tree of datasetTrees) {
-        const node = findNodeById(tree, this.dataset.id);
+        const node = this.datasetsTreeService.findNodeById(tree, this.dataset.id);
         if (node) {
           this.rootDataset = node;
           break;

--- a/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
+++ b/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 import { Dataset } from 'app/datasets/datasets';
-import { StudyFiltersTreeComponent, findNodeById } from './treelist-checkbox.component';
+import { StudyFiltersTreeComponent } from './treelist-checkbox.component';
 import { FormsModule } from '@angular/forms';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
+import { HttpClientModule } from '@angular/common/http';
+import { ConfigService } from 'app/config/config.service';
 
 const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
   null, null, ['id11', 'id12'], null, null, null, null, null,
@@ -31,8 +34,9 @@ describe('StudyFiltersTreeComponent', () => {
 
   beforeEach(async() => {
     await TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [StudyFiltersTreeComponent]
+      imports: [FormsModule, HttpClientModule],
+      declarations: [StudyFiltersTreeComponent],
+      providers: [DatasetsTreeService, ConfigService]
     }).compileComponents();
 
     fixture = TestBed.createComponent(StudyFiltersTreeComponent);
@@ -62,30 +66,5 @@ describe('StudyFiltersTreeComponent', () => {
     expect(component.getAllChildren([
       datasetNodeMock1, datasetNodeMock2
     ])).toStrictEqual(new Set<string>(['id2', 'id3']));
-  });
-
-  it('should test find node by id', () => {
-    expect(findNodeById(datasetNodeMock1, 'id3')).toStrictEqual(new DatasetNode(
-      new Dataset(
-        'id3',
-        null, null, ['id1', 'parent3'], null, null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null, null
-      ), [
-        new Dataset(
-          'id2',
-          null, null, ['id1', 'parent2'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
-        ),
-        new Dataset(
-          'id3',
-          null, null, ['id1', 'parent3'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
-        ),
-        new Dataset(
-          'id4',
-          null, null, ['id4', 'parent4'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
-        )]
-    ));
   });
 });

--- a/src/app/treelist-checkbox/treelist-checkbox.component.ts
+++ b/src/app/treelist-checkbox/treelist-checkbox.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 @Component({
   selector: 'gpf-treelist-checkbox',
   templateUrl: './treelist-checkbox.component.html',
@@ -14,6 +15,8 @@ export class StudyFiltersTreeComponent implements OnInit, OnChanges {
   @Input()
   public selectedStudies: Set<string>;
 
+  public constructor(private datasetsTreeService: DatasetsTreeService) {}
+
   public ngOnInit(): void {
     this.selectedStudies?.clear();
     this.updateFilterStates(this.data);
@@ -25,7 +28,7 @@ export class StudyFiltersTreeComponent implements OnInit, OnChanges {
 
   /* eslint-disable */
   public updateFilters($event): void {
-    const datasetNode = findNodeById(this.data, $event.target.getAttribute('id'));
+    const datasetNode = this.datasetsTreeService.findNodeById(this.data, $event.target.getAttribute('id'));
     if ($event.target.checked) {
       if (datasetNode.children.length > 0) {
         this.getAllChildren(datasetNode.children).forEach(child => {
@@ -94,21 +97,4 @@ export class StudyFiltersTreeComponent implements OnInit, OnChanges {
     });
     return list;
   }
-}
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function findNodeById(node: DatasetNode, id: string): DatasetNode | undefined {
-  if (node.dataset.id === id) {
-    return node;
-  }
-
-  if (node.children) {
-    for (const child of node.children) {
-      const foundNode = findNodeById(child, id);
-      if (foundNode) {
-        return foundNode;
-      }
-    }
-  }
-  return undefined;
 }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.spec.ts
@@ -4,6 +4,8 @@ import { NgxsModule } from '@ngxs/store';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { DatasetsService } from 'app/datasets/datasets.service';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
+import { ConfigService } from 'app/config/config.service';
 
 class DatasetsServiceMock {
   public getSelectedDataset(): object {
@@ -18,7 +20,7 @@ describe('UniqueFamilyVariantsFilterComponent', () => {
   beforeEach(async() => {
     await TestBed.configureTestingModule({
       declarations: [UniqueFamilyVariantsFilterComponent],
-      providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock()}],
+      providers: [{provide: DatasetsService, useValue: new DatasetsServiceMock()}, DatasetsTreeService, ConfigService],
       imports: [HttpClientModule, NgxsModule.forRoot([], {developmentMode: true}), FormsModule]
     }).compileComponents();
 

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -35,8 +35,8 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
-    const childLeafes = await this.datasetsTreeService.getUniqueLeafNodes(this.datasetService.getSelectedDataset().id);
-    if (childLeafes.size > 1) {
+    const childleaves = await this.datasetsTreeService.getUniqueLeafNodes(this.datasetService.getSelectedDataset().id);
+    if (childleaves.size > 1) {
       this.isVisible = true;
     }
   }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -4,6 +4,7 @@ import { UniqueFamilyVariantsFilterState, SetUniqueFamilyVariantsFilter } from '
 import { Validate, IsDefined } from 'class-validator';
 import { StatefulComponent } from '../common/stateful-component';
 import { DatasetsService } from 'app/datasets/datasets.service';
+import { DatasetsTreeService } from 'app/datasets/datasets-tree.service';
 
 @Component({
   selector: 'gpf-unique-family-variants-filter',
@@ -15,7 +16,11 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
   private enabled = false;
   public isVisible = false;
 
-  public constructor(protected store: Store, public datasetService: DatasetsService) {
+  public constructor(
+    protected store: Store,
+    public datasetService: DatasetsService,
+    private datasetsTreeService: DatasetsTreeService
+  ) {
     super(store, UniqueFamilyVariantsFilterState, 'uniqueFamilyVariantsFilter');
   }
 
@@ -25,12 +30,13 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     });
   }
 
-  public ngOnInit(): void {
+  public async ngOnInit(): Promise<void> {
     // restore state
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
-    if (this.datasetService.getSelectedDataset().studies?.length) {
+    const childLeafes = await this.datasetsTreeService.getUniqueLeafNodes(this.datasetService.getSelectedDataset().id);
+    if (childLeafes.size > 1) {
       this.isVisible = true;
     }
   }

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -35,8 +35,8 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     this.store.selectOnce(UniqueFamilyVariantsFilterState).subscribe(state => {
       this.filterValue = state.uniqueFamilyVariants;
     });
-    const childleaves = await this.datasetsTreeService.getUniqueLeafNodes(this.datasetService.getSelectedDataset().id);
-    if (childleaves.size > 1) {
+    const childLeaves = await this.datasetsTreeService.getUniqueLeafNodes(this.datasetService.getSelectedDataset().id);
+    if (childLeaves.size > 1) {
       this.isVisible = true;
     }
   }


### PR DESCRIPTION
## Background

This issue is related to task #845. Currently, there is a temp solution that doesn't really provide actual information if there is more than one study in a dataset if it is nested(for instance if there are multiple datasets only with one study).

## Aim

The idea is to provide a more interactive experience in which there could be more refactored dataset tree list structure instead of many dataset structures(such as dataset, dataset node, etc.).