### PR TITLE
Families by pedigree refactor tag checkboxes

### DIFF
--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -203,6 +203,7 @@ h5 {
 #clear-filters-button {
   white-space: nowrap;
   color: #2a6395;
+  user-select: none;
 }
 
 #clear-filters-button:hover {
@@ -235,6 +236,7 @@ h5 {
 
 #families-sum {
   margin-right: 15px;
+  min-width: 100px;
 }
 
 .tags {

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -178,7 +178,6 @@ h5 {
 
 ::ng-deep .modal-content {
   width: fit-content;
-  min-width: 500px;
 }
 
 #selected-tags-list {
@@ -201,16 +200,12 @@ h5 {
   margin-bottom: 10px;
 }
 
-.search-input {
-  padding-right: 5px;
-}
-
-#uncheck-button {
+#clear-filters-button {
   white-space: nowrap;
   color: #2a6395;
 }
 
-#uncheck-button:hover {
+#clear-filters-button:hover {
   cursor: pointer;
   color: #163d5f;
 }
@@ -240,4 +235,26 @@ h5 {
 
 #families-sum {
   margin-right: 15px;
+}
+
+.tags {
+  color: #cdcdcd;
+  font-size: 22px;
+}
+
+.tags:hover {
+  cursor: pointer;
+}
+
+.selected-tag {
+  color: green;
+}
+
+.deselected-tag {
+  color: red;
+}
+
+.modal-content-lines {
+  display: flex;
+  align-items: center;
 }

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -188,7 +188,7 @@ h5 {
 }
 
 #tags-modal-content {
-  padding: 20px;
+  padding: 8px 20px;
   height: fit-content;
   width: fit-content;
 }
@@ -240,21 +240,39 @@ h5 {
 .tags {
   color: #cdcdcd;
   font-size: 22px;
+  user-select: none;
 }
 
 .tags:hover {
   cursor: pointer;
 }
 
-.selected-tag {
-  color: green;
-}
-
-.deselected-tag {
-  color: red;
-}
-
 .modal-content-lines {
   display: flex;
   align-items: center;
+}
+
+.and-toggle-button {
+  color: #2a6395;
+  width: 70px;
+  padding: 0 20px;
+  border-radius: 5px 0 0 5px;
+  border: 1px solid #2a6395;
+}
+
+.or-toggle-button {
+  color: #2a6395;
+  width: 70px;
+  padding: 0 20px;
+  border-radius: 0 5px 5px 0;
+  border: 1px solid #2a6395;
+}
+
+#mode-label {
+  margin-right: 10px;
+}
+
+.selected-mode {
+  background-color: #2a6395;
+  color: white;
 }

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -94,16 +94,21 @@
       <div id="pedigree-toolbar">
         <button (click)="openModal()" id="open-modal-button">Select tags</button>
         <span *ngIf="tagsHeader" id="selected-tags-list" [title]="tagsHeader">{{ tagsHeader }}</span>
-        <div>
+        <form
+          id="dl-form"
+          (ngSubmit)="downloadTags($event)"
+          action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDataset.id }}"
+          method="post">
           <span id="families-sum">All families: {{ familiesCount }}</span>
+          <input name="queryData" type="hidden" />
           <button
-            [disabled]="currentPedigreeTable.pedigrees.length === 0"
+            class="btn btn-md btn-primary btn-right"
             id="download-button"
-            (click)="downloadTags()"
-            class="btn btn-md btn-primary"
+            [disabled]="currentPedigreeTable.pedigrees.length === 0"
+            type="submit"
             >Download</button
           >
-        </div>
+        </form>
       </div>
       <ng-template #tagsModal class="tags-modal">
         <div id="tags-modal-content">

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -143,14 +143,14 @@
               <span
                 class="material-icons tags"
                 [id]="tag + '-tag-add'"
-                (click)="addFilter(tag)"
+                (click)="selectFilter(tag)"
                 [ngStyle]="{ color: filtersButtonsState[tag] === 1 ? 'green' : '#cdcdcd' }"
                 >add_circle</span
               >
               <span
                 class="material-icons tags"
                 [id]="tag + '-tag-remove'"
-                (click)="removeFilter(tag)"
+                (click)="deselectFilter(tag)"
                 [ngStyle]="{ color: filtersButtonsState[tag] === -1 ? 'red' : '#cdcdcd' }"
                 >remove_circle</span
               >

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -108,7 +108,21 @@
       <ng-template #tagsModal class="tags-modal">
         <div id="tags-modal-content">
           <div id="tags-modal-header">
