### PR TITLE
return sorting buttons to default state

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,5 +1,5 @@
-<div>
-    Logging in...
-    <br>
-    You will be redirected shortly.
+<div
+  >Logging in...
+  <br />
+  You will be redirected shortly.
 </div>

--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -45,13 +45,32 @@
         <gpf-table-subcontent>
           <span *gpfTableCellContent="let data">
             <ng-container *ngIf="data.measureType === 'continuous'">
-              <div title="[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]">
-                <span>[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},</span>
-                <span>{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]</span>
+              <div
+                title="[{{
+                  +data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(','))
+                    | numberWithExp : '1.3-3'
+                }},{{
+                  +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']'))
+                    | numberWithExp : '1.3-3'
+                }}]">
+                <span
+                  >[{{
+                    +data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(','))
+                      | numberWithExp : '1.3-3'
+                  }},</span
+                >
+                <span
+                  >{{
+                    +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']'))
+                      | numberWithExp : '1.3-3'
+                  }}]</span
+                >
               </div>
             </ng-container>
             <ng-container
-              *ngIf="data.measureType === 'categorical' || data.measureType === 'raw' || data.measureType === 'ordinal'">
+              *ngIf="
+                data.measureType === 'categorical' || data.measureType === 'raw' || data.measureType === 'ordinal'
+              ">
               <span *ngFor="let value of data.valuesDomain.split(', ')" title="[{{ value }}]">[{{ value }}]</span>
             </ng-container>
           </span>
@@ -96,9 +115,12 @@
             <span
               class="expanded-span"
               *gpfTableCellContent="let data"
