### PR TITLE
make dropdown disabled when changing collection

### DIFF
--- a/src/app/gene-sets/gene-sets.component.html
+++ b/src/app/gene-sets/gene-sets.component.html
@@ -7,6 +7,7 @@
           title="{{ selectedGeneSetsCollection.desc }}"
           [(ngModel)]="selectedGeneSetsCollection"
           required
+          (change)="isLoading = true"
           id="selected-collection">
           <option *ngFor="let collection of geneSetsCollections" [ngValue]="collection">{{ collection.desc }}</option>
         </select>


### PR DESCRIPTION
in gene sets

## Background

When changing collection in gene sets and click immediately on the input, the dropdown data might be sets of the previous collection.

## Aim

To fix it.

## Implementation

Disable dropdown when changing collection.