### PR TITLE
Update pheno browser download api

### DIFF
--- a/src/app/pheno-browser/pheno-browser.component.css
+++ b/src/app/pheno-browser/pheno-browser.component.css
@@ -102,3 +102,11 @@
   align-items: center;
   margin-left: auto;
 }
+
+.warning-modal div {
+  background-color: #ffecb5;
+}
+
+.modal {
+  background: #0000007b;
+}

--- a/src/app/pheno-browser/pheno-browser.component.html
+++ b/src/app/pheno-browser/pheno-browser.component.html
@@ -55,3 +55,19 @@
 <div *ngIf="measuresToShow$ | async as measuresToShow" class="col-lg-12" style="padding: 0 30px">
   <gpf-pheno-browser-table [measures]="measuresToShow"></gpf-pheno-browser-table>
 </div>
+
+<div *ngIf="errorModal">
+  <div style="display: flex; align-items: center" class="modal" role="dialog" aria-hidden="true">
+    <div class="modal-dialog warning-modal">
+      <div class="modal-content">
+        <div class="modal-header" style="border-bottom: 0">
+          <h5 class="modal-title">Warning</h5>
+        </div>
+        <div class="modal-body">Too many instruments, select less than 1900!</div>
+        <div class="modal-footer" style="border-top: 0">
+          <button type="button" class="btn btn-secondary" (click)="errorModalBack()">Back</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pheno-browser/pheno-browser.component.html
+++ b/src/app/pheno-browser/pheno-browser.component.html
@@ -37,16 +37,10 @@
       </div>
       <div id="download-wrapper">
         <span>Phenotype measures</span>
-        <form
-          id="dl-form"
-          (ngSubmit)="downloadMeasures($event)"
-          action="{{ configService.baseUrl }}pheno_browser/download"
-          method="post">
-          <input name="queryData" type="hidden" />
-          <button id="download-measures" class="btn btn-md btn-primary btn-right" type="submit">
-            <span class="material-symbols-outlined">download</span>
-          </button>
-        </form>
+        <input name="queryData" type="hidden" />
+        <button (click)="downloadMeasures()" id="download-measures" class="btn btn-md btn-primary btn-right">
+          <span class="material-symbols-outlined">download</span>
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -30,6 +30,7 @@ import { ConfigService } from 'app/config/config.service';
 import { RegressionComparePipe } from 'app/utils/regression-compare.pipe';
 import { GetRegressionIdsPipe } from 'app/utils/get-regression-ids.pipe';
 import { BackgroundColorPipe } from 'app/utils/background-color.pipe';
+import { HttpClient, HttpHandler } from '@angular/common/http';
 
 const fakeJsonMeasurei1 = JSON.parse(JSON.stringify(fakeJsonMeasureOneRegression)) as object;
 fakeJsonMeasurei1['instrument_name'] = 'i1';