-            <!-- and / or -->
+            <div>
+              <span id="mode-label">Choose mode: </span>
+              <button
+                class="and-toggle-button"
+                (click)="tagIntersection = true; updateTagFilters()"
+                [ngClass]="{ 'selected-mode': tagIntersection }"
+                >And</button
+              >
+              <button
+                class="or-toggle-button"
+                (click)="tagIntersection = false; updateTagFilters()"
+                [ngClass]="{ 'selected-mode': !tagIntersection }"
+                >Or</button
+              >
+            </div>
             <a (click)="clearFilters()" id="clear-filters-button">Clear filters</a>
           </div>
 
@@ -121,8 +135,18 @@
               'column-gap': '16px'
             }">
             <div *ngFor="let tag of orderedTagList" class="modal-content-lines">
-              <span class="material-icons tags" [id]="tag + '-tag-add'" (click)="addFilter(tag)">add_circle</span>
-              <span class="material-icons tags" [id]="tag + '-tag-remove'" (click)="removeFilter(tag)"
+              <span
+                class="material-icons tags"
+                [id]="tag + '-tag-add'"
+                (click)="addFilter(tag)"
+                [ngStyle]="{ color: filtersButtonsState[tag] === 1 ? 'green' : '#cdcdcd' }"
+                >add_circle</span
+              >
+              <span
+                class="material-icons tags"
+                [id]="tag + '-tag-remove'"
+                (click)="removeFilter(tag)"
+                [ngStyle]="{ color: filtersButtonsState[tag] === -1 ? 'red' : '#cdcdcd' }"
                 >remove_circle</span
               >
               <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -131,17 +131,13 @@
               'column-gap': '16px'
             }">
             <div *ngFor="let tag of orderedTagList">
-              <input
-                [disabled]="!tag.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase())"
-                type="checkbox"
-                [id]="tag + '-tag'"
-                [checked]="selectedItems.includes(tag)"
-                (change)="updateSelectedTags(tag)" />
-              <label
+              <span class="material-icons" [id]="tag + '-tag-add'" (click)="addFilter(tag)">add_circle</span>
+              <span class="material-icons" [id]="tag + '-tag-remove'" (click)="removeFilter(tag)">remove_circle</span>
+              <span
                 [attr.for]="tag + '-tag'"
                 id="tag-label"
                 [ngStyle]="!tag.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) && { opacity: '30%' }"
-                >{{ tag }}</label
+                >{{ tag }}</span
               >
             </div>
           </div>

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -98,7 +98,8 @@
           id="dl-form"
           (ngSubmit)="downloadTags($event)"
           action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDataset.id }}"
-          method="post">
+          method="post"
+          style="display: flex; align-items: center">
           <span id="families-sum">All families: {{ familiesCount }}</span>
           <input name="queryData" type="hidden" />
           <button
@@ -117,13 +118,13 @@
               <span id="mode-label">Choose mode: </span>
               <button
                 class="and-toggle-button"
-                (click)="tagIntersection = true; updateTagFilters()"
+                (click)="tagIntersection = true; updateTagsHeader()"
                 [ngClass]="{ 'selected-mode': tagIntersection }"
                 >And</button
               >
               <button
                 class="or-toggle-button"
-                (click)="tagIntersection = false; updateTagFilters()"
+                (click)="tagIntersection = false; updateTagsHeader()"
                 [ngClass]="{ 'selected-mode': !tagIntersection }"
                 >Or</button
               >

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -93,9 +93,7 @@
 
       <div id="pedigree-toolbar">
         <button (click)="openModal()" id="open-modal-button">Select tags</button>
-        <span *ngIf="selectedTagsHeader" id="selected-tags-list" [title]="selectedTagsHeader">{{
-          selectedTagsHeader
-        }}</span>
+        <span *ngIf="tagsHeader" id="selected-tags-list" [title]="tagsHeader">{{ tagsHeader }}</span>
         <div>
           <span id="families-sum">All families: {{ familiesCount }}</span>
           <button
@@ -110,16 +108,8 @@
       <ng-template #tagsModal class="tags-modal">
         <div id="tags-modal-content">
           <div id="tags-modal-header">
