### PR TITLE
Disable dataset description editing

### DIFF
--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -6,7 +6,7 @@
       </div>
       <div id="edit-description">
         <markdown id="markdown-id" [data]="dataset.description || ''"></markdown>
-        <div *ngIf="!editMode">
+        <div *ngIf="!editMode && isDescriptionEditable">
           <div style="position: relative">
             <i
               *ngIf="('' | userInfo)?.isAdministrator"

--- a/src/app/dataset-description/dataset-description.component.ts
+++ b/src/app/dataset-description/dataset-description.component.ts
@@ -22,6 +22,7 @@ export class DatasetDescriptionComponent implements OnInit {
   public editMode = false;
   public editorText: string;
   private initialDatasetDescription: string;
+  public isDescriptionEditable: boolean;
 
   public editorOptions: EditorOption = {
     autofocus: true,
@@ -63,6 +64,7 @@ export class DatasetDescriptionComponent implements OnInit {
       } else {
         this.editorText = dataset.description;
         this.initialDatasetDescription = dataset.description;
+        this.isDescriptionEditable = dataset.descriptionEditable;
       }
       this.loading = false;
     });

--- a/src/app/dataset-node/dataset-node.spec.ts
+++ b/src/app/dataset-node/dataset-node.spec.ts
@@ -76,7 +76,8 @@ const datasetMock = new Dataset(
   ],
   new GeneBrowser(true, 'frequencyCol1', 'frequencyName1', 'effectCol1', 'locationCol1', 5, 6, true),
   false,
