### PR TITLE
Pheno browser download form

### DIFF
--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -19,7 +19,11 @@
   <gpf-unique-family-variants-filter></gpf-unique-family-variants-filter>
 
   <div class="form-block">
-    <form id="dl-form" (ngSubmit)="onSubmit($event)" action="{{ configService.baseUrl }}genotype_browser/query" method="post">
+    <form
+      id="dl-form"
+      (ngSubmit)="onSubmit($event)"
+      action="{{ configService.baseUrl }}genotype_browser/query"
+      method="post">
       <input name="queryData" type="hidden" />
       <button
         class="btn btn-md btn-primary btn-right"

--- a/src/app/pheno-browser/pheno-browser.component.html
+++ b/src/app/pheno-browser/pheno-browser.component.html
@@ -38,9 +38,16 @@
       </div>
       <div id="download-wrapper">
         <span>Phenotype measures</span>
-        <button id="download-measures" class="btn btn-md btn-primary btn-right" (click)="downloadMeasures()">
-          <span class="material-symbols-outlined"> download </span>
-        </button>
+        <form
+          id="dl-form"
+          (ngSubmit)="downloadMeasures($event)"
+          action="{{ configService.baseUrl }}pheno_browser/download"
+          method="post">
+          <input name="queryData" type="hidden" />
+          <button id="download-measures" class="btn btn-md btn-primary btn-right" type="submit">
+            <span class="material-symbols-outlined"> download </span>
+          </button>
+        </form>
       </div>
     </div>
   </div>

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -235,21 +235,23 @@ describe('PhenoBrowserComponent', () => {
   }));
 
   it('should test download', () => {
-    const spyOnQueryService = jest.spyOn<any, any>(phenoBrowserServiceMock, 'downloadMeasures');
-    const blobSaveSpy = jest.spyOn(saveAs, 'saveAs');
-    component.downloadMeasures();
-    expect(blobSaveSpy).toHaveBeenCalledWith([], 'measures_testDatasetId.csv');
-    expect(blobSaveSpy).toHaveBeenCalledTimes(1);
-    expect(spyOnQueryService).toHaveBeenCalledWith('testDatasetId', null,
-      [{base_url: undefined, description: 'a test measure', figureDistribution: 'http://localhost:8000basetest.jpg',
-        figureDistributionSmall: null, index: 1, instrumentName: 'i1', measureId: 'i1.test_measure',
-        measureName: 'test_measure', measureType: 'ordinal',
-        regressions:
-        {age: {figureRegression: 'http://localhost:8000baseimagepath',
-          figureRegressionSmall: 'http://localhost:8000baseimagepathsmall', measureId: 'i1.test_measure',
-          pvalueRegressionFemale: 0.2, pvalueRegressionMale: 0.000001, regressionId: 'age'}
-        }, valuesDomain: '0,1'}]);
-    expect(spyOnQueryService).toHaveBeenCalledTimes(1);
-    expect(spyOnQueryService.mock.results).toMatchObject([{type: 'return', value: {}}]);
+    const mockEvent = {
+      target: document.createElement('form'),
+      preventDefault: jest.fn()
+    };
+    mockEvent.target.queryData = {
+      value: ''
+    };
+
+    jest.spyOn(mockEvent.target, 'submit').mockImplementation();
+    component.downloadMeasures(mockEvent as any);
+    expect((mockEvent.target.queryData as HTMLInputElement).value).toStrictEqual(JSON.stringify({
+      /* eslint-disable @typescript-eslint/naming-convention */
+      dataset_id: component.selectedDataset.id,
+      instrument: null,
+      measure_ids: ['i1.test_measure']
+      /* eslint-enable */
+    }));
+    expect(mockEvent.target.submit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { PhenoBrowserComponent } from './pheno-browser.component';
 import { DatasetsService } from '../datasets/datasets.service';
 import { PhenoBrowserService } from './pheno-browser.service';
-import { PhenoInstruments, PhenoInstrument, PhenoMeasures, PhenoMeasure } from './pheno-browser';
+import { PhenoInstruments,PhenoInstrument, PhenoMeasures, PhenoMeasure, PhenoRegressions } from './pheno-browser';
 import { fakeJsonMeasureOneRegression } from './pheno-browser.spec';
 import { environment } from '../../environments/environment';
 import { FormsModule } from '@angular/forms';
@@ -30,13 +30,12 @@ import { ConfigService } from 'app/config/config.service';
 import { RegressionComparePipe } from 'app/utils/regression-compare.pipe';
 import { GetRegressionIdsPipe } from 'app/utils/get-regression-ids.pipe';
 import { BackgroundColorPipe } from 'app/utils/background-color.pipe';
-import * as saveAs from 'file-saver';
 
-const fakeJsonMeasurei1 = JSON.parse(JSON.stringify(fakeJsonMeasureOneRegression));
-fakeJsonMeasurei1.instrument_name = 'i1';
-fakeJsonMeasurei1.measure_id = 'i1.test_measure';
-fakeJsonMeasurei1.measure_name = 'test_measure';
-fakeJsonMeasurei1.regressions[0].measure_id = 'i1.test_measure';
+const fakeJsonMeasurei1 = JSON.parse(JSON.stringify(fakeJsonMeasureOneRegression)) as object;
+fakeJsonMeasurei1['instrument_name'] = 'i1';
+fakeJsonMeasurei1['measure_id'] = 'i1.test_measure';
+fakeJsonMeasurei1['measure_name'] = 'test_measure';
+(fakeJsonMeasurei1['regressions'] as PhenoRegressions[])[0]['measure_id']= 'i1.test_measure';
 
 class MockPhenoBrowserService {
   public getInstruments(): Observable<PhenoInstruments> {
@@ -50,6 +49,7 @@ class MockPhenoBrowserService {
 
   public getMeasuresInfo(): Observable<PhenoMeasures> {
     const measuresInfo = PhenoMeasures.fromJson(
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       {base_image_url: 'base', has_descriptions: true, regression_names: {age: 'age'}}
     );
     return of(measuresInfo);
@@ -78,12 +78,12 @@ class MockActivatedRoute {
 }
 
 class MockRouter {
-  public createUrlTree(commands: any[], navigationExtras: any) {
+  public createUrlTree(commands: any[], navigationExtras: any): string {
     return `${navigationExtras.queryParams.instrument}/${navigationExtras.queryParams.search}`;
   }
 }
 
-function setQuery(fixture: ComponentFixture<PhenoBrowserComponent>, instrument: number, search: string) {
+function setQuery(fixture: ComponentFixture<PhenoBrowserComponent>, instrument: number, search: string): void {
   const selectElem = fixture.nativeElement.querySelector('select');
   const searchElem = fixture.nativeElement.querySelector('input');
   const selectedOptionElem = fixture.debugElement.queryAll(By.css('option'))[instrument];
@@ -129,7 +129,7 @@ describe('PhenoBrowserComponent', () => {
         { provide: PhenoBrowserService, useValue: phenoBrowserServiceMock },
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useClass: MockRouter },
-        { provide: Location, useValue: locationSpy },
+        { provide: Location, useValue: locationSpy as object},
         { provide: PValueIntensityPipe, useClass: PValueIntensityPipe },
         { provide: ResizeService, useValue: resizeSpy },
         ConfigService
@@ -194,8 +194,8 @@ describe('PhenoBrowserComponent', () => {
     jest.spyOn(router, 'createUrlTree');
     setQuery(fixture, 2, 'q12');
     fixture.whenStable().then(() => {
-      expect(router.createUrlTree).toHaveBeenCalledTimes(2);
-      expect(router.createUrlTree).toHaveBeenCalledWith(['.'], {
+      expect((router as Router).createUrlTree).toHaveBeenCalledTimes(2);
+      expect((router as Router).createUrlTree).toHaveBeenCalledWith(['.'], {
         relativeTo: activatedRoute,
         queryParams: {instrument: 'i2', search: 'q12'}
       });
@@ -244,7 +244,7 @@ describe('PhenoBrowserComponent', () => {
     };
 
     jest.spyOn(mockEvent.target, 'submit').mockImplementation();
-    component.downloadMeasures(mockEvent as any);
+    component.downloadMeasures(mockEvent as unknown as Event);
     expect((mockEvent.target.queryData as HTMLInputElement).value).toStrictEqual(JSON.stringify({
       /* eslint-disable @typescript-eslint/naming-convention */
       dataset_id: component.selectedDataset.id,

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -138,10 +138,12 @@ export class PhenoBrowserComponent implements OnInit {
       // }
       // );
 
+      const measureIds = this.measuresToShow.measures.map(m => m.measureId);
+
       const data = {
         dataset_id: this.selectedDatasetId,
         instrument: instrument,
-        measure_ids: this.measuresToShow.measures
+        measure_ids: measureIds
       };
       console.log(data)
       if (event.target instanceof HTMLFormElement) {

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -119,35 +119,23 @@ export class PhenoBrowserComponent implements OnInit {
   }
 
   public downloadMeasures(event: Event): void {
-    let filename: string;
-
     this.selectedInstrument$.pipe(take(1)).subscribe(instrument => {
-      filename = `measures_${this.selectedDatasetId}_${instrument}.csv`;
-
       if (instrument === '') {
         instrument = null;
-        filename = `measures_${this.selectedDatasetId}.csv`;
       }
-
-      // this.phenoBrowserService.downloadMeasures(
-      //   this.selectedDatasetId,
-      //   instrument,
-      //   this.measuresToShow.measures
-      // ).pipe(take(1)).subscribe(data => {
-      //   saveAs(data, filename);
-      // }
-      // );
 
       const measureIds = this.measuresToShow.measures.map(m => m.measureId);
 
+      /* eslint-disable @typescript-eslint/naming-convention */
       const data = {
         dataset_id: this.selectedDatasetId,
         instrument: instrument,
         measure_ids: measureIds
       };
-      console.log(data)
+      /* eslint-enable */
+
       if (event.target instanceof HTMLFormElement) {
-        event.target.queryData.value = JSON.stringify(data);
+        (event.target.queryData as HTMLInputElement).value = JSON.stringify(data);
         event.target.submit();
       }
     });

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -9,7 +9,6 @@ import { DatasetsService } from '../datasets/datasets.service';
 import { debounceTime, distinctUntilChanged, map, share, switchMap, take, tap } from 'rxjs/operators';
 import { environment } from 'environments/environment';
 import { ConfigService } from 'app/config/config.service';
-import { saveAs } from 'file-saver';
 
 @Component({
   selector: 'gpf-pheno-browser',

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -118,7 +118,7 @@ export class PhenoBrowserComponent implements OnInit {
     this.selectedInstrument$.next(instrument);
   }
 
-  public downloadMeasures(): void {
+  public downloadMeasures(event: Event): void {
     let filename: string;
 
     this.selectedInstrument$.pipe(take(1)).subscribe(instrument => {
@@ -129,14 +129,25 @@ export class PhenoBrowserComponent implements OnInit {
         filename = `measures_${this.selectedDatasetId}.csv`;
       }
 
-      this.phenoBrowserService.downloadMeasures(
-        this.selectedDatasetId,
-        instrument,
-        this.measuresToShow.measures
-      ).pipe(take(1)).subscribe(data => {
-        saveAs(data, filename);
+      // this.phenoBrowserService.downloadMeasures(
+      //   this.selectedDatasetId,
+      //   instrument,
+      //   this.measuresToShow.measures
+      // ).pipe(take(1)).subscribe(data => {
+      //   saveAs(data, filename);
+      // }
+      // );
+
+      const data = {
+        dataset_id: this.selectedDatasetId,
+        instrument: instrument,
+        measure_ids: this.measuresToShow.measures
+      };
+      console.log(data)
+      if (event.target instanceof HTMLFormElement) {
+        event.target.queryData.value = JSON.stringify(data);
+        event.target.submit();
       }
-      );
     });
   }
 

--- a/src/app/pheno-browser/pheno-browser.service.ts
+++ b/src/app/pheno-browser/pheno-browser.service.ts
@@ -104,21 +104,4 @@ export class PhenoBrowserService {
     return `${this.config.baseUrl}${this.downloadUrl}`
            + `?dataset_id=${datasetId}&instrument=${instrument}`;
   }
-
-  public downloadMeasures(
-    datasetId: string,
-    instrument: PhenoInstrument,
-    selectedMeasures: PhenoMeasure[]
-  ): Observable<Blob> {
-    const measureIds = selectedMeasures.map(m => m.measureId);
-    return this.http.post(
-      this.config.baseUrl + this.downloadUrl,
-      { dataset_id: datasetId, instrument: instrument, measure_ids: measureIds },
-      {
-        responseType: 'blob',
-        headers: new HttpHeaders().append('Content-Type', 'application/json'),
-        withCredentials: true
-      }
-    );
-  }
 }

--- a/src/app/pheno-browser/pheno-browser.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.spec.ts
@@ -73,7 +73,7 @@ describe('pheno measure', () => {
     expect(phenoMeasure.instrumentName).toBe('test_instrument');
     expect(phenoMeasure.valuesDomain).toBe('0,1');
     expect(phenoMeasure.figureDistribution).toBe('test.jpg');
-    expect(phenoMeasure.figureDistributionSmall).toBe(null);
+    expect(phenoMeasure.figureDistributionSmall).toBeNull();
     expect(phenoMeasure.measureId).toBe('test_instrument.test_measure');
     expect(phenoMeasure.measureName).toBe('test_measure');
     expect(phenoMeasure.measureType).toBe('ordinal');
@@ -82,15 +82,19 @@ describe('pheno measure', () => {
 });
 
 describe('pheno measures', () => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   const base_path = '/test_base_url/';
   let phenoMeasure = PhenoMeasure.fromJson(fakeJsonMeasure);
 
   phenoMeasure = PhenoMeasure.addBasePath(phenoMeasure, base_path);
 
   const phenoMeasures = PhenoMeasures.fromJson({
+    /* eslint-disable @typescript-eslint/naming-convention */
     base_image_url: base_path,
     measures: [fakeJsonMeasure],
-    has_descriptions: true,
+    has_descriptions: true
+    /* eslint-enable */
+
   });
 
   it('should be creatable from a given json', () => {
@@ -132,26 +136,28 @@ describe('PhenoRegressions', () => {
   const phenoRegressionsBasePath = new PhenoRegressions(fakeJsonMeasureTwoRegressions.regressions);
 
   it('should be creatable from a given json', () => {
-    expect(phenoRegressions['age'].regressionId).toBe('age');
-    expect(phenoRegressions['age'].measureId).toBe('test_instrument.test_measure');
-    expect(phenoRegressions['age'].figureRegression).toBe('imagepathage');
-    expect(phenoRegressions['age'].figureRegressionSmall).toBe('imagepathagesmall');
-    expect(phenoRegressions['age'].pvalueRegressionMale).toBe(0.01);
-    expect(phenoRegressions['age'].pvalueRegressionFemale).toBe(1.00);
+    expect((phenoRegressions['age'] as PhenoRegression).regressionId).toBe('age');
+    expect((phenoRegressions['age'] as PhenoRegression).measureId).toBe('test_instrument.test_measure');
+    expect((phenoRegressions['age'] as PhenoRegression).figureRegression).toBe('imagepathage');
+    expect((phenoRegressions['age'] as PhenoRegression).figureRegressionSmall).toBe('imagepathagesmall');
+    expect((phenoRegressions['age'] as PhenoRegression).pvalueRegressionMale).toBe(0.01);
+    expect((phenoRegressions['age'] as PhenoRegression).pvalueRegressionFemale).toBe(1.00);
 
-    expect(phenoRegressions['iq'].regressionId).toBe('iq');
-    expect(phenoRegressions['iq'].measureId).toBe('test_instrument.test_measure');
-    expect(phenoRegressions['iq'].figureRegression).toBe('imagepathiq');
-    expect(phenoRegressions['iq'].figureRegressionSmall).toBe('imagepathiqsmall');
-    expect(phenoRegressions['iq'].pvalueRegressionMale).toBe(0.02);
-    expect(phenoRegressions['iq'].pvalueRegressionFemale).toBe(2.00);
+    expect((phenoRegressions['iq'] as PhenoRegression).regressionId).toBe('iq');
+    expect((phenoRegressions['iq'] as PhenoRegression).measureId).toBe('test_instrument.test_measure');
+    expect((phenoRegressions['iq'] as PhenoRegression).figureRegression).toBe('imagepathiq');
+    expect((phenoRegressions['iq'] as PhenoRegression).figureRegressionSmall).toBe('imagepathiqsmall');
+    expect((phenoRegressions['iq'] as PhenoRegression).pvalueRegressionMale).toBe(0.02);
+    expect((phenoRegressions['iq'] as PhenoRegression).pvalueRegressionFemale).toBe(2.00);
   });
 
   it('should be able to add a base path', () => {
     phenoRegressionsBasePath.addBasePath('a_base_path/');
-    expect(phenoRegressionsBasePath['age'].figureRegression).toBe('a_base_path/imagepathage');
-    expect(phenoRegressionsBasePath['age'].figureRegressionSmall).toBe('a_base_path/imagepathagesmall');
-    expect(phenoRegressionsBasePath['iq'].figureRegression).toBe('a_base_path/imagepathiq');
-    expect(phenoRegressionsBasePath['iq'].figureRegressionSmall).toBe('a_base_path/imagepathiqsmall');
+    expect((phenoRegressionsBasePath['age'] as PhenoRegression).figureRegression).toBe('a_base_path/imagepathage');
+    expect((phenoRegressionsBasePath['age'] as PhenoRegression).figureRegressionSmall)
+      .toBe('a_base_path/imagepathagesmall');
+    expect((phenoRegressionsBasePath['iq'] as PhenoRegression).figureRegression).toBe('a_base_path/imagepathiq');
+    expect((phenoRegressionsBasePath['iq'] as PhenoRegression).figureRegressionSmall)
+      .toBe('a_base_path/imagepathiqsmall');
   });
 });

--- a/src/app/pheno-browser/pheno-browser.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.spec.ts
@@ -82,15 +82,14 @@ describe('pheno measure', () => {
 });
 
 describe('pheno measures', () => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const base_path = '/test_base_url/';
+  const basePath = '/test_base_url/';
   let phenoMeasure = PhenoMeasure.fromJson(fakeJsonMeasure);
 
-  phenoMeasure = PhenoMeasure.addBasePath(phenoMeasure, base_path);
+  phenoMeasure = PhenoMeasure.addBasePath(phenoMeasure, basePath);
 
   const phenoMeasures = PhenoMeasures.fromJson({
     /* eslint-disable @typescript-eslint/naming-convention */
-    base_image_url: base_path,
+    base_image_url: basePath,
     measures: [fakeJsonMeasure],
     has_descriptions: true
     /* eslint-enable */

--- a/src/app/pheno-browser/pheno-browser.ts
+++ b/src/app/pheno-browser/pheno-browser.ts
@@ -32,10 +32,12 @@ export class PhenoRegression {
 
 export class PhenoRegressions {
   public static emptyRegression = new PhenoRegression({
+    /* eslint-disable @typescript-eslint/naming-convention */
     figure_regression: null,
     figure_regression_small: null,
     pvalue_regression_male: null,
     pvalue_regression_female: null
+    /* eslint-enable */
   });
 
   public constructor(regArr: object[]) {
@@ -109,7 +111,7 @@ export class PhenoMeasure {
 
       measure.regressions,
 
-      measure.base_url
+      measure.baseUrl
     );
     return newMeasure;
   }
@@ -129,15 +131,15 @@ export class PhenoMeasure {
 
     public readonly regressions: PhenoRegressions,
 
-    public readonly base_url: string,
+    public readonly baseUrl: string,
   ) { }
 }
 
 export class PhenoMeasures {
   public addMeasure(measure: PhenoMeasure): void {
     let basePath: string;
-    if (measure.base_url) {
-      basePath = measure.base_url + this.baseImageUrl;
+    if (measure.baseUrl) {
+      basePath = measure.baseUrl + this.baseImageUrl;
     } else {
       basePath = environment.basePath + this.baseImageUrl;
     }
@@ -159,7 +161,7 @@ export class PhenoMeasures {
 
       measure.regressions,
 
-      measure.base_url
+      measure.baseUrl
     );
     this.measures.push(newMeasure);
   }


### PR DESCRIPTION
## Background

Pheno download button doesn't start downloading when the query was sent. Instead it downloads when there is response which can cause confusion when the download is slower and there is no indication that the process has started.

## Aim

To change the way of downloading.

## Implementation

Use <form>. Have genotype browser download button as an example.

closes: #936 