-            <input
-              #searchTag
-              (search)="search(searchTag.value)"
-              (keyup)="search(searchTag.value)"
-              id="search-tags"
-              class="search-input form-control my-0 py-1"
-              type="search"
-              placeholder="Search tags"
-              autocomplete="off" />
-            <a (click)="uncheckAll()" id="uncheck-button">Uncheck all</a>
+            <!-- and / or -->
+            <a (click)="clearFilters()" id="clear-filters-button">Clear filters</a>
           </div>
 
           <div
@@ -130,15 +120,12 @@
               'grid-template-rows': 'repeat(' + tagsModalsNumberOfRows + ', 30px)',
               'column-gap': '16px'
             }">
-            <div *ngFor="let tag of orderedTagList">
-              <span class="material-icons" [id]="tag + '-tag-add'" (click)="addFilter(tag)">add_circle</span>
-              <span class="material-icons" [id]="tag + '-tag-remove'" (click)="removeFilter(tag)">remove_circle</span>
-              <span
-                [attr.for]="tag + '-tag'"
-                id="tag-label"
-                [ngStyle]="!tag.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) && { opacity: '30%' }"
-                >{{ tag }}</span
+            <div *ngFor="let tag of orderedTagList" class="modal-content-lines">
+              <span class="material-icons tags" [id]="tag + '-tag-add'" (click)="addFilter(tag)">add_circle</span>
+              <span class="material-icons tags" [id]="tag + '-tag-remove'" (click)="removeFilter(tag)"
+                >remove_circle</span
               >
+              <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>
             </div>
           </div>
         </div>

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -119,8 +119,6 @@ export class VariantReportsComponent implements OnInit {
       this.filtersButtonsState[tag] = 1;
     }
     this.updateSelectedTagsList(tag);
