### PR TITLE
Agp configuration

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,10 +5,10 @@ import { BnNgIdleService } from 'bn-ng-idle';
 import { UsersService } from './users/users.service';
 import { switchMap } from 'rxjs/operators';
 import { NgbNavConfig } from '@ng-bootstrap/ng-bootstrap';
-import { AgpTableConfig } from './autism-gene-profiles-table/autism-gene-profiles-table';
-import { AgpTableService } from './autism-gene-profiles-table/autism-gene-profiles-table.service';
 import { APP_BASE_HREF } from '@angular/common';
 import { AppVersionService } from './app-version.service';
+import { AutismGeneProfilesService } from './autism-gene-profiles-block/autism-gene-profiles.service';
+import { AgpSingleViewConfig } from './autism-gene-profiles-single-view/autism-gene-profile-single-view';
 
 @Component({
   selector: 'gpf-root',
@@ -55,7 +55,7 @@ export class AppComponent implements OnInit {
   public showSidenav = false;
   public title = 'GPF: Genotypes and Phenotypes in Families';
   public imgPathPrefix = environment.imgPathPrefix;
-  public agpConfig: AgpTableConfig;
+  public agpConfig: AgpSingleViewConfig;
   private sessionTimeoutInSeconds = 7 * 24 * 60 * 60; // 1 week
 
   public gpfjsVersion = environment?.version;
@@ -82,7 +82,7 @@ export class AppComponent implements OnInit {
   }
 
   public constructor(
-    private autismGeneProfilesService: AgpTableService,
+    private autismGeneProfilesService: AutismGeneProfilesService,
     private bnIdle: BnNgIdleService,
     private usersService: UsersService,
     private ngbNavConfig: NgbNavConfig,

--- a/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.spec.ts
+++ b/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.spec.ts
@@ -12,16 +12,116 @@ import { NgxsModule } from '@ngxs/store';
 import { MultipleSelectMenuComponent } from 'app/multiple-select-menu/multiple-select-menu.component';
 import { FormsModule } from '@angular/forms';
 import { APP_BASE_HREF } from '@angular/common';
+import { AutismGeneProfilesService } from './autism-gene-profiles.service';
+import { Observable, of } from 'rxjs';
+import { AgpSingleViewConfig } from 'app/autism-gene-profiles-single-view/autism-gene-profile-single-view';
+import { TruncatePipe } from '../utils/truncate.pipe';
+import { AgpColumn, AgpTableConfig } from 'app/autism-gene-profiles-table/autism-gene-profiles-table';
+
+const config = {
+  shown: [],
+  defaultDataset: 'mockDataset',
+  geneSets: [
+    {
+      category: 'autism_gene_sets',
+      displayName: 'Autism Gene Sets',
+      defaultVisible: true,
+      sets: [
+        { setId: 'SFARI ALL', defaultVisible: true, collectionId: 'sfari', meta: null }
+      ]
+    }
+  ],
+  genomicScores: [
+    {
+      category: 'autism_scores',
+      defaultVisible: true,
+      displayName: 'Autism Scores',
+      scores: [
+        { format: '%s', defaultVisible: true, scoreName: 'SFARI gene score', meta: null }
+      ]
+    }
+  ],
+  datasets: [
+    {
+      defaultVisible: true,
+      displayName: 'Sequencing de Novo',
+      id: 'sequencing_de_novo',
+      meta: null,
+      shown: [],
+      personSets: [
+        {
+          id: 'autism',
+          shown: [],
+          defaultVisible: true,
+          displayName: 'autism',
+          collectionId: 'phenotype',
+          description: '',
+          parentsCount: 9836,
+          childrenCount: 21775,
+          statistics: [
+            {
+              id: 'denovo_lgds',
+              description: 'de Novo LGDs',
+              displayName: 'dn LGDs',
+              effects: [
+                'LGDs'
+              ],
+              category: 'denovo',
+              defaultVisible: true,
+              scores: [],
+              variantTypes: []
+            }
+          ]
+        }
+      ],
+      statistics: []
+    }
+  ],
+  order: [
+    { section: null, id: 'autism_gene_sets_rank' },
+    { section: 'genomicScores', id: 'autism_scores' },
+    { section: 'datasets', id: 'sequencing_de_novo' }
+  ],
+  pageSize: 5
+};
+
+class AutismGeneProfilesServiceMock {
+  public getConfig(): Observable<AgpSingleViewConfig> {
+    return of(config);
+  }
+}
+
+/* eslint-disable max-len */
+const geneColumn = new AgpColumn('createTab', [], 'Gene', false, 'geneSymbol', null, false, true);
+const geneSetSetsCol = new AgpColumn(null, [], 'SFARI ALL', true, 'autism_gene_sets_rank.SFARI ALL', null, true, true);
+const geneSetCol = new AgpColumn(null, [geneSetSetsCol], 'Autism Gene Sets', false, 'autism_gene_sets_rank', null, true, true);
+const geneScoreScoresCol = new AgpColumn(null, [], 'SFARI gene score', true, 'autism_scores.SFARI gene score', null, true, true);
+const geneScoreCol = new AgpColumn(null, [geneScoreScoresCol], 'Autism Scores', false, 'autism_scores', null, false, true);
+const datasetPersonSetsStatisticsCol = new AgpColumn('goToQuery', [], 'dn LGDs', false, 'sequencing_de_novo.autism.denovo_lgds', null, true, true);
+const datasetPersonSetsCol = new AgpColumn(null, [datasetPersonSetsStatisticsCol], 'autism (21775)', false, 'sequencing_de_novo.autism', null, false, true);
+const datasetCol = new AgpColumn(null, [datasetPersonSetsCol], 'Sequencing de Novo', false, 'sequencing_de_novo', null, false, true);
+/* eslint-enable max-len */
+
+const agpTableConfigMock= new AgpTableConfig();
+agpTableConfigMock.columns = [geneColumn, geneSetCol, geneScoreCol, datasetCol];
+agpTableConfigMock.defaultDataset = 'mockDataset';
+agpTableConfigMock.pageSize = 5;
 
 describe('AutismGeneProfilesBlockComponent', () => {
   let component: AutismGeneProfilesBlockComponent;
   let fixture: ComponentFixture<AutismGeneProfilesBlockComponent>;
+  const autismGeneProfilesServiceMock = new AutismGeneProfilesServiceMock();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AutismGeneProfilesBlockComponent, AgpTableComponent, MultipleSelectMenuComponent],
+      declarations: [AutismGeneProfilesBlockComponent, AgpTableComponent, MultipleSelectMenuComponent, TruncatePipe],
       providers: [
-        ConfigService, QueryService, DatasetsService, UsersService, { provide: APP_BASE_HREF, useValue: '' }
+        ConfigService,
+        QueryService,
+        DatasetsService,
+        UsersService,
+        { provide: APP_BASE_HREF, useValue: '' },
+        { provide: AutismGeneProfilesService, useValue: autismGeneProfilesServiceMock }
       ],
       imports: [
         HttpClientTestingModule, NgbNavModule, RouterTestingModule, FormsModule,
@@ -36,5 +136,12 @@ describe('AutismGeneProfilesBlockComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create agp table configuration', () => {
+    component.ngOnInit();
+    expect(component.agpTableConfig).toStrictEqual(agpTableConfigMock);
+    expect(component.agpTableSortBy).toBe('autism_gene_sets_rank');
+    expect(component.agpSingleViewConfig).toStrictEqual(config);
   });
 });

--- a/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.ts
+++ b/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.ts
@@ -9,7 +9,6 @@ import { map, take } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { QueryService } from 'app/query/query.service';
 import { AgpColumn, AgpTableConfig } from 'app/autism-gene-profiles-table/autism-gene-profiles-table';
-import { AgpTableService } from 'app/autism-gene-profiles-table/autism-gene-profiles-table.service';
 import {
   AutismGeneProfileSingleViewComponent
 } from 'app/autism-gene-profiles-single-view/autism-gene-profile-single-view.component';
@@ -25,7 +24,6 @@ export class AutismGeneProfilesBlockComponent implements OnInit {
   public agpSingleViewConfig: AgpSingleViewConfig;
 
   public constructor(
-    private agpTableService: AgpTableService,
     private autismGeneProfilesService: AutismGeneProfilesService,
     private queryService: QueryService,
     private store: Store

--- a/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.ts
+++ b/src/app/autism-gene-profiles-block/autism-gene-profiles-block.component.ts
@@ -156,6 +156,9 @@ export class AutismGeneProfilesBlockComponent implements OnInit {
       agpTableConfig.columns.push(datasetColumn);
     });
 
+    const order = config.order.map(el => el.id);
+    agpTableConfig.columns.sort((col1, col2) => order.indexOf(col1.id) - order.indexOf(col2.id));
+
     return agpTableConfig;
   }
 

--- a/src/app/autism-gene-profiles-single-view/autism-gene-profile-single-view.ts
+++ b/src/app/autism-gene-profiles-single-view/autism-gene-profile-single-view.ts
@@ -16,6 +16,8 @@ export class AgpSingleViewConfig {
 
   @Type(() => AgpOrder)
   public order: AgpOrder[];
+
+  public pageSize: number;
 }
 
 export class AgpGeneSetsCategory {

--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.component.ts
@@ -7,7 +7,7 @@ import { MultipleSelectMenuComponent } from 'app/multiple-select-menu/multiple-s
 import { SortingButtonsComponent } from 'app/sorting-buttons/sorting-buttons.component';
 import { debounceTime, distinctUntilChanged, take, tap } from 'rxjs/operators';
 import { Subject, Subscription, zip } from 'rxjs';
-import { AgpTableConfig, Column } from './autism-gene-profiles-table';
+import { AgpTableConfig, AgpColumn } from './autism-gene-profiles-table';
 import { AgpTableService } from './autism-gene-profiles-table.service';
 import { environment } from 'environments/environment';
 
@@ -31,7 +31,7 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
   public modalPosition = {top: 0, left: 0};
   public showKeybinds = false;
 
-  public leaves: Column[];
+  public leaves: AgpColumn[];
   public genes = [];
   public shownRows: number[] = []; // indexes
   public highlightedGenes: Set<string> = new Set();
@@ -160,19 +160,19 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public calculateHeaderLayout(): void {
-    this.leaves = Column.leaves(this.config.columns);
+    this.leaves = AgpColumn.leaves(this.config.columns);
     this.nothingFoundWidth = (this.leaves.length * 110) + 40; // must match .table-row values
     let columnIdx = 0;
     const maxDepth: number = Math.max(...this.leaves.map(leaf => leaf.depth));
 
     for (const leaf of this.leaves) {
       leaf.gridColumn = (columnIdx + 1).toString();
-      Column.calculateGridRow(leaf, maxDepth);
+      AgpColumn.calculateGridRow(leaf, maxDepth);
       columnIdx++;
     }
 
     for (const column of this.config.columns) {
-      Column.calculateGridColumn(column);
+      AgpColumn.calculateGridColumn(column);
     }
   }
 
@@ -200,7 +200,7 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
       });
   }
 
-  public openDropdown(column: Column, $event): void {
+  public openDropdown(column: AgpColumn, $event): void {
     $event.stopPropagation(); // stop propagation to avoid triggering sort
 
     if (this.ngbDropdownMenu.dropdown._open) {
@@ -295,7 +295,7 @@ export class AgpTableComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  public handleCellClick($event, row, column: Column): void {
+  public handleCellClick($event, row, column: AgpColumn): void {
     const linkClick: boolean = $event.target.classList.contains('clickable');
     const geneSymbol = row[this.geneSymbolColumnId] as string;
 

--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.service.spec.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.service.spec.ts
@@ -2,9 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ConfigService } from 'app/config/config.service';
 // eslint-disable-next-line no-restricted-imports
-import { lastValueFrom, of } from 'rxjs';
-import { take } from 'rxjs/operators';
-import { AgpTableConfig } from './autism-gene-profiles-table';
+import { of } from 'rxjs';
 import { AgpTableService } from './autism-gene-profiles-table.service';
 
 describe('AgpTableService', () => {
@@ -20,18 +18,6 @@ describe('AgpTableService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-  });
-
-  it('should get config', async() => {
-    const getConfigSpy = jest.spyOn(service['http'], 'get');
-    getConfigSpy.mockReturnValue(of({ mockConfigProperty: 'mockConfigValue' }));
-
-    const resultConfig = service.getConfig();
-
-    expect(getConfigSpy).toHaveBeenCalledWith(service['config'].baseUrl + service['configUrl']);
-    const res = await lastValueFrom(resultConfig.pipe(take(1)));
-    expect(res['mockConfigProperty']).toBe('mockConfigValue');
-    expect(res).toBeInstanceOf(AgpTableConfig);
   });
 
   it('should get genes', () => {

--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.service.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.service.ts
@@ -1,35 +1,20 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from 'app/config/config.service';
-import { plainToClass } from 'class-transformer';
 // eslint-disable-next-line no-restricted-imports
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { AgpTableConfig } from './autism-gene-profiles-table';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AgpTableService {
-  private readonly configUrl = 'autism_gene_tool/table/configuration';
   private readonly genesUrl = 'autism_gene_tool/table/rows';
 
   public constructor(
     private http: HttpClient,
     private config: ConfigService
   ) {}
-
-  public getConfig(): Observable<AgpTableConfig> {
-    return this.http
-      .get(this.config.baseUrl + this.configUrl).pipe(
-        map(res => {
-          if (Object.keys(res).length === 0) {
-            return;
-          }
-          return plainToClass(AgpTableConfig, res);
-        })
-      );
-  }
 
   public getGenes(page: number, searchString?: string, sortBy?: string, order?: string): Observable<any[]> {
     let url = this.config.baseUrl + this.genesUrl;

--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.spec.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.spec.ts
@@ -1,5 +1,5 @@
 import { plainToClass } from 'class-transformer';
-import { AgpTableConfig, Column } from './autism-gene-profiles-table';
+import { AgpTableConfig, AgpColumn } from './autism-gene-profiles-table';
 
 const column1 = {
   clickable: 'createTab',
@@ -158,7 +158,7 @@ describe('AgpTableConfig', () => {
   });
 
   it('should set column visibility', () => {
-    Column.leaves(config.columns);
+    AgpColumn.leaves(config.columns);
 
     // Basic visibility
     config.columns[0].visibility = false;
@@ -183,7 +183,7 @@ describe('AgpTableConfig', () => {
   });
 
   it('should get visible children', () => {
-    Column.leaves(config.columns);
+    AgpColumn.leaves(config.columns);
 
     // 2 children visible
     config.columns[2].columns[0].columns[0].visibility = true;
@@ -226,7 +226,7 @@ describe('AgpTableConfig', () => {
   });
 
   it('should set column parent and depth and get leaves', () => {
-    const leaves = Column.leaves(config.columns);
+    const leaves = AgpColumn.leaves(config.columns);
 
     expect(config.columns[0].parent).toBeNull();
     expect(config.columns[0].depth).toBe(1);
@@ -280,10 +280,10 @@ describe('AgpTableConfig', () => {
   });
 
   it('should calculate grid row', () => {
-    const leaves = Column.leaves(config.columns);
+    const leaves = AgpColumn.leaves(config.columns);
     const maxDepth = Math.max(...leaves.map(leaf => leaf.depth));
 
-    leaves.forEach(leaf => Column.calculateGridRow(leaf, maxDepth));
+    leaves.forEach(leaf => AgpColumn.calculateGridRow(leaf, maxDepth));
 
     expect(config.columns[0].gridRow).toBe('1 / 4');
     expect(config.columns[1].gridRow).toBe('1');
@@ -299,7 +299,7 @@ describe('AgpTableConfig', () => {
   });
 
   it('should calculate grid column', () => {
-    const leaves = Column.leaves(config.columns);
+    const leaves = AgpColumn.leaves(config.columns);
 
     let columnIdx = 0;
     for (const leaf of leaves) {
@@ -307,7 +307,7 @@ describe('AgpTableConfig', () => {
       columnIdx++;
     }
 
-    config.columns.forEach(col => Column.calculateGridColumn(col));
+    config.columns.forEach(col => AgpColumn.calculateGridColumn(col));
 
     expect(config.columns[0].gridColumn).toBe('1');
     expect(config.columns[1].gridColumn).toBe('2 / 4');

--- a/src/app/autism-gene-profiles-table/autism-gene-profiles-table.ts
+++ b/src/app/autism-gene-profiles-table/autism-gene-profiles-table.ts
@@ -26,6 +26,26 @@ export class AgpColumn {
 
   private visible: boolean;
 
+  public constructor(
+    clickable: string,
+    columns: AgpColumn[],
+    displayName: string,
+    displayVertical: boolean,
+    id: string,
+    meta: string,
+    sortable: boolean,
+    visibility: boolean
+  ) {
+    this.clickable = clickable;
+    this.columns = columns;
+    this.displayName = displayName;
+    this.displayVertical = displayVertical;
+    this.id = id;
+    this.meta = meta;
+    this.sortable = sortable;
+    this.visibility = visibility;
+  }
+
   public get visibility(): boolean {
     return this.visible;
   }

--- a/src/app/multiple-select-menu/multiple-select-menu.component.ts
+++ b/src/app/multiple-select-menu/multiple-select-menu.component.ts
@@ -1,6 +1,6 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
-import { Column } from 'app/autism-gene-profiles-table/autism-gene-profiles-table';
+import { AgpColumn } from 'app/autism-gene-profiles-table/autism-gene-profiles-table';
 import { environment } from 'environments/environment';
 
 @Component({
@@ -9,14 +9,14 @@ import { environment } from 'environments/environment';
   styleUrls: ['./multiple-select-menu.component.css']
 })
 export class MultipleSelectMenuComponent implements OnChanges {
-  @Input() public columns: Column[];
+  @Input() public columns: AgpColumn[];
   @Output() public applyEvent = new EventEmitter<void>();
   @Output() public reorderEvent = new EventEmitter<string[]>();
   @ViewChild('searchInput') public searchInput: ElementRef;
 
   public buttonLabel = 'Uncheck all';
   public searchText: string;
-  public filteredColumns: Column[];
+  public filteredColumns: AgpColumn[];
   public searchPlaceholder: string;
 
   public imgPathPrefix = environment.imgPathPrefix;
@@ -51,7 +51,7 @@ export class MultipleSelectMenuComponent implements OnChanges {
     this.apply();
   }
 
-  public toggleItem(column: Column, $event: Event): void {
+  public toggleItem(column: AgpColumn, $event: Event): void {
     if (!($event.target instanceof HTMLInputElement)) {
       return;
     }


### PR DESCRIPTION
## Background
Well explained in [this](https://github.com/iossifovlab/gpfjs/issues/936) issue.

## Aim
To create config for agp table based on the response of the other query (api/v3/autism_gene_tool/single-view/configuration) and make unit test.

## Implementation
Add `createTableConfig` method in `AutismGeneProfileSingleViewComponent` which creates the config. The method uses another three helping methods - `createTableGeneSet`, `createTableGenomicScore`, `createTableDataset` which return columns (of type `AgpColumn`). Each column object contains
```
      "id": "column ID", 
      "displayName": "some name",
      "visible": True/False,
      "displayVertical": True/False,
      "sortable": True/False,
      "clickable": string,
      "columns": [], 
      "meta": "some string metadata"
```


closes #936 
