### PR TITLE
Fix download bug

### DIFF
--- a/src/app/pheno-browser/pheno-browser.service.ts
+++ b/src/app/pheno-browser/pheno-browser.service.ts
@@ -137,7 +137,7 @@ export class PhenoBrowserService {
   }): string {
     return this.config.baseUrl
       + 'pheno_browser/download?'
-      + `dataset_id=${data.search_term}`
+      + `dataset_id=${data.dataset_id}`
       + `&instrument=${data.instrument}`
       + `&search_term=${data.search_term}`;
   }


### PR DESCRIPTION
## Background
Pheno browser download had a new bug where the search term was used for the dataset ID.

## Aim
Fix it

## Implementation
Reverted the 1 line culprit.
