### PR TITLE
fix pheno tool chart result

### DIFF
--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -1,5 +1,9 @@
 <div class="description">{{ phenoToolResults.description }}</div>
-<svg [attr.width]="width" [attr.height]="height">
+<svg
+  [attr.width]="width > 4 ? width * 300 : 1100"
+  [attr.height]="height"
+  [style.margin-left]="width > 4 ? width * width * -4 : 0"
+  [attr.transform]="'scale(' + (1 - width * 0.02) + ')'">
   <text x="0" y="45">with hit</text>
   <text x="0" y="65">without hit</text>
 
@@ -12,7 +16,7 @@
       [yScale]="yScale"></g>
   </g>
 
-  <g transform="translate(800, 550)">
+  <g [attr.transform]="'translate(' + width * 220 + ', 600)'">
     <rect x="0" y="0" width="150" height="65" fill-opacity="0" stroke-width="2" stroke="black"></rect>
     <circle cx="10" cy="10" r="3" stroke="blue" fill="blue" stroke-width="2"></circle>
     <text x="20" y="15">male with hit</text>

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -2,7 +2,7 @@
 <svg
   [attr.width]="width > 4 ? width * 300 : 1100"
   [attr.height]="height"
-  [style.margin-left]="width > 4 ? width * width * -4 : 0"
+  [style.margin-left]="width > 4 ? width * -70 : 0"
   [attr.transform]="'scale(' + (1 - width * 0.02) + ')'">
   <text x="0" y="45">with hit</text>
   <text x="0" y="65">without hit</text>

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.spec.ts
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.spec.ts
@@ -14,7 +14,7 @@ describe('PhenoToolResultsChartComponent', () => {
     component = fixture.componentInstance;
     component.phenoToolResults = {
       description: undefined,
-      results: undefined
+      results: []
     };
     fixture.detectChanges();
   }));

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.ts
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 import { PhenoToolResults, PhenoToolResult } from '../pheno-tool/pheno-tool-results';
 import * as d3 from 'd3';
 
@@ -7,13 +7,17 @@ import * as d3 from 'd3';
   templateUrl: './pheno-tool-results-chart.component.html',
   styleUrls: ['./pheno-tool-results-chart.component.css']
 })
-export class PhenoToolResultsChartComponent implements OnChanges {
+export class PhenoToolResultsChartComponent implements OnInit, OnChanges {
   @ViewChild('innerGroup', {static: true}) public innerGroup: any;
   @Input() public phenoToolResults: PhenoToolResults;
   @Input() public width = 1060;
   @Input() public height = 700;
   @Input() public innerHeight = 450;
   public yScale: d3.ScaleLinear<number, number>;
+
+  public ngOnInit(): void {
+    this.width = this.phenoToolResults.results.length;
+  }
 
   public ngOnChanges(): void {
     this.yScale = d3.scaleLinear().range([this.innerHeight, 0]);


### PR DESCRIPTION
## Background

Pheno tool result is cut when more than 4 effect types are selected because the width of the chart is fixed.
![image](https://github.com/iossifovlab/gpfjs/assets/56651698/c0d135aa-33e7-4022-b067-7c42ac8252b3)

## Aim

To fix it.

## Implementation

Make the width dynamically and scale down the chart when more effect types are selected.