-    this.updateTagFilters();
-    this.updateFamiliesCount();
   }
 
   public deselectFilter(tag: string): void {
@@ -130,8 +128,6 @@ export class VariantReportsComponent implements OnInit {
       this.filtersButtonsState[tag] = -1;
     }
     this.updateDeselectedTagsList(tag);
-    this.updateTagFilters();
-    this.updateFamiliesCount();
   }
 
   public updateSelectedTagsList(tag: string): void {
@@ -163,21 +159,24 @@ export class VariantReportsComponent implements OnInit {
   }
 
   public updateTagsHeader(): void {
+    const separator = this.tagIntersection ? ' and ' : ' or ';
     this.tagsHeader = '';
     if (this.selectedTags.length > 0) {
-      this.tagsHeader += this.selectedTags.join(', ');
+      this.tagsHeader += this.selectedTags.join(separator);
     }
 
     if (this.deselectedTags.length > 0) {
       if (this.tagsHeader !== '') {
-        this.tagsHeader += ', ';
+        this.tagsHeader += separator;
       }
-      this.tagsHeader += 'not ' + this.deselectedTags.join(', not ');
+      this.tagsHeader += 'not ' + this.deselectedTags.join(separator + ' not ');
     }
 
     if (this.selectedTags.length === 0 && this.deselectedTags.length === 0) {
       this.tagsHeader = '';
     }
+    this.updateTagFilters();
+    this.updateFamiliesCount();
   }
 
 
@@ -209,6 +208,7 @@ export class VariantReportsComponent implements OnInit {
     this.tagsHeader = '';
     this.filtersButtonsState = _.mapValues(this.filtersButtonsState, () => 0);
     this.updateTagFilters();
+    this.updateFamiliesCount();
   }
 
   public updatePedigrees(newCounters: Dictionary<PedigreeCounter[]>): void {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -112,7 +112,7 @@ export class VariantReportsComponent implements OnInit {
     );
   }
 
-  public addFilter(tag: string): void {
+  public selectFilter(tag: string): void {
     if (this.filtersButtonsState[tag] === 1) {
       this.filtersButtonsState[tag] = 0;
     } else {
@@ -123,7 +123,7 @@ export class VariantReportsComponent implements OnInit {
     this.updateFamiliesCount();
   }
 
-  public removeFilter(tag: string): void {
+  public deselectFilter(tag: string): void {
     if (this.filtersButtonsState[tag] === -1) {
       this.filtersButtonsState[tag] = 0;
     } else {
@@ -168,17 +168,18 @@ export class VariantReportsComponent implements OnInit {
       this.tagsHeader += this.selectedTags.join(', ');
     }
 
-    if (this.deselectedTags.length > 0 && this.selectedTags.length > 0) {
-      this.tagsHeader += ', ';
-      this.tagsHeader += this.deselectedTags.join(', ');
-    } else {
-      this.tagsHeader += this.deselectedTags.join(', ');
+    if (this.deselectedTags.length > 0) {
+      if (this.tagsHeader !== '') {
+        this.tagsHeader += ', ';
+      }
+      this.tagsHeader += 'not ' + this.deselectedTags.join(', not ');
     }
 
     if (this.selectedTags.length === 0 && this.deselectedTags.length === 0) {
       this.tagsHeader = '';
     }
   }
+
 
   public updateFamiliesCount(): void {
     this.familiesCount = 0;
@@ -220,8 +221,6 @@ export class VariantReportsComponent implements OnInit {
     const copiedCounters = this.copyOriginalPedigreeCounters();
     const filteredCounters = {};
     for (const [groupName, counters] of Object.entries(copiedCounters)) {
-      console.log(counters);
-
       filteredCounters[groupName] =
         counters.filter(x => {
           if (this.tagIntersection) {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -10,6 +10,7 @@ import { environment } from 'environments/environment';
 import { Dictionary } from 'lodash';
 import * as _ from 'lodash';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { ConfigService } from 'app/config/config.service';
 
 @Pipe({ name: 'getPeopleCounterRow' })
 export class PeopleCounterRowPipe implements PipeTransform {
@@ -59,6 +60,7 @@ export class VariantReportsComponent implements OnInit {
 
   public constructor(
     public modalService: NgbModal,
+    public config: ConfigService,
     private variantReportsService: VariantReportsService,
     private datasetsService: DatasetsService
   ) { }
@@ -277,10 +279,23 @@ export class VariantReportsComponent implements OnInit {
     return this.variantReportsService.getDownloadLink();
   }
 
-  public downloadTags(): void {
-    const tags = this.selectedTags.join(',');
-    // to do deselectedTags
-    location.href = this.variantReportsService.getDownloadLinkTags(tags);
+  public downloadTags(event): void {
+    let body = {};
+    if (this.selectedTags.length || this.deselectedTags.length) {
+      body = {
+        tagsQuery: {
+          orMode: !this.tagIntersection,
+          includeTags: this.selectedTags,
+          excludeTags: this.deselectedTags
+        }
+      };
+    }
+
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    event.target.queryData.value = JSON.stringify(body);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    event.target.submit();
+    /* eslint-enable */
   }
 
   private orderByColumnOrder(childrenCounters: DeNovoData[], columns: string[], strict = false): DeNovoData[] {

--- a/src/app/variant-reports/variant-reports.service.ts
+++ b/src/app/variant-reports/variant-reports.service.ts
@@ -31,15 +31,6 @@ export class VariantReportsService {
     return `${environment.apiPath}${this.downloadUrl}${selectedDatasetId}`;
   }
 
-  public getDownloadLinkTags(tags: string): string {
-    const selectedDatasetId = this.datasetsService.getSelectedDataset().id;
-    let url = `${this.config.baseUrl}${this.downloadUrl}${selectedDatasetId}`;
-    if (tags) {
-      url = `${url}?${new URLSearchParams({'tags': tags})}`;
-    }
-    return url;
-  }
-
   public getFamilies(datasetId: string, groupName: string, counterId: number): Observable<string[]> {
     const options = { withCredentials: true };
     const data = { study_id: datasetId, group_name: groupName, counter_id: counterId };


### PR DESCRIPTION
## Background

New functionalities need to be add: 
- make deselecting tags possible. When tag is deselected it means it shows pedigrees which don't have this tag
- add mode "Or". Current implementation supports only logical operation "And". When selecting or deselecting multiple tags we want to choose if we want to apply logical operator "And" or "Or"

## Aim

To add the new features.

## Implementation

- Remove searching functionality.
- Add + (for selecting)  and - (for deselecting) icons for each tag. Each tag has state marked with 1 (selected), 0 (neutral) and -1 (deselected) saved in `filtersButtonsState: Record<string, number>`
- Add toggle button for choosing which mode to be applied ("And" and "Or"). There is boolean variable which says which is the current mode. Default is `tagIntersection = true;` which says that "And" mode is selected.
- Update download
- Add unit tests