-  'genome1'
+  'genome1',
+  true
 );
 
 describe('DatasetNode', () => {

--- a/src/app/datasets/datasets-tree.service.spec.ts
+++ b/src/app/datasets/datasets-tree.service.spec.ts
@@ -11,22 +11,22 @@ import { DatasetNode } from 'app/dataset-node/dataset-node';
 
 const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
   null, null, ['id11', 'id12'], null, null, null, null, null,
-  null, null, null, null, null, null, null, null, null, null, null
+  null, null, null, null, null, null, null, null, null, null, null, null
 ), [
   new Dataset(
     'id2',
     null, null, ['id1', 'parent2'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id3',
     null, null, ['id1', 'parent3'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id4',
     null, null, ['id4', 'parent4'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   )
 ]);
 
@@ -57,22 +57,22 @@ describe('DatasetService', () => {
       new Dataset(
         'id3',
         null, null, ['id1', 'parent3'], null, null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null, null
+        null, null, null, null, null, null, null, null, null, null, null, null
       ), [
         new Dataset(
           'id2',
           null, null, ['id1', 'parent2'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
+          null, null, null, null, null, null, null, null, null, null, null, null
         ),
         new Dataset(
           'id3',
           null, null, ['id1', 'parent3'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
+          null, null, null, null, null, null, null, null, null, null, null, null
         ),
         new Dataset(
           'id4',
           null, null, ['id4', 'parent4'], null, null, null, null, null,
-          null, null, null, null, null, null, null, null, null, null, null
+          null, null, null, null, null, null, null, null, null, null, null, null
         )]
     ));
   });

--- a/src/app/datasets/datasets.component.spec.ts
+++ b/src/app/datasets/datasets.component.spec.ts
@@ -70,7 +70,8 @@ const mockDataset1 = new Dataset(
   ],
   new GeneBrowser(true, 'frequencyCol1', 'frequencyName1', 'effectCol1', 'locationCol1', 5, 6, true),
   false,
-  'genome1'
+  'genome1',
+  true
 );
 
 describe('DatasetComponent', () => {

--- a/src/app/datasets/datasets.spec.ts
+++ b/src/app/datasets/datasets.spec.ts
@@ -565,7 +565,8 @@ describe('Dataset', () => {
     ],
     new GeneBrowser(true, 'frequencyCol1', 'frequencyName1', 'effectCol1', 'locationCol1', 5, 6, true),
     false,
-    'genome1'
+    'genome1',
+    true
   );
 
   const datasetMock2 = new Dataset(
@@ -643,7 +644,8 @@ describe('Dataset', () => {
     ],
     new GeneBrowser(false, 'frequencyCol6', 'frequencyName7', 'effectCol4', 'locationCol2', 7, 8, true),
     true,
-    'genome2'
+    'genome2',
+    true
   );
 
   /* eslint-disable */
@@ -799,7 +801,8 @@ describe('Dataset', () => {
       has_affected_status: true
     },
     has_denovo: false,
-    genome: 'genome1'
+    genome: 'genome1',
+    description_editable: true
   };
 
   const datasetJson2 = {
@@ -953,7 +956,8 @@ describe('Dataset', () => {
       has_affected_status: true
     },
     has_denovo: true,
-    genome: 'genome2'
+    genome: 'genome2',
+    description_editable: true
   };
   /* eslint-enable */
 
@@ -977,6 +981,7 @@ describe('Dataset', () => {
     const datasetMockFromJson = Dataset.fromDatasetAndDetailsJson({
       id: 'id1',
       description: 'desc1',
+      description_editable: true,
       name: 'name1',
       parents: ['parent1', 'parent2'],
       access_rights: false,
@@ -1120,7 +1125,7 @@ describe('Dataset', () => {
       },
     }, {
       has_denovo: false,
-      genome: 'genome1'
+      genome: 'genome1',
     });
     /* eslint-enable */
 

--- a/src/app/datasets/datasets.ts
+++ b/src/app/datasets/datasets.ts
@@ -264,7 +264,8 @@ export class Dataset extends IdName {
       UserGroup.fromJsonArray(json['groups'] as object[]),
       json['gene_browser'] ? GeneBrowser.fromJson(json['gene_browser'] as object) : null,
       json['has_denovo'] as boolean,
-      json['genome'] as string
+      json['genome'] as string,
+      json['description_editable'] as boolean
     );
   }
 
@@ -294,7 +295,8 @@ export class Dataset extends IdName {
       UserGroup.fromJsonArray(datasetJson['groups'] as object[]),
       datasetJson['gene_browser'] ? GeneBrowser.fromJson(datasetJson['gene_browser'] as object) : null,
       detailsJson['has_denovo'] as boolean,
-      detailsJson['genome'] as string
+      detailsJson['genome'] as string,
+      datasetJson['description_editable'] as boolean
     );
   }
 
@@ -333,7 +335,8 @@ export class Dataset extends IdName {
     public readonly groups: UserGroup[],
     public readonly geneBrowser: GeneBrowser,
     public readonly hasDenovo: boolean,
-    public readonly genome: string
+    public readonly genome: string,
+    public readonly descriptionEditable: boolean
   ) {
     super(id, name);
   }

--- a/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
+++ b/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
@@ -9,22 +9,22 @@ import { ConfigService } from 'app/config/config.service';
 
 const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
   null, null, ['id11', 'id12'], null, null, null, null, null,
-  null, null, null, null, null, null, null, null, null, null, null
+  null, null, null, null, null, null, null, null, null, null, null, null
 ), [
   new Dataset(
     'id2',
     null, null, ['id1', 'parent2'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id3',
     null, null, ['id1', 'parent3'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id4',
     null, null, ['id4', 'parent4'], null, null, null, null, null,
-    null, null, null, null, null, null, null, null, null, null, null
+    null, null, null, null, null, null, null, null, null, null, null, null
   )
 ]);
 
@@ -54,12 +54,12 @@ describe('StudyFiltersTreeComponent', () => {
     const datasetNodeMock2 = new DatasetNode(new Dataset(
       'id2',
       null, null, ['id21', 'id22'], null, null, null, null, null,
-      null, null, null, null, null, null, null, null, null, null, null
+      null, null, null, null, null, null, null, null, null, null, null, null
     ), [
       new Dataset(
         'id4',
         null, null, ['id23', 'id24'], null, null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null, null
+        null, null, null, null, null, null, null, null, null, null, null, null
       )
     ]);
 


### PR DESCRIPTION
## Background

Editing dataset description is not supported in federation instance, so a new variable ` description_editable` is added to configuration file which says if in the current instance is allowed to edit the description.

## Aim

To use this flag and enable/disable the editing of the description.
