### PR TITLE
make agp table load more genes #865

### DIFF
--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.ts
@@ -134,8 +134,10 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
     this.pageIndex = 1;
     this.loadMoreGenes = true;
     this.showNothingFound = false;
+    // In case of page zoom out where scroll will disappear, load more pages.
+    const initialPageCount = 4 * this.viewportPageCount;
 
-    for (let i = 1; i <= this.viewportPageCount; i++) {
+    for (let i = 1; i <= initialPageCount; i++) {
       agpRequests.push(
         this.autismGeneProfilesService
           .getGenes(this.pageIndex, this.geneInput, this.sortBy, this.orderBy)
@@ -143,7 +145,7 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
       );
       this.pageIndex++;
     }
-    this.pageIndex = this.viewportPageCount;
+    this.pageIndex = initialPageCount;
     this.getGenesSubscription.unsubscribe();
     this.getGenesSubscription = zip(agpRequests).subscribe(res => {
       this.genes = [];


### PR DESCRIPTION
## Background

Unzoomed screen which caused scroll to hide because content can fit inside the new viewport size, but that disables the logic that loads new pages.

## Aim

To fix the bug.

## Implementation

Increase initial page count that is loaded to prevent scroll from hiding.

closes #865 
