### PR TITLE
gene browser: fix table not showing on 0 selected variants

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -231,7 +231,6 @@
       </div>
 
       <gpf-genotype-preview-table
-        *ngIf="showFamilyVariants"
         [columns]="selectedDataset?.genotypeBrowserConfig?.tableColumns"
         [genotypePreviewVariantsArray]="genotypePreviewVariantsArray"
         [legend]="legend">

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -38,7 +38,6 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public selectedDataset: Dataset;
   public showResults: boolean;
   public showError = false;
-  public showFamilyVariants = false;
   public familyVariantsLoaded = false;
   public geneBrowserConfig: GeneBrowser;
 
@@ -94,12 +93,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
 
     this.subscriptions.push(
       this.queryService.streamingStartSubject.subscribe(() => {
-        this.showFamilyVariants = false;
         this.familyVariantsLoaded = false;
         this.variantsCountDisplay = 'Loading variants...';
-      }),
-      this.queryService.streamingUpdateSubject.subscribe(() => {
-        this.showFamilyVariants = true;
       }),
       this.queryService.streamingFinishedSubject.subscribe(() => {
         this.familyVariantsLoaded = true;

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -1,6 +1,6 @@
 import {
-  ContentChild, ViewChildren, ViewChild, HostListener, Input, Component,
-  ContentChildren, QueryList, AfterViewChecked, ElementRef, ChangeDetectorRef
+  ContentChild, ViewChildren, ViewChild, HostListener, Input, Component, ContentChildren, QueryList,
+  AfterViewChecked, ElementRef, ChangeDetectorRef, OnChanges, SimpleChanges
 } from '@angular/core';
 import { GpfTableColumnComponent } from './component/column.component';
 import { GpfTableSubheaderComponent } from './component/subheader.component';
@@ -18,7 +18,7 @@ export class SortInfo {
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.css'],
 })
-export class GpfTableComponent implements AfterViewChecked {
+export class GpfTableComponent implements OnChanges, AfterViewChecked {
   @ViewChild('table') public tableViewChild: any;
   @ViewChild('header', { read: ElementRef }) public tableHeader: ElementRef;
   @ViewChildren('rows') public rowViewChildren: QueryList<any>;
@@ -41,6 +41,12 @@ export class GpfTableComponent implements AfterViewChecked {
   public showLegend: boolean;
 
   public constructor(private cdr: ChangeDetectorRef) { }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes['dataSource']) {
+      this.tableData = this.getVisibleData();
+    }
+  }
 
   public ngAfterViewChecked(): void {
     if (this.tableData.length < (this.getScrollIndices()[1] - this.getScrollIndices()[0])) {


### PR DESCRIPTION
In gene browser, the genotype preview table wouldn't show when there are 0 selected varaints

closes https://github.com/iossifovlab/gpfjs/issues/956