### PR TITLE
Gene scores help

### DIFF
--- a/src/app/gene-scores/gene-scores.component.css
+++ b/src/app/gene-scores/gene-scores.component.css
@@ -11,3 +11,9 @@
 #select-help-wrapper {
   display: flex;
 }
+
+select {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/app/gene-scores/gene-scores.component.css
+++ b/src/app/gene-scores/gene-scores.component.css
@@ -1,0 +1,13 @@
+#help-icon {
+  margin-top: 3px;
+  margin-left: 10px;
+  color: #b4b4b4;
+}
+
+#help-icon:hover {
+  cursor: pointer;
+}
+
+#select-help-wrapper {
+  display: flex;
+}

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -3,7 +3,7 @@
     <div class="col-sm-3">
       <div id="select-help-wrapper">
         <div class="select-wrapper">
-          <select class="form-control" [(ngModel)]="selectedGeneScores" required>
+          <select class="form-control" [(ngModel)]="selectedGeneScores" [title]="selectedGeneScores.desc" required>
             <option *ngFor="let geneScores of geneScoresArray" [ngValue]="geneScores">{{ geneScores.desc }}</option>
           </select>
           <span class="material-symbols-outlined select-dropdown-icon">arrow_drop_down</span>

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -1,11 +1,20 @@
 <div *ngIf="selectedGeneScores">
   <div class="row panel" id="gene-scores-panel" style="margin-left: 0px; margin-right: 0px">
     <div class="col-sm-3">
-      <div class="select-wrapper">
-        <select class="form-control" [(ngModel)]="selectedGeneScores" required>
-          <option *ngFor="let geneScores of geneScoresArray" [ngValue]="geneScores">{{ geneScores.desc }}</option>
-        </select>
-        <span class="material-symbols-outlined select-dropdown-icon">arrow_drop_down</span>
+      <div id="select-help-wrapper">
+        <div class="select-wrapper">
+          <select class="form-control" [(ngModel)]="selectedGeneScores" required>
+            <option *ngFor="let geneScores of geneScoresArray" [ngValue]="geneScores">{{ geneScores.desc }}</option>
+          </select>
+          <span class="material-symbols-outlined select-dropdown-icon">arrow_drop_down</span>
+        </div>
+        <span
+          [style.visibility]="this.geneScoresLocalState.score.help ? 'visible' : 'hidden'"
+          class="material-symbols-outlined lg"
+          id="help-icon"
+          (click)="showHelp()"
+          >info</span
+        >
       </div>
       <div style="margin-top: 5px">
         <a class="download-link" href="{{ downloadUrl }}">Download</a>
@@ -21,6 +30,8 @@
         [bars]="selectedGeneScores.bars"
         [logScaleX]="selectedGeneScores.logScaleX"
         [logScaleY]="selectedGeneScores.logScaleY"
+        [smallValuesDesc]="selectedGeneScores.smallValuesDesc"
+        [largeValuesDesc]="selectedGeneScores.largeValuesDesc"
         [rangesCounts]="rangesCounts | async"
         [(rangeStart)]="rangeStart"
         [(rangeEnd)]="rangeEnd">

--- a/src/app/gene-scores/gene-scores.component.spec.ts
+++ b/src/app/gene-scores/gene-scores.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalRef, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxsModule } from '@ngxs/store';
 import { ConfigService } from 'app/config/config.service';
 import { Observable } from 'rxjs';
@@ -11,13 +11,19 @@ import { GeneScores } from './gene-scores';
 import { GeneScoresComponent } from './gene-scores.component';
 import { GeneScoresService } from './gene-scores.service';
 import { GeneScoresState } from './gene-scores.state';