@@ -125,6 +126,8 @@ describe('PhenoBrowserComponent', () => {
         PhenoBrowserComponent, GetRegressionIdsPipe, BackgroundColorPipe],
       providers: [
         PhenoBrowserComponent,
+        HttpClient,
+        HttpHandler,
         { provide: DatasetsService, useValue: datasetServiceMock },
         { provide: PhenoBrowserService, useValue: phenoBrowserServiceMock },
         { provide: ActivatedRoute, useValue: activatedRoute },

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -23,7 +23,7 @@ import { NumberWithExpPipe } from '../utils/number-with-exp.pipe';
 import { PValueIntensityPipe } from '../utils/p-value-intensity.pipe';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { ResizeService } from '../table/resize.service';
 import { By } from '@angular/platform-browser';
 import { ConfigService } from 'app/config/config.service';
@@ -61,8 +61,12 @@ class MockPhenoBrowserService {
            + `?dataset_id=${datasetId}&instrument=${instrument}`;
   }
 
-  public downloadMeasures(): Observable<Blob> {
-    return of([] as any);
+  public validateMeasureDownload(): Observable<{status: number}> {
+    return of({status: undefined});
+  }
+
+  public getDownloadMeasuresLink(): string {
+    return '';
   }
 }
 
@@ -238,23 +242,38 @@ describe('PhenoBrowserComponent', () => {
   }));
 
   it('should test download', () => {
-    const mockEvent = {
-      target: document.createElement('form'),
-      preventDefault: jest.fn()
-    };
-    mockEvent.target.queryData = {
-      value: ''
-    };
-
-    jest.spyOn(mockEvent.target, 'submit').mockImplementation();
-    component.downloadMeasures(mockEvent as unknown as Event);
-    expect((mockEvent.target.queryData as HTMLInputElement).value).toStrictEqual(JSON.stringify({
+    const data = {
       /* eslint-disable @typescript-eslint/naming-convention */
-      dataset_id: component.selectedDataset.id,
-      instrument: null,
-      measure_ids: ['i1.test_measure']
+      dataset_id: 'datasetId',
+      instrument: 'instrument',
+      search_term: 'search'
       /* eslint-enable */
-    }));
-    expect(mockEvent.target.submit).toHaveBeenCalledTimes(1);
+    };
+    component.selectedDatasetId = data.dataset_id;
+    component.selectedInstrument$ = new BehaviorSubject(data.instrument);
+    component.searchTermObs$ = of(data.search_term);
+
+    const validateSpy = jest.spyOn(phenoBrowserServiceMock, 'validateMeasureDownload');
+    const downloadSpy = jest.spyOn(phenoBrowserServiceMock, 'getDownloadMeasuresLink');
+
+    validateSpy.mockReturnValue(of({ status: 404 }));
+    component.downloadMeasures();
+    expect(validateSpy).toHaveBeenCalledWith(data);
+    expect(downloadSpy).not.toHaveBeenCalled();
+    expect(component.errorModal).toBe(false);
+
+    validateSpy.mockReturnValue(of({ status: 413 }));
+    component.downloadMeasures();
+    expect(validateSpy).toHaveBeenCalledWith(data);
+    expect(downloadSpy).not.toHaveBeenCalled();
+    expect(component.errorModal).toBe(true);
+
+    component.errorModal = false;
+
+    validateSpy.mockReturnValue(of({ status: 200 }));
+    component.downloadMeasures();
+    expect(validateSpy).toHaveBeenCalledWith(data);
+    expect(downloadSpy).toHaveBeenCalledWith(data);
+    expect(component.errorModal).toBe(false);
   });
 });

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -18,14 +18,14 @@ import { HttpClient } from '@angular/common/http';
 })
 export class PhenoBrowserComponent implements OnInit {
   public selectedInstrument$: BehaviorSubject<PhenoInstrument> = new BehaviorSubject<PhenoInstrument>(undefined);
-  private searchTermObs$: Observable<string>;
+  public searchTermObs$: Observable<string>;
   private measuresToShow: PhenoMeasures;
   public measuresToShow$: Observable<PhenoMeasures>;
   public errorModal = false;
 
   public instruments: Observable<PhenoInstruments>;
 
-  private selectedDatasetId: string;
+  public selectedDatasetId: string;
   public selectedDataset: Dataset;
 
   public input$ = new ReplaySubject<string>(1);

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { ActivatedRoute, Router, Params } from '@angular/router';
 import { Location } from '@angular/common';
-import { Observable, BehaviorSubject, ReplaySubject, combineLatest, of } from 'rxjs';
+import { Observable, BehaviorSubject, ReplaySubject, combineLatest, of, zip } from 'rxjs';
 import { PhenoBrowserService } from './pheno-browser.service';
 import { PhenoInstruments, PhenoInstrument, PhenoMeasures, PhenoMeasure } from './pheno-browser';
 import { Dataset } from 'app/datasets/datasets';
@@ -9,6 +9,7 @@ import { DatasetsService } from '../datasets/datasets.service';
 import { debounceTime, distinctUntilChanged, map, share, switchMap, take, tap } from 'rxjs/operators';
 import { environment } from 'environments/environment';
 import { ConfigService } from 'app/config/config.service';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'gpf-pheno-browser',
@@ -17,8 +18,10 @@ import { ConfigService } from 'app/config/config.service';
 })
 export class PhenoBrowserComponent implements OnInit {
   public selectedInstrument$: BehaviorSubject<PhenoInstrument> = new BehaviorSubject<PhenoInstrument>(undefined);
+  private searchTermObs$: Observable<string>;
   private measuresToShow: PhenoMeasures;
   public measuresToShow$: Observable<PhenoMeasures>;
+  public errorModal = false;
 
   public instruments: Observable<PhenoInstruments>;
 
@@ -32,6 +35,7 @@ export class PhenoBrowserComponent implements OnInit {
   public imgPathPrefix = environment.imgPathPrefix;
 
   public constructor(
+    private http: HttpClient,
     private route: ActivatedRoute,
     private router: Router,
     private phenoBrowserService: PhenoBrowserService,
@@ -53,13 +57,13 @@ export class PhenoBrowserComponent implements OnInit {
   }
 
   private initMeasuresToShow(datasetId: string): void {
-    const searchTermObs$ = this.input$.pipe(
+    this.searchTermObs$ = this.input$.pipe(
       map((searchTerm: string) => searchTerm.trim()),
       debounceTime(300),
       distinctUntilChanged()
     );
 
-    this.measuresToShow$ = combineLatest([searchTermObs$, this.selectedInstrument$]).pipe(
+    this.measuresToShow$ = combineLatest([this.searchTermObs$, this.selectedInstrument$]).pipe(
       tap(([searchTerm, newSelection]) => {
         this.measuresToShow = null;
         const queryParamsObject: any = {};
@@ -118,26 +122,34 @@ export class PhenoBrowserComponent implements OnInit {
   }
 
   public downloadMeasures(event: Event): void {
-    this.selectedInstrument$.pipe(take(1)).subscribe(instrument => {
-      if (instrument === '') {
-        instrument = null;
-      }
-
-      const measureIds = this.measuresToShow.measures.map(m => m.measureId);
-
-      /* eslint-disable @typescript-eslint/naming-convention */
-      const data = {
-        dataset_id: this.selectedDatasetId,
-        instrument: instrument,
-        measure_ids: measureIds
-      };
-      /* eslint-enable */
-
-      if (event.target instanceof HTMLFormElement) {
-        (event.target.queryData as HTMLInputElement).value = JSON.stringify(data);
-        event.target.submit();
-      }
-    });
+    combineLatest([this.searchTermObs$, this.selectedInstrument$])
+      .pipe(
+        take(1),
+        switchMap(([searchTerm, instrument]) => {
+          if (instrument === '') {
+            instrument = null;
+          }
+          /* eslint-disable @typescript-eslint/naming-convention */
+          const data = {
+            dataset_id: this.selectedDatasetId,
+            instrument: instrument,
+            search_term: searchTerm
+          };
+          /* eslint-enable */
+          return zip(of(data), this.http
+            .head(`${this.configService.baseUrl}pheno_browser/download`, {params: data})
+            .pipe(map(response => response as PhenoInstruments)))
+        })
+      ).subscribe(([data, validity]) => {
+        if (validity.status === 200) {
+          if (event.target instanceof HTMLFormElement) {
+            (event.target.queryData as HTMLInputElement).value = JSON.stringify(data);
+            event.target.submit();
+          }
+        } else if (validity.status === 413) {
+          errorModal = true;
+        }
+      });
   }
 
   public search(value: string): void {
@@ -159,5 +171,9 @@ export class PhenoBrowserComponent implements OnInit {
     this.waitForSearchBoxToLoad().then(() => {
       this.searchBox.nativeElement.focus();
     });
+  }
+
+  public errorModalBack(): void {
+    this.errorModal = false;
   }
 }

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -121,7 +121,7 @@ export class PhenoBrowserComponent implements OnInit {
     this.selectedInstrument$.next(instrument);
   }
 
-  public downloadMeasures(event: Event): void {
+  public downloadMeasures(): void {
     combineLatest([this.searchTermObs$, this.selectedInstrument$])
       .pipe(
         take(1),
@@ -135,19 +135,13 @@ export class PhenoBrowserComponent implements OnInit {
           /* eslint-enable */
           return zip(
             of(data),
-            this.phenoBrowserService.validateMeasureDownload(
-              this.selectedDatasetId,
-              instrument,
-              searchTerm
-            )
+            this.phenoBrowserService.validateMeasureDownload(data)
           );
         })
       ).subscribe(([data, validity]) => {
         if (validity.status === 200) {
-          if (event.target instanceof HTMLFormElement) {
-            (event.target.queryData as HTMLInputElement).value = JSON.stringify(data);
-            event.target.submit();
-          }
+          // this.phenoBrowserService.getDownloadMeasuresLink(data)
+          window.open(this.phenoBrowserService.getDownloadMeasuresLink(data));
         } else if (validity.status === 413) {
           this.errorModal = true;
         }

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -126,9 +126,6 @@ export class PhenoBrowserComponent implements OnInit {
       .pipe(
         take(1),
         switchMap(([searchTerm, instrument]) => {
-          if (instrument === '') {
-            instrument = null;
-          }
           /* eslint-disable @typescript-eslint/naming-convention */
           const data = {
             dataset_id: this.selectedDatasetId,
@@ -136,9 +133,14 @@ export class PhenoBrowserComponent implements OnInit {
             search_term: searchTerm
           };
           /* eslint-enable */
-          return zip(of(data), this.http
-            .head(`${this.configService.baseUrl}pheno_browser/download`, {params: data})
-            .pipe(map(response => response as PhenoInstruments)))
+          return zip(
+            of(data),
+            this.phenoBrowserService.validateMeasureDownload(
+              this.selectedDatasetId,
+              instrument,
+              searchTerm
+            )
+          );
         })
       ).subscribe(([data, validity]) => {
         if (validity.status === 200) {
@@ -147,7 +149,7 @@ export class PhenoBrowserComponent implements OnInit {
             event.target.submit();
           }
         } else if (validity.status === 413) {
-          errorModal = true;
+          this.errorModal = true;
         }
       });
   }

--- a/src/app/pheno-browser/pheno-browser.service.ts
+++ b/src/app/pheno-browser/pheno-browser.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
-import { Observable, Subject } from 'rxjs';
+import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
+import { Observable, Subject, of } from 'rxjs';
 import { CookieService } from 'ngx-cookie-service';
 import { PhenoInstruments, PhenoInstrument, PhenoMeasures, PhenoMeasure } from './pheno-browser';
 import { ConfigService } from '../config/config.service';
-import { map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { AuthService } from 'app/auth.service';
 
 const oboe = require('oboe');
@@ -103,5 +103,24 @@ export class PhenoBrowserService {
   public getDownloadLink(instrument: PhenoInstrument, datasetId: string): string {
     return `${this.config.baseUrl}${this.downloadUrl}`
            + `?dataset_id=${datasetId}&instrument=${instrument}`;
+  }
+
+  public validateMeasureDownload(
+    datasetId: string, instrument: string, searchTerm: string
+  ): Observable<HttpResponse<object>> {
+    const headers = this.getHeaders();
+    const params =
+      new HttpParams()
+        .set('dataset_id', datasetId)
+        .set('instrument', instrument)
+        .set('search_term', searchTerm);
+
+    return this.http
+      .head<HttpResponse<object>>(
+        this.config.baseUrl + 'pheno_browser/download',
+        {headers: headers, withCredentials: true, params: params, observe: 'response'}
+      ).pipe(
+        catchError((err: HttpResponse<object>) => of(err))
+      );
   }
 }

--- a/src/app/pheno-browser/pheno-browser.service.ts
+++ b/src/app/pheno-browser/pheno-browser.service.ts
@@ -105,15 +105,17 @@ export class PhenoBrowserService {
            + `?dataset_id=${datasetId}&instrument=${instrument}`;
   }
 
-  public validateMeasureDownload(
-    datasetId: string, instrument: string, searchTerm: string
-  ): Observable<HttpResponse<object>> {
+  public validateMeasureDownload(data: {
+      dataset_id: string;
+      instrument: string;
+      search_term: string;
+  }): Observable<HttpResponse<object>> {
     const headers = this.getHeaders();
     const params =
       new HttpParams()
-        .set('dataset_id', datasetId)
-        .set('instrument', instrument)
-        .set('search_term', searchTerm);
+        .set('dataset_id', data.dataset_id)
+        .set('instrument', data.instrument)
+        .set('search_term', data.search_term);
 
     return this.http
       .head<HttpResponse<object>>(
@@ -122,5 +124,24 @@ export class PhenoBrowserService {
       ).pipe(
         catchError((err: HttpResponse<object>) => of(err))
       );
+  }
+
+  public getDownloadMeasuresLink(data: {
+    dataset_id: string;
+    instrument: string;
+    search_term: string;
+  }): string {
+    const headers = this.getHeaders();
+    const params =
+      new HttpParams()
+        .set('dataset_id', data.dataset_id)
+        .set('instrument', data.instrument)
+        .set('search_term', data.search_term);
+
+    return this.config.baseUrl
+      + 'pheno_browser/download?'
+      + `dataset_id=${data.dataset_id}`
+      + `&instrument=${data.instrument}`
+      + `&search_term=${data.search_term}`;
   }
 }


### PR DESCRIPTION
## Background
"Currently the pheno browser download works by sending a list of measures in the request body. This list of measures is assembled continuously in the background while the page is loaded and fully interactive, giving the illusion of being ready to use. Attempting to download before all measures are collected will result in a smaller file, because less measures are selected."

## Aim
"Instruments have now been implemented in the pheno browser DB and we should avoid sending a list of measures. Instead, we should use an instrument name to get all measures on the backend or send the search term to the backend to replicate the search on the frontend."

References GPF issue 578

## Implementation
Add warning modal if a user attempts an invalid download.
Update request parameters.

