### PR TITLE
update font awesome verison

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@angular/platform-browser": "15.1.0",
     "@angular/platform-browser-dynamic": "15.1.0",
     "@angular/router": "15.1.0",
+    "@fortawesome/fontawesome-free": "6.4.2",
     "@ng-bootstrap/ng-bootstrap": "14.0.1",
     "@ngxs/store": "3.7.6",
     "@types/d3": "7.4.0",
@@ -45,7 +46,6 @@
     "dompurify": "2.4.3",
     "element-resize-detector": "1.2.4",
     "file-saver": "2.0.5",
-    "font-awesome": "4.7.0",
     "jquery": "3.6.3",
     "lodash": "4.17.21",
     "ng-multiselect-dropdown": "0.3.9",
@@ -72,6 +72,8 @@
     "@angular-eslint/template-parser": "15.2.0",
     "@angular/cli": "15.1.1",
     "@angular/compiler-cli": "15.1.0",
+    "@sentry/angular-ivy": "7.41.0",
+    "@sentry/tracing": "7.41.0",
     "@types/jest": "^28.0.0",
     "@typescript-eslint/eslint-plugin": "5.48.2",
     "@typescript-eslint/parser": "5.48.2",
@@ -89,9 +91,7 @@
     "prettier": "2.8.3",
     "stylelint": "14.16.1",
     "stylelint-config-standard": "29.0.0",
-    "typescript": "4.9.4",
-    "@sentry/angular-ivy": "7.41.0",
-    "@sentry/tracing": "7.41.0"
+    "typescript": "4.9.4"
   },
   "browserslist": [
     "defaults",


### PR DESCRIPTION
## Background

Font awesome version was old (we were using version 4 from 2016).

## Aim

To update the version.

## Implementation

Updated to the last version which is 6 by installing the module @fortawesome/fontawesome-free.

closes #833 