### PR TITLE
Add keyboard navigation in dropdowns

### DIFF
--- a/src/app/gene-browser/gene-browser.component.css
+++ b/src/app/gene-browser/gene-browser.component.css
@@ -103,3 +103,7 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+::ng-deep .dropdown-item:focus {
+  outline: none;
+}

--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -6,7 +6,7 @@
     <div class="card-block">
       <div ngbDropdown class="input-group panel" style="padding: 15px; align-items: baseline">
         <input
-          ngbDropdownAnchor
+          ngbDropdownToggle
           #searchBox
           id="search-box"
           placeholder="Search gene"
@@ -20,6 +20,7 @@
 
         <div ngbDropdownMenu id="genes-dropdown">
           <button
+            ngbDropdownItem
             *ngFor="let suggestion of geneSymbolSuggestions"
             class="dropdown-item"
             type="button"

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -143,6 +143,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   public reset(): void {
+    this.dropdown.close();
     this.showResults = false;
     this.location.replaceState(`datasets/${this.selectedDatasetId}/gene-browser`);
   }

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.css
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.css
@@ -12,3 +12,7 @@
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
+
+::ng-deep .dropdown-item:focus {
+  outline: none;
+}

--- a/src/app/pheno-measure-selector/pheno-measure-selector.component.html
+++ b/src/app/pheno-measure-selector/pheno-measure-selector.component.html
@@ -1,5 +1,6 @@
 <div ngbDropdown class="input-group" style="display: inline-flex; flex-wrap: nowrap">
   <input
+    ngbDropdownToggle
     ngbDropdownAnchor
     #searchBox
     id="search-box"
@@ -18,6 +19,7 @@
     </ng-container>
 
     <button
+      ngbDropdownItem
       *ngFor="let measure of filteredMeasures"
       class="dropdown-item"
       type="button"

--- a/src/app/searchable-select/searchable-select.component.html
+++ b/src/app/searchable-select/searchable-select.component.html
@@ -1,5 +1,6 @@
 <div ngbDropdown role="group" style="display: inline-flex; flex-wrap: nowrap; width: 100%" placement="bottom-right">
   <input
+    ngbDropdownToggle
     [hidden]="caption"
     #searchBox
     id="search-box"
@@ -32,6 +33,7 @@
   <div ngbDropdownMenu style="width: 100%; overflow-x: hidden; max-height: 300px; overflow-y: scroll; z-index: 150">
     <div id="loading-dropdown-text" *ngIf="data.length === 0 && searchBox.value !== ''">Nothing found</div>
     <button
+      ngbDropdownItem
       *ngFor="let element of data"
       class="dropdown-item"
       type="button"

--- a/src/app/searchable-select/searchable-select.css
+++ b/src/app/searchable-select/searchable-select.css
@@ -34,3 +34,7 @@
 #search-box:disabled {
   background-color: rgb(239, 239, 239);
 }
+
+::ng-deep .dropdown-item:focus {
+  outline: none;
+}

--- a/src/app/user-groups-selector/user-groups-selector.component.html
+++ b/src/app/user-groups-selector/user-groups-selector.component.html
@@ -11,7 +11,9 @@
     <div style="margin-top: 5px">
       <div class="col-12">
         <div ngbDropdown class="d-inline-block" autoClose="outside" placement="bottom-left">
-          <button class="btn btn-light" id="create-group-btn" (click)="focusGroupNameInput()" ngbDropdownToggle>Create group</button>
+          <button class="btn btn-light" id="create-group-btn" (click)="focusGroupNameInput()" ngbDropdownToggle
+            >Create group</button
+          >
           <div ngbDropdownMenu>
             <form style="margin: 10px">
               <div class="form-group">


### PR DESCRIPTION
## Background

Currently ngbdropdowns can't be iterated with keyboard arrows.

## Aim

To enable keyboard navigation with arrows.

## Implementation

Mark dropdown items as 'ngbDropdownItem' and change the design of the focused element. (added to selectable search component, gene browser search and proband pheno measure selector)

closes #825 

