### PR TITLE
fix dataset dropdown first tool navigation bug

### DIFF
--- a/src/app/dataset-node/dataset-node.component.ts
+++ b/src/app/dataset-node/dataset-node.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Dataset, toolPageLinks } from 'app/datasets/datasets';
+import { Dataset } from 'app/datasets/datasets';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { Observable } from 'rxjs';
 import { DatasetNode } from './dataset-node';

--- a/src/app/dataset-node/dataset-node.component.ts
+++ b/src/app/dataset-node/dataset-node.component.ts
@@ -25,14 +25,7 @@ export class DatasetNodeComponent implements OnInit {
 
   public select(openInNewTab = false): void {
     if (this.datasetNode !== undefined && this.datasetNode.dataset !== undefined) {
-      let url: string;
-      const firstTool = this.findFirstTool(this.datasetNode.dataset);
-
-      if (firstTool) {
-        url = `/datasets/${this.datasetNode.dataset.id}/${this.findFirstTool(this.datasetNode.dataset)}`;
-      } else {
-        url = `/datasets/${this.datasetNode.dataset.id}`;
-      }
+      const url = `/datasets/${this.datasetNode.dataset.id}`;
 
       if (!openInNewTab) {
         this.router.navigate([url]);
@@ -42,26 +35,6 @@ export class DatasetNodeComponent implements OnInit {
           newWindow.location.assign(url);
         }
       }
-    }
-  }
-
-  public findFirstTool(selectedDataset: Dataset): string {
-    if (selectedDataset.description) {
-      return toolPageLinks.datasetDescription;
-    } else if (selectedDataset.commonReport.enabled) {
-      return toolPageLinks.datasetStatistics;
-    } else if (selectedDataset.geneBrowser.enabled) {
-      return toolPageLinks.geneBrowser;
-    } else if (selectedDataset.genotypeBrowser && selectedDataset.genotypeBrowserConfig) {
-      return toolPageLinks.genotypeBrowser;
-    } else if (selectedDataset.phenotypeBrowser) {
-      return toolPageLinks.phenotypeBrowser;
-    } else if (selectedDataset.enrichmentTool) {
-      return toolPageLinks.enrichmentTool;
-    } else if (selectedDataset.phenotypeTool) {
-      return toolPageLinks.phenotypeTool;
-    } else {
-      return '';
     }
   }
 }

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -92,15 +92,15 @@ export class DatasetsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.showNoToolsWarning = !this.findFirstTool(this.selectedDataset);
+    const firstTool = this.findFirstTool(this.selectedDataset);
+    this.showNoToolsWarning = !firstTool;
 
     this.registerAlertVisible = !this.selectedDataset.accessRights;
 
     if (!this.isToolSelected()) {
-      const firstTool = this.findFirstTool(this.selectedDataset);
       if (firstTool) {
         this.router.navigate(
-          ['/', 'datasets', this.selectedDataset.id, this.findFirstTool(this.selectedDataset)],
+          ['/', 'datasets', this.selectedDataset.id, firstTool],
           {replaceUrl: true}
         );
       } else {
@@ -111,7 +111,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
       const toolName = url[url.indexOf('datasets') + 2];
 
       if (!this.isToolEnabled(this.selectedDataset, toolName)) {
-        this.router.navigate(['/', 'datasets', this.selectedDataset.id, this.findFirstTool(this.selectedDataset)]);
+        this.router.navigate(['/', 'datasets', this.selectedDataset.id, firstTool]);
       }
     }
   }


### PR DESCRIPTION
## Background
Switching between datasets isn't correctly going to the first tool of the dataset - usually dataset description (if it exists)

## Aim
Fix navigation

## Implementation
Dataset dropdown is using complicated recursive component tree-like logic. Most of the nodes in the "tree" were using data that is incorrectly assumed that it contains tool information. The first root node of the tree (the dataset component) has intercept logic to find the first tool of a dataset when navigating to it by url. The other nodes copy this logic but use incomplete data (which leads to the bug). The solution was to redirect to dataset pages from the child nodes without putting the tool in the url - this way the root dataset component will intercept the navigation and update the destination to the right tool of the dataset. Deletion of duplicate code was enough to implement this.