+import { PopupComponent } from 'app/popup/popup.component';
 
 class MockGeneScoresService {
   public provide = true;
   public getGeneScores(): Observable<GeneScores[]> {
     if (this.provide) {
-      return of([new GeneScores([1, 2], 'score3', [4, 5], 'desc6', [7, 8], 'xScale9', 'yScale10'),
-        new GeneScores([11, 12], 'score13', [14, 15], 'desc16', [17, 18], 'xScale19', 'yScale20')
+      return of([
+        new GeneScores(
+          [1, 2], [4, 5], 'desc1', 'help1', 'larger1', 'smaller1', 'score31', [7, 8], 'xScale1', 'yScale1'
+        ),
+        new GeneScores(
+          [11, 12], [14, 15], 'desc2', 'help2', 'larger2', 'smaller2', 'score2', [17, 18], 'xScale2', 'yScale2'
+        )
       ]);
     } else {
       return of([] as GeneScores[]);
@@ -27,9 +33,13 @@ class MockGeneScoresService {
 describe('GeneScoresComponent', () => {
   let component: GeneScoresComponent;
   let fixture: ComponentFixture<GeneScoresComponent>;
-  const mockGeneScoresService: MockGeneScoresService = new MockGeneScoresService();
+  let mockGeneScoresService: MockGeneScoresService;
+  let modalService: NgbModal;
+  let modalRef: NgbModalRef;
 
   beforeEach(() => {
+    mockGeneScoresService = new MockGeneScoresService();
+
     TestBed.configureTestingModule({
       imports: [
         NgxsModule.forRoot([GeneScoresState], {developmentMode: true}), HttpClientTestingModule, NgbNavModule
@@ -38,8 +48,13 @@ describe('GeneScoresComponent', () => {
       providers: [{provide: GeneScoresService, useValue: mockGeneScoresService}, ConfigService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
+
+    modalService = TestBed.inject(NgbModal);
+    modalRef = modalService.open(PopupComponent);
+
     fixture = TestBed.createComponent(GeneScoresComponent);
     component = fixture.componentInstance;
+
     fixture.detectChanges();
   });
 
@@ -55,6 +70,22 @@ describe('GeneScoresComponent', () => {
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('div > div.form-block > div.card > ul > li > span'))).toBeTruthy();
     expect(fixture.debugElement.query(By.css('div > div#gene-scores-panel'))).not.toBeTruthy();
+  });
+
+  it('should show help', () => {
+    jest.spyOn(modalService, 'open').mockReturnValue(modalRef);
+    component.showHelp();
+    expect(modalService.open).toHaveBeenCalledWith(PopupComponent, {
+      size: 'lg',
+      centered: true
+    });
+    expect(modalService.open).toHaveBeenCalledWith(PopupComponent, {
+      size: 'lg',
+      centered: true
+    });
+    expect((modalRef.componentInstance as PopupComponent).data).toBe('help1');
+
+    modalRef.close();
   });
 });
 

--- a/src/app/gene-scores/gene-scores.component.ts
+++ b/src/app/gene-scores/gene-scores.component.ts
@@ -9,11 +9,14 @@ import { catchError, debounceTime, distinctUntilChanged, map, switchMap } from '
 import { StatefulComponent } from 'app/common/stateful-component';
 import { ValidateNested } from 'class-validator';
 import { environment } from 'environments/environment';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { PopupComponent } from 'app/popup/popup.component';
 
 @Component({
   encapsulation: ViewEncapsulation.None, // TODO: What is this?
   selector: 'gpf-gene-scores',
   templateUrl: './gene-scores.component.html',
+  styleUrls: ['./gene-scores.component.css'],
 })
 export class GeneScoresComponent extends StatefulComponent implements OnInit {
   private rangeChanges = new ReplaySubject<[string, number, number]>(1);
@@ -23,7 +26,7 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
   public rangesCounts: Observable<Array<number>>;
   public downloadUrl: string;
 
-  @ValidateNested() private geneScoresLocalState = new GeneScoresLocalState();
+  @ValidateNested() public geneScoresLocalState = new GeneScoresLocalState();
 
   public imgPathPrefix = environment.imgPathPrefix;
 
@@ -31,6 +34,7 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
     protected store: Store,
     private geneScoresService: GeneScoresService,
     private config: ConfigService,
+    private modalService: NgbModal
   ) {
     super(store, GeneScoresState, 'geneScores');
     this.partitions = this.rangeChanges.pipe(
@@ -107,6 +111,15 @@ export class GeneScoresComponent extends StatefulComponent implements OnInit {
     this.updateLabels();
     this.downloadUrl = this.getDownloadUrl();
     this.store.dispatch(new SetGeneScore(this.geneScoresLocalState.score));
+  }
+
+  public showHelp(): void {
+    const modalRef = this.modalService.open(PopupComponent, {
+      size: 'lg',
+      centered: true
+    });
+
+    (modalRef.componentInstance as PopupComponent).data = this.geneScoresLocalState.score.help;
   }
 
   public set rangeStart(range: number) {

--- a/src/app/gene-scores/gene-scores.ts
+++ b/src/app/gene-scores/gene-scores.ts
@@ -5,15 +5,18 @@ import { IsMoreThanOrEqual } from '../utils/is-more-than-validator';
 export class GeneScores {
   public readonly logScaleX: boolean;
   public readonly logScaleY: boolean;
-  public static fromJson(json: any): GeneScores {
+  public static fromJson(json: object): GeneScores {
     return new GeneScores(
-      json['bars'],
-      json['score'],
-      json['bins'],
-      json['desc'],
-      json['range'],
-      json['xscale'],
-      json['yscale']
+      json['bars'] as number[],
+      json['bins'] as number[],
+      json['desc'] as string,
+      json['help'] as string,
+      json['large_values_desc'] as string,
+      json['small_values_desc'] as string,
+      json['score'] as string,
+      json['range'] as number[],
+      json['xscale'] as string,
+      json['yscale'] as string
     );
   }
 
@@ -24,12 +27,16 @@ export class GeneScores {
 
   public constructor(
     public readonly bars: number[],
-    public readonly score: string,
     public readonly bins: number[],
     public readonly desc: string,
+    public readonly help: string,
+    public readonly largeValuesDesc: string,
+    public readonly smallValuesDesc: string,
+    public readonly score: string,
     public readonly domain: number[],
     private xScale: string,
-    private yScale: string
+    private yScale: string,
+
   ) {
     if (bins.length === (bars.length + 1)) {
       bars.push(0);

--- a/src/app/genomic-scores/genomic-scores.component.css
+++ b/src/app/genomic-scores/genomic-scores.component.css
@@ -1,6 +1,7 @@
 #help-icon {
   margin-top: 3px;
   margin-left: 10px;
+  color: #b4b4b4;
 }
 
 #help-icon:hover {

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -15,7 +15,7 @@
       class="material-symbols-outlined lg"
       id="help-icon"
       (click)="showHelp()"
-      >help</span
+      >info</span
     >
   </div>
   <div class="col-sm-12">


### PR DESCRIPTION
## Background

Gene scores wasn't provided with additional info/helper for selected score.

## Aim

To add helper

## Implementation

- Add info icon next to gene scores dropdown. After clicking the icon a modal with additional information such as histogram, links, etc is opened. 
- Changed the style of dropdown when the selected text is to long.
- Also changed the style of the helper icon in genomic scores.
