### PR TITLE
update regions filter regex to validate numbers having digits separat…

### DIFF
--- a/src/app/regions-filter/regions-filter.validator.spec.ts
+++ b/src/app/regions-filter/regions-filter.validator.spec.ts
@@ -29,13 +29,14 @@ describe('RegionsFilterValidator', () => {
     expect(component.validate('  Y:76710815 ', args)).toBe(true);
     expect(component.validate('  9:76710815 ', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830 ', args)).toBe(true);
+    expect(component.validate('10:113,141,317', args)).toBe(true);
+    expect(component.validate('10:113,141,317-113,141,318 ', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830 \n11:10169163-10169314  ' +
       '\n\n\n12:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830, X:10169163-10169314, Y:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830, 11:10169163-10169314, 12:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830, 11:10169,163-10169,314,12:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710,815-76710830, 11:10,169,163-10169,314,12:50344524-50352664', args)).toBe(true);
-
 
     expect(component.validate('  9:76710833-76710830 ', args)).toBe(false);
     expect(component.validate('  9:76710833-76710830:320-345 ', args)).toBe(false);
@@ -68,18 +69,24 @@ describe('RegionsFilterValidator', () => {
     expect(component.validate('  chrY:76710815 ', args)).toBe(true);
     expect(component.validate('  chr9:76710815 ', args)).toBe(true);
     expect(component.validate('  chr9:76710815-76710830 ', args)).toBe(true);
+    expect(component.validate('chr10:113,141,317', args)).toBe(true);
+    expect(component.validate('chr10:113,141,317-113,141,318 ', args)).toBe(true);
     expect(component.validate('chr9', args)).toBe(true);
     expect(component.validate('  chr9:76710815-76710830 \nchr11:10169163-10169314  ' +
       '\nchr12:50344524-50352664', args)).toBe(true);
+
     expect(component.validate('  chr9:76710815-76710830 , chrX:10169163-10169314,  ' +
       'chrY:50344524-50352664', args)).toBe(true);
+
     expect(component.validate('  chr9:76710815-76710830, ' +
       'chr11:10169,163-10169,314,chr12:50344524-50352664', args)).toBe(true);
+
     expect(component.validate('  chr9:76710,815-76710830, ' +
       'chr11:10,169,163-10169,314,chr12:50344524-50352664', args)).toBe(true);
 
     expect(component.validate('  chr9:76710815-76710830 \n11:10169163-10169314  ' +
       '\nchr12:50344524-50352664', args)).toBe(false);
+
     expect(component.validate('  chr9:76710844-76710830 ', args)).toBe(false);
     expect(component.validate('chr23', args)).toBe(false);
     expect(component.validate('chr9:', args)).toBe(false);
@@ -89,8 +96,10 @@ describe('RegionsFilterValidator', () => {
 
     expect(component.validate('chr9:76710815-76710830, ' +
       'chr11:10169,163-101693,14,chr12:50344524-50352664', args)).toBe(false);
+
     expect(component.validate('chr9:76710815-76710830, ' +
       '11:10169,163-101,69314,12:50344524-50352664', args)).toBe(false);
+
     expect(component.validate('  chr9:76710815-76710830, ' +
       'chr11:10169,163-101,69314,,chr12:50344524-50352664', args)).toBe(false);
   });

--- a/src/app/regions-filter/regions-filter.validator.spec.ts
+++ b/src/app/regions-filter/regions-filter.validator.spec.ts
@@ -30,17 +30,26 @@ describe('RegionsFilterValidator', () => {
     expect(component.validate('  9:76710815 ', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830 ', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830 \n11:10169163-10169314  ' +
-          '\n\n\n12:50344524-50352664', args)).toBe(true);
+      '\n\n\n12:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830, X:10169163-10169314, Y:50344524-50352664', args)).toBe(true);
     expect(component.validate('  9:76710815-76710830, 11:10169163-10169314, 12:50344524-50352664', args)).toBe(true);
+    expect(component.validate('  9:76710815-76710830, 11:10169,163-10169,314,12:50344524-50352664', args)).toBe(true);
+    expect(component.validate('  9:76710,815-76710830, 11:10,169,163-10169,314,12:50344524-50352664', args)).toBe(true);
+
 
     expect(component.validate('  9:76710833-76710830 ', args)).toBe(false);
-    expect(component.validate('  9:76710833-76710830:420-345 ', args)).toBe(false);
+    expect(component.validate('  9:76710833-76710830:320-345 ', args)).toBe(false);
+    expect(component.validate('  9:76710833-76710\n830:320-345 ', args)).toBe(false);
+    expect(component.validate('  9:76710833-76710830+12:420-345 ', args)).toBe(false);
+
     expect(component.validate('23', args)).toBe(false);
     expect(component.validate('9:', args)).toBe(false);
     expect(component.validate('X12', args)).toBe(false);
     expect(component.validate('Y1', args)).toBe(false);
     expect(component.validate('chr9:76710815-76710830 ', args)).toBe(false);
+    expect(component.validate('  9:76710815-76710830, 11:10169,163-101693,14,12:50344524-50352664', args)).toBe(false);
+    expect(component.validate('  9:76710815-76710830, 11:10169,163-101,69314,12:50344524-50352664', args)).toBe(false);
+    expect(component.validate('  9:76710815-76710830, 11:10169,163-101,69314,,12:50344524-50352664', args)).toBe(false);
   });
 
   it('should check if regions filter input is valid for hg38', () => {
@@ -61,17 +70,28 @@ describe('RegionsFilterValidator', () => {
     expect(component.validate('  chr9:76710815-76710830 ', args)).toBe(true);
     expect(component.validate('chr9', args)).toBe(true);
     expect(component.validate('  chr9:76710815-76710830 \nchr11:10169163-10169314  ' +
-        '\nchr12:50344524-50352664', args)).toBe(true);
+      '\nchr12:50344524-50352664', args)).toBe(true);
     expect(component.validate('  chr9:76710815-76710830 , chrX:10169163-10169314,  ' +
-        'chrY:50344524-50352664', args)).toBe(true);
+      'chrY:50344524-50352664', args)).toBe(true);
+    expect(component.validate('  chr9:76710815-76710830, ' +
+      'chr11:10169,163-10169,314,chr12:50344524-50352664', args)).toBe(true);
+    expect(component.validate('  chr9:76710,815-76710830, ' +
+      'chr11:10,169,163-10169,314,chr12:50344524-50352664', args)).toBe(true);
 
     expect(component.validate('  chr9:76710815-76710830 \n11:10169163-10169314  ' +
-        '\nchr12:50344524-50352664', args)).toBe(false);
+      '\nchr12:50344524-50352664', args)).toBe(false);
     expect(component.validate('  chr9:76710844-76710830 ', args)).toBe(false);
     expect(component.validate('chr23', args)).toBe(false);
     expect(component.validate('chr9:', args)).toBe(false);
     expect(component.validate('chrX12', args)).toBe(false);
     expect(component.validate('chrY1', args)).toBe(false);
     expect(component.validate('9:76710815-76710830 ', args)).toBe(false);
+
+    expect(component.validate('chr9:76710815-76710830, ' +
+      'chr11:10169,163-101693,14,chr12:50344524-50352664', args)).toBe(false);
+    expect(component.validate('chr9:76710815-76710830, ' +
+      '11:10169,163-101,69314,12:50344524-50352664', args)).toBe(false);
+    expect(component.validate('  chr9:76710815-76710830, ' +
+      'chr11:10169,163-101,69314,,chr12:50344524-50352664', args)).toBe(false);
   });
 });

