### PR TITLE
Genomic scores help

### DIFF
--- a/src/app/genomic-scores-block/genomic-scores-block.ts
+++ b/src/app/genomic-scores-block/genomic-scores-block.ts
@@ -4,10 +4,12 @@ export class GenomicScores {
   public static fromJson(json): GenomicScores {
     return new GenomicScores(
       json['bars'],
-      json['score'],
       json['bins'],
       json['desc'],
       json['help'],
+      json['large_values_desc'],
+      json['small_values_desc'],
+      json['score'],
       json['xscale'],
       json['yscale']
     );
@@ -19,10 +21,12 @@ export class GenomicScores {
 
   public constructor(
     public readonly bars: number[],
-    public readonly score: string,
     public readonly bins: number[],
     public readonly desc: string,
     public readonly help: string,
+    public readonly largeValuesDesc: string,
+    public readonly smallValuesDesc: string,
+    public readonly score: string,
     xScale: string,
     yScale: string
   ) {

--- a/src/app/genomic-scores-block/genomic-scores-block.ts
+++ b/src/app/genomic-scores-block/genomic-scores-block.ts
@@ -1,17 +1,17 @@
 export class GenomicScores {
   public readonly logScaleX: boolean;
   public readonly logScaleY: boolean;
-  public static fromJson(json): GenomicScores {
+  public static fromJson(json: object): GenomicScores {
     return new GenomicScores(
-      json['bars'],
-      json['bins'],
-      json['desc'],
-      json['help'],
-      json['large_values_desc'],
-      json['small_values_desc'],
-      json['score'],
-      json['xscale'],
-      json['yscale']
+      json['bars'] as number[],
+      json['bins'] as number[],
+      json['desc'] as string,
+      json['help'] as string,
+      json['large_values_desc'] as string,
+      json['small_values_desc'] as string,
+      json['score'] as string,
+      json['xscale'] as string,
+      json['yscale'] as string
     );
   }
 

--- a/src/app/genomic-scores/genomic-scores.component.css
+++ b/src/app/genomic-scores/genomic-scores.component.css
@@ -1,5 +1,5 @@
 #help-icon {
-  margin-top: 6px;
+  margin-top: 3px;
   margin-left: 10px;
 }
 

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -12,7 +12,7 @@
   <div>
     <span
       [style.visibility]="this.genomicScoreState.score.help ? 'visible' : 'hidden'"
-      class="material-symbols-outlined"
+      class="material-symbols-outlined lg"
       id="help-icon"
       (click)="showHelp()"
       >help</span

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -30,6 +30,8 @@
       [domainMax]="domainMax"
       [logScaleX]="selectedGenomicScores.logScaleX"
       [logScaleY]="selectedGenomicScores.logScaleY"
+      [smallValuesDesc]="selectedGenomicScores.smallValuesDesc"
+      [largeValuesDesc]="selectedGenomicScores.largeValuesDesc"
       [(rangeStart)]="rangeStart"
       [(rangeEnd)]="rangeEnd"
       style="display: block; margin-top: 17px">

--- a/src/app/genomic-scores/genomic-scores.component.spec.ts
+++ b/src/app/genomic-scores/genomic-scores.component.spec.ts
@@ -74,7 +74,7 @@ describe('GenomicScoresComponent', () => {
       size: 'lg',
       centered: true
     });
-    expect(modalRef.componentInstance.data).toBe('gs help');
+    expect((modalRef.componentInstance as PopupComponent).data).toBe('gs help');
 
     modalRef.close();
   });

--- a/src/app/genomic-scores/genomic-scores.component.spec.ts
+++ b/src/app/genomic-scores/genomic-scores.component.spec.ts
@@ -67,10 +67,12 @@ describe('GenomicScoresComponent', () => {
     jest.spyOn(modalService, 'open').mockReturnValue(modalRef);
     component.showHelp();
     expect(modalService.open).toHaveBeenCalledWith(PopupComponent, {
-      size: 'lg'
+      size: 'lg',
+      centered: true
     });
     expect(modalService.open).toHaveBeenCalledWith(PopupComponent, {
-      size: 'lg'
+      size: 'lg',
+      centered: true
     });
     expect(modalRef.componentInstance.data).toBe('gs help');
 

--- a/src/app/genomic-scores/genomic-scores.component.ts
+++ b/src/app/genomic-scores/genomic-scores.component.ts
@@ -28,7 +28,8 @@ export class GenomicScoresComponent {
 
   public showHelp(): void {
     const modalRef = this.modalService.open(PopupComponent, {
-      size: 'lg'
+      size: 'lg',
+      centered: true
     });
     modalRef.componentInstance.data = this.genomicScoreState.score.help;
   }

--- a/src/app/genomic-scores/genomic-scores.component.ts
+++ b/src/app/genomic-scores/genomic-scores.component.ts
@@ -31,7 +31,8 @@ export class GenomicScoresComponent {
       size: 'lg',
       centered: true
     });
-    modalRef.componentInstance.data = this.genomicScoreState.score.help;
+
+    (modalRef.componentInstance as PopupComponent).data = this.genomicScoreState.score.help;
   }
 
   public set rangeStart(range: number) {

--- a/src/app/histogram/histogram-range-selector-line.component.css
+++ b/src/app/histogram/histogram-range-selector-line.component.css
@@ -32,3 +32,16 @@
   display: inline-block;
   width: 100px;
 }
+
+#values-description {
+  display: flex;
+  justify-content: space-between;
+  font-style: italic;
+  color: #acacac;
+  font-size: 14px;
+  width: 100%;
+  max-width: 600px;
+  margin: auto;
+  margin-top: -12px;
+  margin-bottom: 22px;
+}

--- a/src/app/histogram/histogram.component.html
+++ b/src/app/histogram/histogram.component.html
@@ -35,6 +35,11 @@
     </g>
   </svg>
 
+  <div *ngIf="smallValuesDesc && largeValuesDesc" id="values-description">
+    <span>{{ smallValuesDesc }}</span>
+    <span>{{ largeValuesDesc }}</span>
+  </div>
+
   <div class="histogram-controls" *ngIf="showMinMaxInputWithDefaultValue" style="justify-content: space-between">
     <div class="histogram-from">
       <label for="from-input-field">From (Min: {{ minValue }})</label>

--- a/src/app/histogram/histogram.component.ts
+++ b/src/app/histogram/histogram.component.ts
@@ -60,6 +60,9 @@ export class HistogramComponent implements OnInit, OnChanges {
   @Input() public centerLabels: boolean;
   @Input() public showMinMaxInput: boolean;
 
+  @Input() public largeValuesDesc: string;
+  @Input() public smallValuesDesc: string;
+
   public beforeRangeText: string;
   public insideRangeText: string;
   public afterRangeText: string;

--- a/src/app/popup/popup.component.css
+++ b/src/app/popup/popup.component.css
@@ -1,8 +1,7 @@
 .modal-body {
   width: 100%;
-  height: 100%;
+  height: 715px;
   max-width: 794px;
-  max-height: 675px;
   overflow-y: auto;
   overflow-wrap: break-word;
 }

--- a/src/app/popup/popup.component.css
+++ b/src/app/popup/popup.component.css
@@ -1,0 +1,8 @@
+.modal-body {
+  width: 100%;
+  height: 100%;
+  max-width: 794px;
+  max-height: 675px;
+  overflow-y: auto;
+  overflow-wrap: break-word;
+}

--- a/src/app/popup/popup.component.html
+++ b/src/app/popup/popup.component.html
@@ -1,6 +1,3 @@
 <div class="modal-body">
   <markdown [data]="data"></markdown>
 </div>
-<div class="modal-footer">
-  <input type="button" class="btn btn-md btn-primary" value="Close" (click)="closeModal()" />
-</div>

--- a/src/app/remove-button/remove-button.component.css
+++ b/src/app/remove-button/remove-button.component.css
@@ -2,5 +2,10 @@
   width: 30px;
   height: 30px;
   float: right;
-  margin-top: 5px;
+  margin-top: 3px;
+  margin-right: 3px;
+}
+
+#remove-button > span {
+  font-size: 30px;
 }

--- a/src/app/remove-button/remove-button.component.html
+++ b/src/app/remove-button/remove-button.component.html
@@ -1,3 +1,3 @@
 <div id="remove-button">
-  <span class="material-symbols-outlined red bold clickable" (click)="remove()">close</span>
+  <span class="material-symbols-outlined red lg bold clickable" (click)="remove()">close</span>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -447,6 +447,10 @@ gpf-genotype-preview-field gpf-pedigree gpf-pedigree-chart .svg-container {
   font-size: 20px;
 }
 
+.material-symbols-outlined.lg {
+  font-size: 32px;
+}
+
 .material-symbols-outlined.red {
   color: red;
 }
@@ -455,6 +459,10 @@ gpf-genotype-preview-field gpf-pedigree gpf-pedigree-chart .svg-container {
 
 summary > h4 {
   display: inline;
+}
+
+summary.details {
+  width: 100px;
 }
 
 .details-body {
@@ -479,6 +487,26 @@ summary > h4 {
 .histogram-image img {
   width: 100%;
   height: 100%;
-  max-width: 560px;
-  max-height: 400px;
+  max-width: 600px;
+  max-height: 440px;
+}
+
+.modal-histogram {
+  text-align: center;
+  max-width: 745px;
+}
+
+.modal-content {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.modal-content a {
+  text-decoration: none;
+  color: #0645ad;
+  cursor: pointer;
+}
+
+.modal-content a:hover {
+  text-decoration: underline;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -451,6 +451,8 @@ gpf-genotype-preview-field gpf-pedigree gpf-pedigree-chart .svg-container {
   color: red;
 }
 
+/* styles for genomic scores help */
+
 summary > h4 {
   display: inline;
 }
@@ -473,6 +475,7 @@ summary > h4 {
   margin-bottom: 10px;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .histogram-image img {
   width: 100%;
   height: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -450,3 +450,32 @@ gpf-genotype-preview-field gpf-pedigree gpf-pedigree-chart .svg-container {
 .material-symbols-outlined.red {
   color: red;
 }
+
+summary > h4 {
+  display: inline;
+}
+
+.details-body {
+  margin-top: 10px;
+  margin-left: 30px;
+}
+
+.values-desc {
+  display: flex;
+  justify-content: space-between;
+  font-style: italic;
+  color: #acacac;
+  font-size: 14px;
+  width: 100%;
+  max-width: 560px;
+  margin: auto;
+  margin-top: -40px;
+  margin-bottom: 10px;
+}
+
+.histogram-image img {
+  width: 100%;
+  height: 100%;
+  max-width: 560px;
+  max-height: 400px;
+}


### PR DESCRIPTION
## Background

Genomic scores help popup need some ui changes

## Aim

To make the following changes:
- make histogram image smaller and responsible
- remove text **small values:** and **large values:** and put their values under the histogram in left and right corner
- hide Details (make it expandable)
- if not null add `large_values_desc` and `small_values_desc` (which come from the response) under the histogram in the left and right corner

Use gpf branch `genomic-scores-help-ui`



