### PR TITLE
add close button to info modal

### DIFF
--- a/src/app/popup/popup.component.css
+++ b/src/app/popup/popup.component.css
@@ -5,3 +5,9 @@
   overflow-y: auto;
   overflow-wrap: break-word;
 }
+
+#close-button {
+  float: right;
+  border: none;
+  background-color: transparent;
+}

--- a/src/app/popup/popup.component.html
+++ b/src/app/popup/popup.component.html
@@ -1,3 +1,4 @@
 <div class="modal-body">
+  <button id="close-button" class="material-symbols-outlined bold clickable" (click)="closeModal()">close</button>
   <markdown [data]="data"></markdown>
 </div>


### PR DESCRIPTION
## Background

The helper modal in Gene scores and Genomic scores doesn't have close button.

## Aim

To add close button.

## Implementation

Add button.