--- a/src/app/regions-filter/regions-filter.validator.ts
+++ b/src/app/regions-filter/regions-filter.validator.ts
@@ -8,31 +8,32 @@ export class RegionsFilterValidator implements ValidatorConstraintInterface {
     }
 
     let valid = true;
-    const lines = text.split(/[\n,]/)
+    text = text.replace(/,(?![0-9]{3}\D{1})/g, '\n');
+    const regions = text.split('\n')
       .map(t => t.trim())
       .filter(t => Boolean(t));
 
-    if (lines.length === 0) {
+    if (regions.length === 0) {
       valid = false;
     }
 
-    for (const line of lines) {
-      valid = valid && this.isValid(line, args.object['genome'] as string);
+    for (const region of regions) {
+      valid = valid && this.isRegionValid(region, args.object['genome'] as string);
     }
 
     return valid;
   }
 
-  private isValid(line: string, genome: string): boolean {
+  private isRegionValid(region: string, genome: string): boolean {
+    region = region.replaceAll(',', '');
     let chromRegex = '(2[0-2]|1[0-9]|[0-9]|X|Y)';
     if (genome === 'hg38') {
       chromRegex = 'chr' + chromRegex;
     }
     const lineRegex = `${chromRegex}:([0-9]+)(?:-([0-9]+))?|${chromRegex}`;
 
-
-    const match = line.match(new RegExp(lineRegex, 'i'));
-    if (match === null || match[0] !== line) {
+    const match = region.match(new RegExp(lineRegex, 'i'));
+    if (match === null || match[0] !== region) {
       return false;
     }
 

--- a/src/app/regions-filter/regions-filter.validator.ts
+++ b/src/app/regions-filter/regions-filter.validator.ts
@@ -8,6 +8,7 @@ export class RegionsFilterValidator implements ValidatorConstraintInterface {
     }
 
     let valid = true;
+    text += '\n'; // Expression needs to read symbol after regions
     text = text.replace(/,(?![0-9]{3}\D{1})/g, '\n');
     const regions = text.split('\n')
       .map(t => t.trim())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2017",
+      "es2021",
       "dom"
     ],
     "noImplicitThis": true,


### PR DESCRIPTION
…ed by commas, update es to 2021 and update unit tests

## Background

Regions filter textfield content is validated by a regex which doesn't support the syntax `chr12:1,000,000-2,000,000`  - big numbers which have commas. 

## Aim

To update regex.

## Implementation

Update regex.
