### PR TITLE
fix agp clear search input button

### DIFF
--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.html
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.html
@@ -127,7 +127,7 @@
             *ngIf="searchBox.value !== '' && !showSearchLoading"
             class="search-clear-icon"
             [style.background-image]="'url(' + imgPathPrefix + 'search-clear-icon.png)'"
-            (click)="searchBox.value = ''; search(searchBox.value); showSearchLoading = true">
+            (click)="searchBox.value = ''; searchKeystrokes$.next(searchBox.value); showSearchLoading = true">
           </span>
           <span
             *ngIf="showSearchLoading"


### PR DESCRIPTION
## Background

After clicking agp clear search button and type again the table doesn't show correct result.

## Aim

To fix it

## Implementation

Change called method when clear button is clicked.

closes #883 