-              [style.background-color]="data.regressions.getReg(regressionId).pvalueRegressionMale | getBackgroundColor">
-              <span [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'"
-                >{{data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'}}</span
+              [style.background-color]="
+                data.regressions.getReg(regressionId).pvalueRegressionMale | getBackgroundColor
+              ">
+              <span
+                [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'"
+                >{{ data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4' }}</span
               >
             </span>
           </gpf-table-subcontent>

--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -1,119 +1,122 @@
-<gpf-table [dataSource]="measures.measures" style="display: inline-block; min-width: 1200px">
-  <gpf-table-column [columnWidth]="singleColumnWidth">
-    <gpf-table-header caption="Instrument" field="instrumentName"></gpf-table-header>
-    <gpf-table-content>
-      <span *gpfTableCellContent="let data">
-        <div [attr.title]="data.instrumentName">{{ data.instrumentName }}</div>
-      </span>
-    </gpf-table-content>
-  </gpf-table-column>
-  <gpf-table-column [columnWidth]="singleColumnWidth">
-    <gpf-table-header caption="Proband Pheno Measure" field="measureName"></gpf-table-header>
-    <gpf-table-content>
-      <span *gpfTableCellContent="let data">
-        <div [attr.title]="data.measureName">{{ data.measureName }}</div>
-      </span>
-    </gpf-table-content>
-  </gpf-table-column>
-  <gpf-table-column *ngIf="measures.hasDescriptions">
-    <gpf-table-header caption="Measure Description" field="description"></gpf-table-header>
-    <gpf-table-content>
-      <span *gpfTableCellContent="let data">
-        <div [attr.title]="data.description">{{ data.description }}</div>
-      </span>
-    </gpf-table-content>
-  </gpf-table-column>
-  <gpf-table-column [columnWidth]="singleColumnWidth">
-    <gpf-table-header caption="Pheno Measure Values"></gpf-table-header>
-    <gpf-table-content>
-      <span *gpfTableCellContent="let data">
-        <a [class.clickable]="!!data.figureDistribution" (click)="openModal(data.figureDistribution)">
-          <img *ngIf="data.figureDistributionSmall" class="table-chart" [src]="data.figureDistributionSmall" />
-        </a>
-      </span>
-    </gpf-table-content>
-  </gpf-table-column>
-  <gpf-table-column [columnWidth]="singleColumnWidth">
-    <gpf-table-header>
-      <gpf-table-subheader caption="Measure Type" field="measureType"></gpf-table-subheader>
-      <gpf-table-subheader caption="Values Domain"></gpf-table-subheader>
-    </gpf-table-header>
-    <gpf-table-content>
-      <gpf-table-subcontent field="measureType"></gpf-table-subcontent>
-      <gpf-table-subcontent>
-        <span *gpfTableCellContent="let data">
-          <ng-container *ngIf="data.measureType === 'continuous'">
-            <div title="[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]">
-              <span>[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},</span>
-              <span>{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]</span>
-            </div>
-          </ng-container>
-          <ng-container
-            *ngIf="data.measureType === 'categorical' || data.measureType === 'raw' || data.measureType === 'ordinal'">
-            <span *ngFor="let value of data.valuesDomain.split(', ')" title="[{{ value }}]">[{{ value }}]</span>
-          </ng-container>
-        </span>
-      </gpf-table-subcontent>
-    </gpf-table-content>
-  </gpf-table-column>
-  <ng-container *ngFor="let regressionId of measures.regressionNames | getRegressionIds">
+<ng-container #viewContainerRef [ngTemplateOutlet]="templateRef"></ng-container>
+<ng-template #templateRef>
+  <gpf-table [dataSource]="measures.measures" style="display: inline-block; min-width: 1200px">
     <gpf-table-column [columnWidth]="singleColumnWidth">
-      <gpf-table-header
-        caption="Regression by {{
-          measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
-        }}"></gpf-table-header>
+      <gpf-table-header caption="Instrument" field="instrumentName"></gpf-table-header>
       <gpf-table-content>
         <span *gpfTableCellContent="let data">
-          <a
-            [class.clickable]="!!data.regressions.getReg(regressionId).figureRegression"
-            (click)="openModal(data.regressions.getReg(regressionId).figureRegression)">
-            <img
-              *ngIf="data.regressions.getReg(regressionId).figureRegressionSmall"
-              class="table-chart"
-              [src]="data.regressions.getReg(regressionId).figureRegressionSmall" />
+          <div [attr.title]="data.instrumentName">{{ data.instrumentName }}</div>
+        </span>
+      </gpf-table-content>
+    </gpf-table-column>
+    <gpf-table-column [columnWidth]="singleColumnWidth">
+      <gpf-table-header caption="Proband Pheno Measure" field="measureName"></gpf-table-header>
+      <gpf-table-content>
+        <span *gpfTableCellContent="let data">
+          <div [attr.title]="data.measureName">{{ data.measureName }}</div>
+        </span>
+      </gpf-table-content>
+    </gpf-table-column>
+    <gpf-table-column *ngIf="measures.hasDescriptions">
+      <gpf-table-header caption="Measure Description" field="description"></gpf-table-header>
+      <gpf-table-content>
+        <span *gpfTableCellContent="let data">
+          <div [attr.title]="data.description">{{ data.description }}</div>
+        </span>
+      </gpf-table-content>
+    </gpf-table-column>
+    <gpf-table-column [columnWidth]="singleColumnWidth">
+      <gpf-table-header caption="Pheno Measure Values"></gpf-table-header>
+      <gpf-table-content>
+        <span *gpfTableCellContent="let data">
+          <a [class.clickable]="!!data.figureDistribution" (click)="openModal(data.figureDistribution)">
+            <img *ngIf="data.figureDistributionSmall" class="table-chart" [src]="data.figureDistributionSmall" />
           </a>
         </span>
       </gpf-table-content>
     </gpf-table-column>
     <gpf-table-column [columnWidth]="singleColumnWidth">
-      <gpf-table-header
-        caption="{{
-          measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
-        }} PV">
-        <gpf-table-subheader
-          caption="male"
-          field="pvalueRegressionMale"
-          [comparator]="regressionId | regressionComparePipe : 'pvalueRegressionMale'"></gpf-table-subheader>
-        <gpf-table-subheader
-          caption="female"
-          field="pvalueRegressionFemale"
-          [comparator]="regressionId | regressionComparePipe : 'pvalueRegressionFemale'"></gpf-table-subheader>
+      <gpf-table-header>
+        <gpf-table-subheader caption="Measure Type" field="measureType"></gpf-table-subheader>
+        <gpf-table-subheader caption="Values Domain"></gpf-table-subheader>
       </gpf-table-header>
       <gpf-table-content>
+        <gpf-table-subcontent field="measureType"></gpf-table-subcontent>
         <gpf-table-subcontent>
-          <span
-            class="expanded-span"
-            *gpfTableCellContent="let data"
-            [style.background-color]="data.regressions.getReg(regressionId).pvalueRegressionMale | getBackgroundColor">
-            <span [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'"
-              >{{data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'}}</span
-            >
-          </span>
-        </gpf-table-subcontent>
-        <gpf-table-subcontent>
-          <span
-            class="expanded-span"
-            *gpfTableCellContent="let data"
-            [style.background-color]="
-              data.regressions.getReg(regressionId).pvalueRegressionFemale | getBackgroundColor
-            ">
-            <span
-              [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionFemale | numberWithExp : '1.2-4'"
-              >{{ data.regressions.getReg(regressionId).pvalueRegressionFemale | numberWithExp : '1.2-4' }}</span
-            >
+          <span *gpfTableCellContent="let data">
+            <ng-container *ngIf="data.measureType === 'continuous'">
+              <div title="[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]">
+                <span>[{{+data.valuesDomain.slice(data.valuesDomain.indexOf('[') + 1, data.valuesDomain.indexOf(',')) | numberWithExp : '1.3-3' }},</span>
+                <span>{{ +data.valuesDomain.slice(data.valuesDomain.indexOf(',') + 1, data.valuesDomain.indexOf(']')) | numberWithExp : '1.3-3' }}]</span>
+              </div>
+            </ng-container>
+            <ng-container
+              *ngIf="data.measureType === 'categorical' || data.measureType === 'raw' || data.measureType === 'ordinal'">
+              <span *ngFor="let value of data.valuesDomain.split(', ')" title="[{{ value }}]">[{{ value }}]</span>
+            </ng-container>
           </span>
         </gpf-table-subcontent>
       </gpf-table-content>
     </gpf-table-column>
-  </ng-container>
-</gpf-table>
+    <ng-container *ngFor="let regressionId of measures.regressionNames | getRegressionIds">
+      <gpf-table-column [columnWidth]="singleColumnWidth">
+        <gpf-table-header
+          caption="Regression by {{
+            measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
+          }}"></gpf-table-header>
+        <gpf-table-content>
+          <span *gpfTableCellContent="let data">
+            <a
+              [class.clickable]="!!data.regressions.getReg(regressionId).figureRegression"
+              (click)="openModal(data.regressions.getReg(regressionId).figureRegression)">
+              <img
+                *ngIf="data.regressions.getReg(regressionId).figureRegressionSmall"
+                class="table-chart"
+                [src]="data.regressions.getReg(regressionId).figureRegressionSmall" />
+            </a>
+          </span>
+        </gpf-table-content>
+      </gpf-table-column>
+      <gpf-table-column [columnWidth]="singleColumnWidth">
+        <gpf-table-header
+          caption="{{
+            measures.regressionNames[regressionId] ? measures.regressionNames[regressionId] : regressionId
+          }} PV">
+          <gpf-table-subheader
+            caption="male"
+            field="pvalueRegressionMale"
+            [comparator]="regressionId | regressionComparePipe : 'pvalueRegressionMale'"></gpf-table-subheader>
+          <gpf-table-subheader
+            caption="female"
+            field="pvalueRegressionFemale"
+            [comparator]="regressionId | regressionComparePipe : 'pvalueRegressionFemale'"></gpf-table-subheader>
+        </gpf-table-header>
+        <gpf-table-content>
+          <gpf-table-subcontent>
+            <span
+              class="expanded-span"
+              *gpfTableCellContent="let data"
+              [style.background-color]="data.regressions.getReg(regressionId).pvalueRegressionMale | getBackgroundColor">
+              <span [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'"
+                >{{data.regressions.getReg(regressionId).pvalueRegressionMale | numberWithExp : '1.2-4'}}</span
+              >
+            </span>
+          </gpf-table-subcontent>
+          <gpf-table-subcontent>
+            <span
+              class="expanded-span"
+              *gpfTableCellContent="let data"
+              [style.background-color]="
+                data.regressions.getReg(regressionId).pvalueRegressionFemale | getBackgroundColor
+              ">
+              <span
+                [attr.title]="data.regressions.getReg(regressionId).pvalueRegressionFemale | numberWithExp : '1.2-4'"
+                >{{ data.regressions.getReg(regressionId).pvalueRegressionFemale | numberWithExp : '1.2-4' }}</span
+              >
+            </span>
+          </gpf-table-subcontent>
+        </gpf-table-content>
+      </gpf-table-column>
+    </ng-container>
+  </gpf-table>
+</ng-template>

--- a/src/app/pheno-browser-table/pheno-browser-table.component.ts
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.ts
@@ -1,4 +1,6 @@
-import { OnInit, Component, HostListener, Input } from '@angular/core';
+import {
+  OnInit, Component, HostListener, Input, OnChanges, TemplateRef, ViewContainerRef, ViewChild
+} from '@angular/core';
 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -11,8 +13,10 @@ import { PhenoMeasures } from '../pheno-browser/pheno-browser';
   templateUrl: './pheno-browser-table.component.html',
   styleUrls: ['./pheno-browser-table.component.css']
 })
-export class PhenoBrowserTableComponent implements OnInit {
+export class PhenoBrowserTableComponent implements OnInit, OnChanges {
   @Input() public measures: PhenoMeasures;
+  @ViewChild('templateRef', { read: TemplateRef }) private templateRef: TemplateRef<Element>;
+  @ViewChild('viewContainerRef', { read: ViewContainerRef }) private viewContainerRef: ViewContainerRef;
 
   public singleColumnWidth;
   private columnsCount = 8;
@@ -23,6 +27,11 @@ export class PhenoBrowserTableComponent implements OnInit {
 
   public ngOnInit(): void {
     this.onResize();
+  }
+
+  public ngOnChanges(): void {
+    this.viewContainerRef?.clear();
+    this.viewContainerRef?.createEmbeddedView(this.templateRef);
   }
 
   public static compare(leftVal: any, rightVal: any): number {


### PR DESCRIPTION
when changing instrument in phenotype browser #848

## Background

When changing instrument the sorting buttons doesn't return to default state and the new instrument is not sorted.

## Aim

To reset sorting buttons when new instument is selected.

## Implementation

Creating new view when selecting new instrument which guarantees that the sorting buttons will be in their default state and clearing the old view.

closes #848 
