### PR TITLE
Add family tags tab family filter

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -18,7 +18,8 @@
   padding-bottom: 0;
 }
 
-.container-fluid a, h3 {
+.container-fluid a,
+h3 {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -185,6 +185,7 @@ import { HomeComponent } from './home/home.component';
 import { AboutComponent } from './about/about.component';
 import { MarkdownEditorComponent } from './markdown-editor/markdown-editor.component';
 import { FamilyTagsComponent } from './family-tags/family-tags.component';
+import { FamilyTagsState } from './family-tags/family-tags.state';
 
 const appRoutes: Routes = [
   {
@@ -423,7 +424,7 @@ const appRoutes: Routes = [
     NgxsModule.forRoot([
       VarianttypesState, EffecttypesState, GenderState,
       InheritancetypesState, PersonIdsState, PresentInChildState, PresentInParentState,
-      GeneSymbolsState, FamilyIdsState, RegionsFilterState, StudyTypesState, GeneSetsState,
+      GeneSymbolsState, FamilyIdsState, FamilyTagsState, RegionsFilterState, StudyTypesState, GeneSetsState,
       GeneScoresState, EnrichmentModelsState, PedigreeSelectorState, FamilyTypeFilterState,
       StudyFiltersState, PersonFiltersState, GenomicScoresBlockState, PhenoToolMeasureState,
       UniqueFamilyVariantsFilterState, ErrorsState

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -184,6 +184,7 @@ import { HelperModalComponent } from './helper-modal/helper-modal.component';
 import { HomeComponent } from './home/home.component';
 import { AboutComponent } from './about/about.component';
 import { MarkdownEditorComponent } from './markdown-editor/markdown-editor.component';
+import { FamilyTagsComponent } from './family-tags/family-tags.component';
 
 const appRoutes: Routes = [
   {
@@ -403,6 +404,7 @@ const appRoutes: Routes = [
     HomeComponent,
     AboutComponent,
     MarkdownEditorComponent,
+    FamilyTagsComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/family-filters-block/family-filters-block.component.css
+++ b/src/app/family-filters-block/family-filters-block.component.css
@@ -9,3 +9,7 @@
 #family-filter {
   padding: 10px;
 }
+
+::ng-deep #tag-list {
+  column-gap: 50px !important;
+}

--- a/src/app/family-filters-block/family-filters-block.component.html
+++ b/src/app/family-filters-block/family-filters-block.component.html
@@ -1,24 +1,30 @@
 <div class="family-filters-block form-block">
   <div class="card">
-    <ul ngbNav #nav="ngbNav" (navChange)="onNavChange()" class="navbar bg-light nav-pills" id="list">
+    <ul
+      ngbNav
+      #nav="ngbNav"
+      (navChange)="onNavChange()"
+      class="navbar bg-light nav-pills"
+      [ngClass]="{ 'panel-bottom': hasContent }"
+      id="list">
       <div class="nav-title-custom">Family filters</div>
       <li [ngbNavItem]="'allFamilies'" id="all-families">
-        <a ngbNavLink>All</a>
+        <a ngbNavLink (click)="hasContent = false">All</a>
       </li>
       <li [ngbNavItem]="'familyIds'" id="family-ids">
-        <a ngbNavLink>Family Ids</a>
+        <a ngbNavLink (click)="hasContent = true">Family Ids</a>
         <ng-template ngbNavContent>
           <gpf-family-ids></gpf-family-ids>
         </ng-template>
       </li>
       <li [ngbNavItem]="'familyTags'" id="family-tags">
-        <a ngbNavLink>Family Tags</a>
+        <a ngbNavLink (click)="hasContent = true">Family Tags</a>
         <ng-template ngbNavContent>
           <gpf-family-tags [numOfCols]="numOfCols" [tags]="orderedTagList"></gpf-family-tags>
         </ng-template>
       </li>
       <li [ngbNavItem]="'advanced'" *ngIf="showAdvancedButton" id="advanced">
-        <a ngbNavLink>Advanced</a>
+        <a ngbNavLink (click)="hasContent = true">Advanced</a>
         <ng-template ngbNavContent>
           <div id="filters">
             <gpf-family-type-filter *ngIf="showFamilyTypeFilter" id="family-filter"></gpf-family-type-filter>

--- a/src/app/family-filters-block/family-filters-block.component.html
+++ b/src/app/family-filters-block/family-filters-block.component.html
@@ -11,6 +11,12 @@
           <gpf-family-ids></gpf-family-ids>
         </ng-template>
       </li>
+      <li [ngbNavItem]="'familyTags'" id="family-tags">
+        <a ngbNavLink>Family Tags</a>
+        <ng-template ngbNavContent>
+          <gpf-family-tags [numOfCols]="numOfCols" [tags]="orderedTagList"></gpf-family-tags>
+        </ng-template>
+      </li>
       <li [ngbNavItem]="'advanced'" *ngIf="showAdvancedButton" id="advanced">
         <a ngbNavLink>Advanced</a>
         <ng-template ngbNavContent>

--- a/src/app/family-filters-block/family-filters-block.component.ts
+++ b/src/app/family-filters-block/family-filters-block.component.ts
@@ -5,6 +5,7 @@ import { FamilyIdsModel, FamilyIdsState } from 'app/family-ids/family-ids.state'
 import { PersonFiltersModel, PersonFiltersState, SetFamilyFilters } from 'app/person-filters/person-filters.state';
 import { StateReset } from 'ngxs-reset-plugin';
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
+import { VariantReportsService } from 'app/variant-reports/variant-reports.service';
 
 @Component({
   selector: 'gpf-family-filters-block',
@@ -18,8 +19,17 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   public showFamilyTypeFilter: boolean;
   public showAdvancedButton: boolean;
 
+  public tags: Array<string> = new Array<string>();
+  public orderedTagList = [];
+  public selectedTags: string[] = [];
+  public deselectedTags: string[] = [];
+  public tagIntersection = true; // mode "And"
+  public numOfCols: number;
+  public numOfRows: string;
+
   public constructor(
     private store: Store,
+    private variantReportsService: VariantReportsService,
   ) { }
 
   public ngOnInit(): void {
@@ -27,6 +37,18 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
     this.showAdvancedButton =
       this.dataset.genotypeBrowserConfig.familyFilters.length !== 0 ||
       this.dataset.genotypeBrowserConfig.hasFamilyStructureFilter;
+
+    if (this.variantReportsService.getTags() !== undefined) {
+      this.variantReportsService.getTags().subscribe(data => {
+        Object.values(data).forEach((tag: string) => {
+          this.tags.push(tag);
+          this.orderedTagList.push(tag);
+        });
+        // Calculate grid for the tags (1 column width === ~5 tags height)
+        this.numOfCols = 4;
+        this.numOfRows = 'auto-fill';
+      });
+    }
   }
 
   public ngAfterViewInit(): void {

--- a/src/app/family-filters-block/family-filters-block.component.ts
+++ b/src/app/family-filters-block/family-filters-block.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, Input, ViewChild, OnInit } from '@angular/core';
+import { Component, AfterViewInit, Input, ViewChild, OnInit, HostListener } from '@angular/core';
 import { Dataset } from '../datasets/datasets';
 import { Store, Selector } from '@ngxs/store';
 import { FamilyIdsModel, FamilyIdsState } from 'app/family-ids/family-ids.state';
@@ -6,7 +6,7 @@ import { PersonFiltersModel, PersonFiltersState, SetFamilyFilters } from 'app/pe
 import { StateReset } from 'ngxs-reset-plugin';
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 import { VariantReportsService } from 'app/variant-reports/variant-reports.service';
-import { FamilyTagsModel, FamilyTagsState } from 'app/family-tags/family-tags.state';
+import { FamilyTagsModel, FamilyTagsState, SetFamilyTags } from 'app/family-tags/family-tags.state';
 
 @Component({
   selector: 'gpf-family-filters-block',
@@ -26,7 +26,6 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   public deselectedTags: string[] = [];
   public tagIntersection = true; // mode "And"
   public numOfCols: number;
-  public numOfRows: string;
 
   public constructor(
     private store: Store,
@@ -45,11 +44,16 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
           this.tags.push(tag);
           this.orderedTagList.push(tag);
         });
-        // Calculate grid for the tags (1 column width === ~5 tags height)
-        this.numOfCols = 4;
-        this.numOfRows = 'auto-fill';
+        // Calculate grid for the tags
+        this.onResize();
       });
     }
+  }
+
+  @HostListener('window:resize')
+  public onResize(): void {
+    const containerWidth = document.getElementsByClassName('family-filters-block')[0].clientWidth;
+    this.numOfCols = Math.floor(Math.sqrt(containerWidth/(2.4*this.tags.length)) - 1);
   }
 
   public ngAfterViewInit(): void {
@@ -67,7 +71,7 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   public onNavChange(): void {
     this.store.dispatch(new SetFamilyFilters([]));
     this.store.dispatch(new StateReset(FamilyIdsState));
-    this.store.dispatch(new StateReset(FamilyTagsState));
+    this.store.dispatch(new SetFamilyTags([], [], true));
   }
 
   @Selector([FamilyIdsState, FamilyTagsState, PersonFiltersState])

--- a/src/app/family-filters-block/family-filters-block.component.ts
+++ b/src/app/family-filters-block/family-filters-block.component.ts
@@ -6,6 +6,7 @@ import { PersonFiltersModel, PersonFiltersState, SetFamilyFilters } from 'app/pe
 import { StateReset } from 'ngxs-reset-plugin';
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 import { VariantReportsService } from 'app/variant-reports/variant-reports.service';
+import { FamilyTagsModel, FamilyTagsState } from 'app/family-tags/family-tags.state';
 
 @Component({
   selector: 'gpf-family-filters-block',
@@ -55,6 +56,8 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
     this.store.selectOnce(FamilyFiltersBlockComponent.familyFiltersBlockState).subscribe(state => {
       if (state['familyIds']) {
         setTimeout(() => this.ngbNav.select('familyIds'));
+      } else if (state['selectedFamilyTags'] || state['deselectedFamilyTags'] || state['tagIntersection']) {
+        setTimeout(() => this.ngbNav.select('familyTags'));
       } else if (state['familyFilters']) {
         setTimeout(() => this.ngbNav.select('advanced'));
       }
@@ -64,15 +67,25 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   public onNavChange(): void {
     this.store.dispatch(new SetFamilyFilters([]));
     this.store.dispatch(new StateReset(FamilyIdsState));
+    this.store.dispatch(new StateReset(FamilyTagsState));
   }
 
-  @Selector([FamilyIdsState, PersonFiltersState])
+  @Selector([FamilyIdsState, FamilyTagsState, PersonFiltersState])
   public static familyFiltersBlockState(
-    familyIdsState: FamilyIdsModel, personFiltersState: PersonFiltersModel
+    familyIdsState: FamilyIdsModel, familyTagsState: FamilyTagsModel, personFiltersState: PersonFiltersModel
   ): object {
     const res = {};
     if (familyIdsState.familyIds.length) {
       res['familyIds'] = familyIdsState.familyIds;
+    }
+    if (familyTagsState.selectedFamilyTags.length) {
+      res['selectedFamilyTags'] = familyTagsState.selectedFamilyTags;
+    }
+    if (familyTagsState.deselectedFamilyTags.length) {
+      res['deselectedFamilyTags'] = familyTagsState.deselectedFamilyTags;
+    }
+    if (!familyTagsState.tagIntersection) {
+      res['tagIntersection'] = familyTagsState.tagIntersection;
     }
     if (personFiltersState.familyFilters.length) {
       res['familyFilters'] = personFiltersState.familyFilters;

--- a/src/app/family-filters-block/family-filters-block.component.ts
+++ b/src/app/family-filters-block/family-filters-block.component.ts
@@ -19,6 +19,7 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   @ViewChild('nav') public ngbNav: NgbNav;
   public showFamilyTypeFilter: boolean;
   public showAdvancedButton: boolean;
+  public hasContent = false;
 
   public tags: Array<string> = new Array<string>();
   public orderedTagList = [];
@@ -59,11 +60,20 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
   public ngAfterViewInit(): void {
     this.store.selectOnce(FamilyFiltersBlockComponent.familyFiltersBlockState).subscribe(state => {
       if (state['familyIds']) {
-        setTimeout(() => this.ngbNav.select('familyIds'));
+        setTimeout(() => {
+          this.ngbNav.select('familyIds');
+          this.hasContent = true;
+        });
       } else if (state['selectedFamilyTags'] || state['deselectedFamilyTags'] || state['tagIntersection']) {
-        setTimeout(() => this.ngbNav.select('familyTags'));
+        setTimeout(() => {
+          this.ngbNav.select('familyTags');
+          this.hasContent = true;
+        });
       } else if (state['familyFilters']) {
-        setTimeout(() => this.ngbNav.select('advanced'));
+        setTimeout(() => {
+          this.ngbNav.select('advanced');
+          this.hasContent = true;
+        });
       }
     });
   }

--- a/src/app/family-ids/family-ids.component.html
+++ b/src/app/family-ids/family-ids.component.html
@@ -1,4 +1,4 @@
-<div class="panel" id="family-ids-panel">
+<div style="padding: 20px" id="family-ids-panel">
   <textarea
     #textArea
     type="text"

--- a/src/app/family-ids/family-ids.component.ts
+++ b/src/app/family-ids/family-ids.component.ts
@@ -21,7 +21,7 @@ export class FamilyIdsComponent extends StatefulComponent implements OnInit {
   public ngOnInit(): void {
     super.ngOnInit();
     this.focusTextInputArea();
-    this.store.selectOnce(state => state.familyIdsState).subscribe(state => {
+    this.store.selectOnce(state => state.familyIdsState).subscribe((state: SetFamilyIds) => {
       // restore state
       this.setFamilyIds(state.familyIds.join('\n'));
     });

--- a/src/app/family-tags/family-tags.component.css
+++ b/src/app/family-tags/family-tags.component.css
@@ -1,0 +1,67 @@
+#tags-modal-content {
+  padding: 8px 20px;
+  height: fit-content;
+  width: fit-content;
+}
+
+#tags-modal-header {
+  display: flex;
+  column-gap: 20px;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.tags {
+  color: #cdcdcd;
+  font-size: 22px;
+  user-select: none;
+}
+
+.tags:hover {
+  cursor: pointer;
+}
+
+.modal-content-lines {
+  display: flex;
+  align-items: center;
+}
+
+.and-toggle-button {
+  color: #2a6395;
+  width: 70px;
+  padding: 0 20px;
+  border-radius: 5px 0 0 5px;
+  border: 1px solid #2a6395;
+}
+
+.or-toggle-button {
+  color: #2a6395;
+  width: 70px;
+  padding: 0 20px;
+  border-radius: 0 5px 5px 0;
+  border: 1px solid #2a6395;
+}
+
+#mode-label {
+  margin-right: 10px;
+}
+
+.selected-mode {
+  background-color: #2a6395;
+  color: white;
+}
+
+#clear-filters-button {
+  white-space: nowrap;
+  color: #2a6395;
+  user-select: none;
+}
+
+#clear-filters-button:hover {
+  cursor: pointer;
+  color: #163d5f;
+}
+
+#tag-label {
+  margin-left: 5px;
+}

--- a/src/app/family-tags/family-tags.component.html
+++ b/src/app/family-tags/family-tags.component.html
@@ -1,4 +1,4 @@
-<div class="panel" id="tags-modal-content">
+<div style="padding: 20px" id="tags-modal-content">
   <div id="tags-modal-header">
     <div>
       <span id="mode-label">Choose mode: </span>

--- a/src/app/family-tags/family-tags.component.html
+++ b/src/app/family-tags/family-tags.component.html
@@ -1,0 +1,41 @@
+<div id="tags-modal-content">
+  <div id="tags-modal-header">
+    <div>
+      <span id="mode-label">Choose mode: </span>
+      <button class="and-toggle-button" (click)="onChooseMode(true)" [ngClass]="{ 'selected-mode': tagIntersection }"
+        >And</button
+      >
+      <button class="or-toggle-button" (click)="onChooseMode(false)" [ngClass]="{ 'selected-mode': !tagIntersection }"
+        >Or</button
+      >
+    </div>
+    <a (click)="clearFilters()" id="clear-filters-button">Clear filters</a>
+  </div>
+
+  <div
+    id="tag-list"
+    [ngStyle]="{
+      display: 'grid',
+      'grid-template-columns': 'repeat(' + numOfCols + ', max-content)',
+      'row-gap': '6px',
+      'column-gap': '16px'
+    }">
+    <div *ngFor="let tag of tags" class="modal-content-lines">
+      <span
+        class="material-icons tags"
+        [id]="tag + '-tag-add'"
+        (click)="selectFilter(tag)"
+        [ngStyle]="{ color: filtersButtonsState[tag] === 1 ? 'green' : '#cdcdcd' }"
+        >add_circle</span
+      >
+      <span
+        class="material-icons tags"
+        [id]="tag + '-tag-remove'"
+        (click)="deselectFilter(tag)"
+        [ngStyle]="{ color: filtersButtonsState[tag] === -1 ? 'red' : '#cdcdcd' }"
+        >remove_circle</span
+      >
+      <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>
+    </div>
+  </div>
+</div>

--- a/src/app/family-tags/family-tags.component.html
+++ b/src/app/family-tags/family-tags.component.html
@@ -1,4 +1,4 @@
-<div id="tags-modal-content">
+<div class="panel" id="tags-modal-content">
   <div id="tags-modal-header">
     <div>
       <span id="mode-label">Choose mode: </span>
@@ -37,5 +37,4 @@
       <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>
     </div>
   </div>
-  <!-- <gpf-errors-alert [errors]="errors"></gpf-errors-alert> -->
 </div>

--- a/src/app/family-tags/family-tags.component.html
+++ b/src/app/family-tags/family-tags.component.html
@@ -38,4 +38,5 @@
       <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>
     </div>
   </div>
+  <!-- <gpf-errors-alert [errors]="errors"></gpf-errors-alert> -->
 </div>

--- a/src/app/family-tags/family-tags.component.html
+++ b/src/app/family-tags/family-tags.component.html
@@ -17,8 +17,7 @@
     [ngStyle]="{
       display: 'grid',
       'grid-template-columns': 'repeat(' + numOfCols + ', max-content)',
-      'row-gap': '6px',
-      'column-gap': '16px'
+      'row-gap': '6px'
     }">
     <div *ngFor="let tag of tags" class="modal-content-lines">
       <span

--- a/src/app/family-tags/family-tags.component.spec.ts
+++ b/src/app/family-tags/family-tags.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FamilyTagsComponent } from './family-tags.component';
+
+describe('FamilyTagsComponent', () => {
+  let component: FamilyTagsComponent;
+  let fixture: ComponentFixture<FamilyTagsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FamilyTagsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FamilyTagsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/family-tags/family-tags.component.spec.ts
+++ b/src/app/family-tags/family-tags.component.spec.ts
@@ -1,4 +1,4 @@
-import { NgxsModule, Store } from '@ngxs/store';
+import { NgxsModule } from '@ngxs/store';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FamilyTagsComponent } from './family-tags.component';

--- a/src/app/family-tags/family-tags.component.spec.ts
+++ b/src/app/family-tags/family-tags.component.spec.ts
@@ -1,16 +1,23 @@
+import { NgxsModule, Store } from '@ngxs/store';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FamilyTagsComponent } from './family-tags.component';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { ErrorsState } from 'app/common/errors.state';
+import { FamilyTagsState } from './family-tags.state';
 
 describe('FamilyTagsComponent', () => {
   let component: FamilyTagsComponent;
   let fixture: ComponentFixture<FamilyTagsComponent>;
 
-  beforeEach(async () => {
+  beforeEach(async() => {
     await TestBed.configureTestingModule({
-      declarations: [ FamilyTagsComponent ]
-    })
-    .compileComponents();
+      declarations: [FamilyTagsComponent],
+      imports: [
+        NgxsModule.forRoot([ErrorsState, FamilyTagsState], {developmentMode: true}),
+        NgbNavModule
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FamilyTagsComponent);
     component = fixture.componentInstance;
@@ -19,5 +26,123 @@ describe('FamilyTagsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should test restoring family tags', () => {
+    component.restoreFamilyTags(['tag1'], ['tag2'], false);
+    expect(component.selectedTags).toStrictEqual(['tag1']);
+    expect(component.deselectedTags).toStrictEqual(['tag2']);
+    expect(component.tagIntersection).toBe(false);
+    expect(component.filtersButtonsState['tag1']).toBe(1);
+    expect(component.filtersButtonsState['tag2']).toBe(-1);
+  });
+
+  it('should test choosing mode and passing the updated mode', () => {
+    jest.spyOn(component.chooseMode, 'emit');
+
+    component.onChooseMode();
+    expect(component.tagIntersection).toBe(true);
+    expect(component.chooseMode.emit).toHaveBeenCalledWith(true);
+
+    component.onChooseMode(false);
+    expect(component.tagIntersection).toBe(false);
+    expect(component.chooseMode.emit).toHaveBeenCalledWith(false);
+  });
+
+  it('should test passing updated tag lists', () => {
+    jest.spyOn(component.updateTagsLists, 'next');
+
+    component.selectedTags = ['tag1'];
+    component.deselectedTags = ['tag2'];
+    component.onUpdateTags();
+    expect(component.updateTagsLists.next).toHaveBeenCalledWith(
+      {
+        selected: ['tag1'],
+        deselected: ['tag2']
+      }
+    );
+  });
+
+  it('should test tags state when selecting', () => {
+    const updateSelectedTagsListMock = jest.spyOn(component, 'updateSelectedTagsList')
+      .mockImplementation(() => null);
+
+    component.filtersButtonsState['tag1'] = 0;
+    component.selectFilter('tag1');
+    expect(component.filtersButtonsState['tag1']).toBe(1);
+    expect(updateSelectedTagsListMock).toHaveBeenCalledWith('tag1');
+
+    component.selectFilter('tag1');
+    expect(component.filtersButtonsState['tag1']).toBe(0);
+  });
+
+  it('should test tags state when deselecting', () => {
+    const updateDeselectedTagsListMock = jest.spyOn(component, 'updateDeselectedTagsList')
+      .mockImplementation(() => null);
+
+    component.filtersButtonsState['tag1'] = 0;
+    component.deselectFilter('tag1');
+    expect(component.filtersButtonsState['tag1']).toBe(-1);
+    expect(updateDeselectedTagsListMock).toHaveBeenCalledWith('tag1');
+
+    component.deselectFilter('tag1');
+    expect(component.filtersButtonsState['tag1']).toBe(0);
+  });
+  it('should test clearing tags', () => {
+    const updateTagsListMock = jest.spyOn(component, 'onUpdateTags')
+      .mockImplementation(() => null);
+
+    component.tags = ['tag1', 'tag2'];
+    component.selectedTags = ['tag1'];
+    component.deselectedTags = ['tag2'];
+    component.filtersButtonsState['tag1'] = 1;
+    component.filtersButtonsState['tag2'] = -1;
+
+    component.clearFilters();
+    expect(component.selectedTags).toStrictEqual([]);
+    expect(component.deselectedTags).toStrictEqual([]);
+    expect(component.filtersButtonsState['tag1']).toBe(0);
+    expect(component.filtersButtonsState['tag2']).toBe(0);
+    expect(updateTagsListMock).toHaveBeenCalledWith();
+  });
+
+  it('should test updating selected tag list', () => {
+    const updateTagsListMock = jest.spyOn(component, 'onUpdateTags')
+      .mockImplementation(() => null);
+
+    component.selectedTags = ['tag1'];
+    component.updateSelectedTagsList('tag2');
+    expect(component.selectedTags).toStrictEqual(['tag1', 'tag2']);
+    expect(updateTagsListMock).toHaveBeenCalledWith();
+
+    component.selectedTags = ['tag1', 'tag2'];
+    component.updateSelectedTagsList('tag1');
+    expect(component.selectedTags).toStrictEqual(['tag2']);
+
+    component.deselectedTags = ['tag2'];
+    component.selectedTags = [];
+    component.updateSelectedTagsList('tag2');
+    expect(component.selectedTags).toStrictEqual(['tag2']);
+    expect(component.deselectedTags).toStrictEqual([]);
+  });
+
+  it('should test updating deselected tag list', () => {
+    const updateTagsListMock = jest.spyOn(component, 'onUpdateTags')
+      .mockImplementation(() => null);
+
+    component.deselectedTags = ['tag1'];
+    component.updateDeselectedTagsList('tag2');
+    expect(component.deselectedTags).toStrictEqual(['tag1', 'tag2']);
+    expect(updateTagsListMock).toHaveBeenCalledWith();
+
+    component.deselectedTags = ['tag1', 'tag2'];
+    component.updateDeselectedTagsList('tag1');
+    expect(component.deselectedTags).toStrictEqual(['tag2']);
+
+    component.selectedTags = ['tag2'];
+    component.deselectedTags = [];
+    component.updateDeselectedTagsList('tag2');
+    expect(component.deselectedTags).toStrictEqual(['tag2']);
+    expect(component.selectedTags).toStrictEqual([]);
   });
 });

--- a/src/app/family-tags/family-tags.component.ts
+++ b/src/app/family-tags/family-tags.component.ts
@@ -86,7 +86,9 @@ export class FamilyTagsComponent extends StatefulComponent implements OnInit {
   public clearFilters(): void {
     this.selectedTags = [];
     this.deselectedTags = [];
-    this.filtersButtonsState = _.mapValues(this.filtersButtonsState, () => 0);
+    this.tags.forEach((tag: string) => {
+      this.filtersButtonsState[tag] = 0;
+    });
 
     this.onUpdateTags();
     this.store.dispatch(new SetFamilyTags(this.selectedTags, this.deselectedTags, this.tagIntersection));

--- a/src/app/family-tags/family-tags.component.ts
+++ b/src/app/family-tags/family-tags.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { StatefulComponent } from 'app/common/stateful-component';
-import _ from 'lodash';
 import { FamilyTagsState, SetFamilyTags } from './family-tags.state';
 import { Store } from '@ngxs/store';
 import { FamilyTags } from './family-tags';
@@ -11,7 +10,7 @@ import { FamilyTags } from './family-tags';
   styleUrls: ['./family-tags.component.css']
 })
 export class FamilyTagsComponent extends StatefulComponent implements OnInit {
-  @Input() public numOfCols: number | string;
+  @Input() public numOfCols: number;
   @Input() public tags = [];
   @Output() public chooseMode = new EventEmitter<boolean>();
   @Output() public updateTagsLists = new EventEmitter();
@@ -55,7 +54,7 @@ export class FamilyTagsComponent extends StatefulComponent implements OnInit {
     this.store.dispatch(new SetFamilyTags(this.selectedTags, this.deselectedTags, this.tagIntersection));
   }
 
-  public onChooseMode(intersected: boolean = true): void {
+  public onChooseMode(intersected = true): void {
     this.tagIntersection = intersected;
     this.store.dispatch(new SetFamilyTags(this.selectedTags, this.deselectedTags, this.tagIntersection));
     this.chooseMode.emit(intersected);

--- a/src/app/family-tags/family-tags.component.ts
+++ b/src/app/family-tags/family-tags.component.ts
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { FamilyTagsState, SetFamilyTags } from './family-tags.state';
 import { Store } from '@ngxs/store';
 import { FamilyTags } from './family-tags';
-import { ValidateNested } from 'class-validator';
 
 @Component({
   selector: 'gpf-family-tags',
@@ -12,8 +11,7 @@ import { ValidateNested } from 'class-validator';
   styleUrls: ['./family-tags.component.css']
 })
 export class FamilyTagsComponent extends StatefulComponent implements OnInit {
-  @Input() public numOfRows: number | string;
-  @Input() public numOfCols: number;
+  @Input() public numOfCols: number | string;
   @Input() public tags = [];
   @Output() public chooseMode = new EventEmitter<boolean>();
   @Output() public updateTagsLists = new EventEmitter();
@@ -22,7 +20,6 @@ export class FamilyTagsComponent extends StatefulComponent implements OnInit {
   public deselectedTags: string[] = [];
   public filtersButtonsState: Record<string, number> = {};
   public tagIntersection = true; // mode "And"
-  // @ValidateNested()
   public familyTags = new FamilyTags();
 
   public constructor(protected store: Store) {
@@ -30,24 +27,25 @@ export class FamilyTagsComponent extends StatefulComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    // super.ngOnInit();
-
     this.tags.forEach((tag: string) => {
       this.filtersButtonsState[tag] = 0;
     });
 
-    this.store.selectOnce(state => state.familyTagsState).subscribe(state => {
-      // restore state
-      this.setFamilyTags(state.selectedFamilyTags, state.deselectedFamilyTags, state.tagIntersection);
+    this.store.selectOnce(state => state.familyTagsState).subscribe((state: SetFamilyTags) => {
+      this.restoreFamilyTags(state.selectedFamilyTags, state.deselectedFamilyTags, state.tagIntersection);
     });
   }
 
-  public setFamilyTags(selectedTags: string[], deselectedTags: string[], intersection: boolean): void {
+  public restoreFamilyTags(selectedTags: string[], deselectedTags: string[], intersection: boolean): void {
     this.selectedTags = selectedTags;
-    this.selectedTags.forEach(tag => this.filtersButtonsState[tag] = 1);
+    this.selectedTags.forEach(tag => {
+      this.filtersButtonsState[tag] = 1;
+    });
 
     this.deselectedTags = deselectedTags;
-    this.deselectedTags.forEach(tag => this.filtersButtonsState[tag] = -1);
+    this.deselectedTags.forEach(tag => {
+      this.filtersButtonsState[tag] = -1;
+    });
 
     this.tagIntersection = intersection;
 

--- a/src/app/family-tags/family-tags.component.ts
+++ b/src/app/family-tags/family-tags.component.ts
@@ -1,0 +1,89 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import _ from 'lodash';
+
+@Component({
+  selector: 'gpf-family-tags',
+  templateUrl: './family-tags.component.html',
+  styleUrls: ['./family-tags.component.css']
+})
+export class FamilyTagsComponent implements OnInit {
+  @Input() public numOfRows: number | string;
+  @Input() public numOfCols: number;
+  @Input() public tags = [];
+  @Output() public chooseMode = new EventEmitter<boolean>();
+  @Output() public updateTagsLists = new EventEmitter();
+
+  public selectedTags: string[] = [];
+  public deselectedTags: string[] = [];
+  public filtersButtonsState: Record<string, number> = {};
+  public tagIntersection = true; // mode "And"
+
+  public onChooseMode(intersected: boolean = true): void {
+    this.tagIntersection = intersected;
+    this.chooseMode.emit(intersected);
+  }
+
+  public onUpdateTags(): void {
+    this.updateTagsLists.next({selected: this.selectedTags, deselected: this.deselectedTags});
+  }
+
+  public ngOnInit(): void {
+    this.tags.forEach((tag: string) => {
+      this.filtersButtonsState[tag] = 0;
+    });
+  }
+
+  public selectFilter(tag: string): void {
+    if (this.filtersButtonsState[tag] === 1) {
+      this.filtersButtonsState[tag] = 0;
+    } else {
+      this.filtersButtonsState[tag] = 1;
+    }
+    this.updateSelectedTagsList(tag);
+  }
+
+  public deselectFilter(tag: string): void {
+    if (this.filtersButtonsState[tag] === -1) {
+      this.filtersButtonsState[tag] = 0;
+    } else {
+      this.filtersButtonsState[tag] = -1;
+    }
+    this.updateDeselectedTagsList(tag);
+  }
+
+  public clearFilters(): void {
+    this.selectedTags = [];
+    this.deselectedTags = [];
+    this.filtersButtonsState = _.mapValues(this.filtersButtonsState, () => 0);
+
+    this.onUpdateTags();
+  }
+
+  public updateSelectedTagsList(tag: string): void {
+    if (!this.selectedTags.includes(tag)) {
+      this.selectedTags.push(tag);
+    } else {
+      const index = this.selectedTags.indexOf(tag);
+      this.selectedTags.splice(index, 1);
+    }
+    if (this.deselectedTags.includes(tag)) {
+      const index = this.deselectedTags.indexOf(tag);
+      this.deselectedTags.splice(index, 1);
+    }
+    this.onUpdateTags();
+  }
+
+  public updateDeselectedTagsList(tag: string): void {
+    if (!this.deselectedTags.includes(tag)) {
+      this.deselectedTags.push(tag);
+    } else {
+      const index = this.deselectedTags.indexOf(tag);
+      this.deselectedTags.splice(index, 1);
+    }
+    if (this.selectedTags.includes(tag)) {
+      const index = this.selectedTags.indexOf(tag);
+      this.selectedTags.splice(index, 1);
+    }
+    this.onUpdateTags();
+  }
+}

--- a/src/app/family-tags/family-tags.state.ts
+++ b/src/app/family-tags/family-tags.state.ts
@@ -11,9 +11,9 @@ export class SetFamilyTags {
 }
 
 export interface FamilyTagsModel {
-    selectedFamilyTags: string[];
-    deselectedFamilyTags: string[];
-    tagIntersection: boolean;
+  selectedFamilyTags: string[];
+  deselectedFamilyTags: string[];
+  tagIntersection: boolean;
 }
 
 @State<FamilyTagsModel>({

--- a/src/app/family-tags/family-tags.state.ts
+++ b/src/app/family-tags/family-tags.state.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { State, Action, StateContext } from '@ngxs/store';
+
+export class SetFamilyTags {
+  public static readonly type = '[Genotype] Set family tags';
+  public constructor(
+    public selectedFamilyTags: string[],
+    public deselectedFamilyTags: string[],
+    public tagIntersection: boolean
+  ) {}
+}
+
+export interface FamilyTagsModel {
+    selectedFamilyTags: string[];
+    deselectedFamilyTags: string[];
+    tagIntersection: boolean;
+}
+
+@State<FamilyTagsModel>({
+  name: 'familyTagsState',
+  defaults: {
+    selectedFamilyTags: [],
+    deselectedFamilyTags: [],
+    tagIntersection: true
+  },
+})
+@Injectable()
+export class FamilyTagsState {
+  @Action(SetFamilyTags)
+  public changeFamilyTags(ctx: StateContext<FamilyTagsModel>, action: SetFamilyTags): void {
+    ctx.patchState({
+      selectedFamilyTags: action.selectedFamilyTags,
+      deselectedFamilyTags: action.deselectedFamilyTags,
+      tagIntersection: action.tagIntersection
+    });
+  }
+}

--- a/src/app/family-tags/family-tags.ts
+++ b/src/app/family-tags/family-tags.ts
@@ -1,7 +1,4 @@
-import { IsEmpty } from 'class-validator';
-
 export class FamilyTags {
-  // @IsEmpty({message: 'Please select at least one family tag.'})
   public selectedTags: string[] = [];
   public deselectedTags: string[] = [];
   public tagIntersection = true; // mode "And"

--- a/src/app/family-tags/family-tags.ts
+++ b/src/app/family-tags/family-tags.ts
@@ -1,0 +1,8 @@
+import { IsEmpty } from 'class-validator';
+
+export class FamilyTags {
+  // @IsEmpty({message: 'Please select at least one family tag.'})
+  public selectedTags: string[] = [];
+  public deselectedTags: string[] = [];
+  public tagIntersection = true; // mode "And"
+}

--- a/src/app/gene-profiles-block/gene-profiles.service.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles.service.spec.ts
@@ -1,10 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ConfigService } from 'app/config/config.service';
-// eslint-disable-next-line no-restricted-imports
 import { lastValueFrom, of } from 'rxjs';
 import { GeneProfilesService } from './gene-profiles.service';
-import { GeneProfilesSingleViewConfig, GeneProfilesGene } from 'app/gene-profiles-single-view/gene-profiles-single-view';
+import {
+  GeneProfilesSingleViewConfig,
+  GeneProfilesGene
+} from 'app/gene-profiles-single-view/gene-profiles-single-view';
 import { take } from 'rxjs/operators';
 
 describe('GeneProfilesService', () => {

--- a/src/app/gene-profiles-block/gene-profiles.service.ts
+++ b/src/app/gene-profiles-block/gene-profiles.service.ts
@@ -1,9 +1,11 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { GeneProfilesSingleViewConfig, GeneProfilesGene } from 'app/gene-profiles-single-view/gene-profiles-single-view';
+import {
+  GeneProfilesSingleViewConfig,
+  GeneProfilesGene
+} from 'app/gene-profiles-single-view/gene-profiles-single-view';
 import { ConfigService } from 'app/config/config.service';
 import { plainToClass } from 'class-transformer';
-// eslint-disable-next-line no-restricted-imports
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -166,14 +166,22 @@ export class GeneProfileSingleViewComponent implements OnInit {
     return genomicScores.find(category => category.id === categoryId).scores.find(score => score.id === scoreId).value;
   }
 
-  public getGeneDatasetValue(gene: GeneProfilesGene, studyId: string, personSetId: string, statisticId: string): GeneProfilesEffectType {
+  public getGeneDatasetValue(
+    gene: GeneProfilesGene,
+    studyId: string,
+    personSetId: string,
+    statisticId: string
+  ): GeneProfilesEffectType {
     return gene.studies.find(study => study.id === studyId).personSets
       .find(genePersonSet => genePersonSet.id === personSetId).effectTypes
       .find(effectType => effectType.id === statisticId);
   }
 
   public goToQuery(
-    geneSymbol: string, personSet: GeneProfilesDatasetPersonSet, datasetId: string, statistic: GeneProfilesDatasetStatistic
+    geneSymbol: string,
+    personSet: GeneProfilesDatasetPersonSet,
+    datasetId: string, 
+    statistic: GeneProfilesDatasetStatistic
   ): void {
     GeneProfileSingleViewComponent.goToQuery(
       this.store, this.queryService, geneSymbol, personSet, datasetId, statistic
@@ -194,9 +202,9 @@ export class GeneProfileSingleViewComponent implements OnInit {
     const genomicScores: GenomicScore[] = [];
     if (statistic.scores) {
       genomicScores[0] = new GenomicScore(
-        statistic.scores[0]['name'],
-        statistic.scores[0]['min'],
-        statistic.scores[0]['max'],
+        statistic.scores[0]['name'] as string,
+        statistic.scores[0]['min'] as number,
+        statistic.scores[0]['max'] as number,
       );
     }
 

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -295,7 +295,7 @@ export class GeneProfilesTableComponent implements OnInit, OnChanges, OnDestroy 
     }
   }
 
-  public handleCellClick($event, row, column: GeneProfilesColumn): void {
+  public handleCellClick($event, row: object, column: GeneProfilesColumn): void {
     const linkClick: boolean = $event.target.classList.contains('clickable');
     const geneSymbol = row[this.geneSymbolColumnId] as string;
 
@@ -350,7 +350,7 @@ export class GeneProfilesTableComponent implements OnInit, OnChanges, OnDestroy 
 
   private focusSearchBox(): void {
     this.waitForSearchBoxToLoad().then(() => {
-      this.searchBox.nativeElement.focus();
+      (this.searchBox.nativeElement as HTMLInputElement).focus();
     });
   }
 }

--- a/src/app/gene-profiles-table/gene-profiles-table.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.ts
@@ -72,7 +72,11 @@ export class GeneProfilesColumn {
     return this.columns.filter(column => column.visibility);
   }
 
-  public static leaves(columns: GeneProfilesColumn[], parent?: GeneProfilesColumn, depth: number = 1): GeneProfilesColumn[] {
+  public static leaves(
+    columns: GeneProfilesColumn[],
+    parent?: GeneProfilesColumn,
+    depth: number = 1
+  ): GeneProfilesColumn[] {
     const result: GeneProfilesColumn[] = [];
     for (const column of columns.filter(c => c.visibility)) {
       column.parent = parent === null || parent === undefined ? null : parent;

--- a/src/app/gene-profiles-table/middle-click.directive.ts
+++ b/src/app/gene-profiles-table/middle-click.directive.ts
@@ -7,7 +7,7 @@ export class MiddleClickDirective {
   @Output('middleclick') public middleClick = new EventEmitter();
 
   @HostListener('mouseup', ['$event'])
-  public middleclickEvent(event): void {
+  public middleclickEvent(event: MouseEvent): void {
     if (event.which === 2) {
       this.middleClick.emit(event);
     }

--- a/src/app/genotype-browser/genotype-browser.ts
+++ b/src/app/genotype-browser/genotype-browser.ts
@@ -9,15 +9,15 @@ export class BrowserQueryFilter {
     private variantTypes: string[]
   ) { }
 
-  public static fromJson(json): BrowserQueryFilter {
+  public static fromJson(json: object): BrowserQueryFilter {
     return new BrowserQueryFilter(
-      json['datasetId'],
-      json['geneSymbols'],
-      json['effectTypes'],
-      json['gender'],
-      PersonSetCollection.fromJson(json['peopleGroup']),
-      json['studyTypes'],
-      json['variantTypes']
+      json['datasetId'] as string,
+      json['geneSymbols'] as string[],
+      json['effectTypes'] as string[],
+      json['gender'] as string[],
+      PersonSetCollection.fromJson(json['peopleGroup'] as PersonSetCollection),
+      json['studyTypes'] as string[],
+      json['variantTypes'] as string[]
     );
   }
 }
@@ -28,10 +28,10 @@ export class PersonSetCollection {
     public checkedValues: string[],
   ) { }
 
-  public static fromJson(json): PersonSetCollection {
+  public static fromJson(json: object): PersonSetCollection {
     return new PersonSetCollection(
-      json['id'],
-      json['checkedValues']
+      json['id'] as string,
+      json['checkedValues'] as string[]
     );
   }
 }
@@ -43,11 +43,11 @@ export class GenomicScore {
     private rangeEnd: number,
   ) {}
 
-  public static fromJson(json): GenomicScore {
+  public static fromJson(json: object): GenomicScore {
     return new GenomicScore(
-      json['metric'],
-      json['rangeStart'],
-      json['rangeEnd'],
+      json['metric'] as string,
+      json['rangeStart'] as number,
+      json['rangeEnd'] as number,
     );
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -53,20 +53,20 @@ export class HomeComponent implements OnInit {
       datasets: this.datasetsTreeService.getDatasetHierarchy(),
       visibleDatasets: this.datasetsService.getVisibleDatasets()
     }).subscribe(({datasets, visibleDatasets}) => {
-      datasets['data'].forEach((d: object) => {
+      (datasets['data'] as Array<object>).forEach((d: object) => {
         this.collectAllStudies(d); this.attachDatasetDescription(d);
       });
 
       this.content = datasets;
       this.visibleDatasets = visibleDatasets as string[];
 
-      this.content['data'].forEach(d => {
-        if (this.visibleDatasets.includes(d.dataset)) {
-          this.datasets.push(d.dataset);
+      (this.content['data'] as Array<object>).forEach(d => {
+        if (this.visibleDatasets.includes(d['dataset'] as string)) {
+          this.datasets.push(d['dataset'] as string);
         }
 
-        if (d.children) {
-          d.children.map(c => c.dataset).forEach(c => {
+        if (d['children'] as Array<object>) {
+          (d['children'] as Array<object>).map(c => c['dataset'] as string).forEach(c => {
             if (this.visibleDatasets.includes(c)) {
               this.datasets.push(c);
             }
@@ -146,9 +146,9 @@ export class HomeComponent implements OnInit {
 
   public attachDatasetDescription(entry: object): void {
     entry['children']?.forEach((d: object) => this.attachDatasetDescription(d));
-    this.datasetsService.getDatasetDescription(entry['dataset']).pipe(take(1)).subscribe(res => {
+    this.datasetsService.getDatasetDescription(entry['dataset'] as string).pipe(take(1)).subscribe(res => {
       if (res['description']) {
-        entry['description'] = this.getFirstParagraph(res['description']);
+        entry['description'] = this.getFirstParagraph(res['description'] as string);
       }
 
       this.studiesLoaded++;
@@ -170,8 +170,8 @@ export class HomeComponent implements OnInit {
 
   public collectAllStudies(data: object): void {
     this.allStudies.add(data['dataset']);
-    if (data['children'] && data['children'].length !== 0) {
-      data['children'].forEach(dataset => {
+    if (data['children'] && (data['children'] as Array<object>).length !== 0) {
+      (data['children'] as Array<object>).forEach(dataset => {
         this.collectAllStudies(dataset);
       });
     }
@@ -185,7 +185,7 @@ export class HomeComponent implements OnInit {
     }
 
     children.forEach(c => {
-      if (this.visibleDatasets.includes(c['dataset'])) {
+      if (this.visibleDatasets.includes(c['dataset'] as string)) {
         result = true;
       }
     });
@@ -209,7 +209,7 @@ export class HomeComponent implements OnInit {
     }
   }
 
-  public findAllByKey(obj, keyToFind): string[] {
+  public findAllByKey(obj, keyToFind: string): string[] {
     return Object.entries(obj)
       .reduce((acc, [key, value]) => key === keyToFind
         ? acc.concat(value)

--- a/src/app/markdown-editor/markdown-editor.component.spec.ts
+++ b/src/app/markdown-editor/markdown-editor.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MarkdownEditorComponent } from './markdown-editor.component';
-import { MarkdownService, SECURITY_CONTEXT } from 'ngx-markdown';
+import { MarkdownService } from 'ngx-markdown';
 
 describe('MarkdownEditorComponent', () => {
   let component: MarkdownEditorComponent;

--- a/src/app/markdown-editor/markdown-editor.component.ts
+++ b/src/app/markdown-editor/markdown-editor.component.ts
@@ -25,7 +25,7 @@ export class MarkdownEditorComponent implements OnInit {
     resize: 'both',
     fullscreen: {enable: false, icons: undefined},
     parser: (val: string) => {
-      const sanitizedText = DOMPurify.sanitize(val.trim());
+      const sanitizedText = DOMPurify.sanitize(val.trim()) as string;
       return this.markdownService.parse(sanitizedText);
     }
   };

--- a/src/app/person-filters/person-filters.component.html
+++ b/src/app/person-filters/person-filters.component.html
@@ -1,4 +1,4 @@
-<div class="panel" id="pheno-filters-panel">
+<div style="padding: 20px" id="pheno-filters-panel">
   <div class="row">
     <div *ngIf="categoricalFilters.length !== 0" class="col-sm-3">
       <div *ngFor="let categoricalFilter of categoricalFilters" class="categorical-filter">

--- a/src/app/query/query.service.spec.ts
+++ b/src/app/query/query.service.spec.ts
@@ -23,7 +23,5 @@ describe('QueryService', () => {
     expect(service).toBeTruthy();
   });
 
-  it.skip('should test downloadVariants', () => {
-    // TODO
-  });
+  it.todo('should test downloadVariants');
 });

--- a/src/app/query/query.service.ts
+++ b/src/app/query/query.service.ts
@@ -22,6 +22,7 @@ export class QueryService {
   private readonly userSaveQueryEndpoint = 'user_queries/save';
   private readonly userCollectQueriesEndpoint = 'user_queries/collect';
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   private readonly headers = new HttpHeaders({ 'Content-Type': 'application/json' });
 
   private oboeInstance = null;
@@ -128,24 +129,25 @@ export class QueryService {
     const queryFilter = { ...filter };
     queryFilter['maxVariantsCount'] = maxVariantsCount;
 
-    this.familyVariantsSubscription = this.streamPost(this.genotypePreviewVariantsUrl, queryFilter).subscribe(variant => {
-      genotypePreviewVariantsArray.addPreviewVariant(
-        <Array<string>> variant,
-        dataset.genotypeBrowserConfig.columnIds
-      );
+    this.familyVariantsSubscription = this.streamPost(this.genotypePreviewVariantsUrl, queryFilter)
+      .subscribe(variant => {
+        genotypePreviewVariantsArray.addPreviewVariant(
+          <Array<string>> variant,
+          dataset.genotypeBrowserConfig.columnIds
+        );
 
-      if (callback !== undefined) {
-        callback();
-      }
+        if (callback !== undefined) {
+          callback();
+        }
 
-      if (variant) {
-        // Attach the genome version to each variant
-        // This is done so that the table can construct the correct UCSC link for the variant
-        genotypePreviewVariantsArray.genotypePreviews[
-          genotypePreviewVariantsArray.genotypePreviews.length - 1
-        ].data.set('genome', dataset.genome);
-      }
-    });
+        if (variant) {
+          // Attach the genome version to each variant
+          // This is done so that the table can construct the correct UCSC link for the variant
+          genotypePreviewVariantsArray.genotypePreviews[
+            genotypePreviewVariantsArray.genotypePreviews.length - 1
+          ].data.set('genome', dataset.genome);
+        }
+      });
 
     return genotypePreviewVariantsArray;
   }
@@ -154,7 +156,7 @@ export class QueryService {
     return this.http.post(this.config.baseUrl + this.geneViewVariantsUrl, filter);
   }
 
-  public saveQuery(queryData: {}, page: string): Observable<object> {
+  public saveQuery(queryData: object, page: string): Observable<object> {
     const options = { headers: this.headers };
 
     queryData = {...queryData};
@@ -193,7 +195,7 @@ export class QueryService {
     return window.location.origin + pathname;
   }
 
-  public getLoadUrlFromResponse(response: {}): string {
+  public getLoadUrlFromResponse(response: object): string {
     return this.getLoadUrl(response['uuid']);
   }
 
@@ -201,6 +203,7 @@ export class QueryService {
     const options = { headers: this.headers, withCredentials: true };
 
     const data = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       query_uuid: uuid,
       name: query_name,
       description: query_description

--- a/src/app/sorting-buttons/sorting-buttons.component.ts
+++ b/src/app/sorting-buttons/sorting-buttons.component.ts
@@ -8,7 +8,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class SortingButtonsComponent {
   @Input() public id: string;
   @Input() public sortState = 0;
-  @Output() public sortEvent = new EventEmitter<{id: string, order: string}>();
+  @Output() public sortEvent = new EventEmitter<{id: string; order: string}>();
   private order = 'desc';
 
   public emitSort(): void {

--- a/src/app/user-edit/user-edit.component.ts
+++ b/src/app/user-edit/user-edit.component.ts
@@ -101,7 +101,7 @@ export class UserEditComponent implements OnInit {
 
   private focusNameInputArea(): void {
     this.waitForNameInputAreaToLoad().then(() => {
-      this.nameInput.nativeElement.focus();
+      (this.nameInput.nativeElement as HTMLInputElement).focus();
     });
   }
 }

--- a/src/app/users-groups/users-groups.ts
+++ b/src/app/users-groups/users-groups.ts
@@ -3,12 +3,12 @@ export class UserGroup {
     return jsonArray.map(v => UserGroup.fromJson(v));
   }
 
-  public static fromJson(json): UserGroup {
+  public static fromJson(json: object): UserGroup {
     return new UserGroup(
-      json['id'],
-      json['name'],
-      json['users'],
-      json['datasets'],
+      json['id'] as number,
+      json['name'] as string,
+      json['users'] as string[],
+      json['datasets'] as Array<{datasetName: string; datasetId: string}>,
     );
   }
 

--- a/src/app/users/users.ts
+++ b/src/app/users/users.ts
@@ -3,14 +3,14 @@ export class User {
     return json.map(user => User.fromJson(user));
   }
 
-  public static fromJson(json): User {
+  public static fromJson(json: object): User {
     return new User(
-      json['id'],
-      json['name'],
-      json['email'],
-      json['groups'],
-      json['hasPassword'],
-      json['allowedDatasets'],
+      json['id'] as number,
+      json['name'] as string,
+      json['email'] as string,
+      json['groups'] as Array<string>,
+      json['hasPassword'] as boolean,
+      json['allowedDatasets'] as Array<{datasetName: string; datasetId: string}>,
     );
   }
 

--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -187,34 +187,6 @@ h5 {
   text-overflow: ellipsis;
 }
 
-#tags-modal-content {
-  padding: 8px 20px;
-  height: fit-content;
-  width: fit-content;
-}
-
-#tags-modal-header {
-  display: flex;
-  column-gap: 20px;
-  align-items: baseline;
-  margin-bottom: 10px;
-}
-
-#clear-filters-button {
-  white-space: nowrap;
-  color: #2a6395;
-  user-select: none;
-}
-
-#clear-filters-button:hover {
-  cursor: pointer;
-  color: #163d5f;
-}
-
-#tag-label {
-  margin-left: 5px;
-}
-
 .download-link {
   cursor: pointer;
   user-select: none;
@@ -237,44 +209,4 @@ h5 {
 #families-sum {
   margin-right: 15px;
   min-width: 100px;
-}
-
-.tags {
-  color: #cdcdcd;
-  font-size: 22px;
-  user-select: none;
-}
-
-.tags:hover {
-  cursor: pointer;
-}
-
-.modal-content-lines {
-  display: flex;
-  align-items: center;
-}
-
-.and-toggle-button {
-  color: #2a6395;
-  width: 70px;
-  padding: 0 20px;
-  border-radius: 5px 0 0 5px;
-  border: 1px solid #2a6395;
-}
-
-.or-toggle-button {
-  color: #2a6395;
-  width: 70px;
-  padding: 0 20px;
-  border-radius: 0 5px 5px 0;
-  border: 1px solid #2a6395;
-}
-
-#mode-label {
-  margin-right: 10px;
-}
-
-.selected-mode {
-  background-color: #2a6395;
-  color: white;
 }

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -112,53 +112,11 @@
         </form>
       </div>
       <ng-template #tagsModal class="tags-modal">
-        <div id="tags-modal-content">
-          <div id="tags-modal-header">
-            <div>
-              <span id="mode-label">Choose mode: </span>
-              <button
-                class="and-toggle-button"
-                (click)="tagIntersection = true; updateTagsHeader()"
-                [ngClass]="{ 'selected-mode': tagIntersection }"
-                >And</button
-              >
-              <button
-                class="or-toggle-button"
-                (click)="tagIntersection = false; updateTagsHeader()"
-                [ngClass]="{ 'selected-mode': !tagIntersection }"
-                >Or</button
-              >
-            </div>
-            <a (click)="clearFilters()" id="clear-filters-button">Clear filters</a>
-          </div>
-
-          <div
-            id="tag-list"
-            [ngStyle]="{
-              display: 'grid',
-              'grid-template-columns': 'repeat(' + tagsModalsNumberOfCols + ', max-content)',
-              'grid-template-rows': 'repeat(' + tagsModalsNumberOfRows + ', 30px)',
-              'column-gap': '16px'
-            }">
-            <div *ngFor="let tag of orderedTagList" class="modal-content-lines">
-              <span
-                class="material-icons tags"
-                [id]="tag + '-tag-add'"
-                (click)="selectFilter(tag)"
-                [ngStyle]="{ color: filtersButtonsState[tag] === 1 ? 'green' : '#cdcdcd' }"
-                >add_circle</span
-              >
-              <span
-                class="material-icons tags"
-                [id]="tag + '-tag-remove'"
-                (click)="deselectFilter(tag)"
-                [ngStyle]="{ color: filtersButtonsState[tag] === -1 ? 'red' : '#cdcdcd' }"
-                >remove_circle</span
-              >
-              <span [attr.for]="tag + '-tag'" id="tag-label">{{ tag }}</span>
-            </div>
-          </div>
-        </div>
+        <gpf-family-tags
+          [numOfCols]="tagsModalsNumberOfCols"
+          [tags]="orderedTagList"
+          (chooseMode)="setTagIntersection($event)"
+          (updateTagsLists)="setTags($event)"></gpf-family-tags>
       </ng-template>
     </div>
 

--- a/src/app/variant-reports/variant-reports.component.spec.ts
+++ b/src/app/variant-reports/variant-reports.component.spec.ts
@@ -20,8 +20,8 @@ class MockDatasetsService {
   public getSelectedDatasetObservable(): object {
     return of({accessRights: true, commonReport: {enabled: true}});
   }
-  public getDatasetsLoadedObservable = (): Observable<any> => of();
-  public getDataset(): Observable<any> {
+  public getDatasetsLoadedObservable = (): Observable<null> => of();
+  public getDataset(): Observable<object> {
     return of({accessRights: true, commonReport: {enabled: true}});
   }
 }
@@ -33,8 +33,8 @@ class MockDatasetsDenovoService {
   public getSelectedDatasetObservable(): object {
     return of({id: 'Denovo', accessRights: true, commonReport: {enabled: true}});
   }
-  public getDatasetsLoadedObservable = (): Observable<any> => of();
-  public getDataset(): Observable<any> {
+  public getDatasetsLoadedObservable = (): Observable<null> => of();
+  public getDataset(): Observable<object> {
     return of({id: 'Denovo', accessRights: true, commonReport: {enabled: true}});
   }
 }
@@ -72,7 +72,7 @@ class VariantReportsServiceMock {
     this.datasetId = datasetId;
   }
 
-  public getVariantReport(datasetId: string): Observable<any> {
+  public getVariantReport(datasetId: string): Observable<object> {
     const pedigreeCounter: PedigreeCounter = new PedigreeCounter(1, 'groupName',
       [
         new PedigreeData('identifier', 'id', 'mother', 'father',

--- a/src/app/variant-reports/variant-reports.component.spec.ts
+++ b/src/app/variant-reports/variant-reports.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PeopleCounterRowPipe, VariantReportsComponent } from './variant-reports.component';
 import { FormsModule } from '@angular/forms';
 import { VariantReportsService } from './variant-reports.service';
-import { Observable, lastValueFrom, of } from 'rxjs';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, ReplaySubject, lastValueFrom, of } from 'rxjs';
+import { ActivatedRoute, NavigationEnd, Router, RouterEvent } from '@angular/router';
 import { DatasetsService } from 'app/datasets/datasets.service';
 import { PerfectlyDrawablePedigreeService } from 'app/perfectly-drawable-pedigree/perfectly-drawable-pedigree.service';
 import { ResizeService } from 'app/table/resize.service';
@@ -12,6 +12,8 @@ import { PedigreeData } from 'app/genotype-preview-model/genotype-preview';
 import { HttpResponse } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ConfigService } from 'app/config/config.service';
+import { NgxsModule } from '@ngxs/store';
+import { RouterTestingModule } from '@angular/router/testing';
 
 class MockDatasetsService {
   public getSelectedDataset(): object {
@@ -287,6 +289,14 @@ class VariantReportsServiceMock {
   }
 }
 
+class MockRouter {
+  public nav = new NavigationEnd(0, '', '');
+  public events = new Observable(observer => {
+    observer.next(this.nav);
+    observer.complete();
+  });
+}
+
 describe('VariantReportsComponent', () => {
   let component: VariantReportsComponent;
   let fixture: ComponentFixture<VariantReportsComponent>;
@@ -297,12 +307,12 @@ describe('VariantReportsComponent', () => {
     const datasetsServiceMock = new MockDatasetsService();
     TestBed.configureTestingModule({
       declarations: [VariantReportsComponent, PeopleCounterRowPipe],
-      imports: [FormsModule],
+      imports: [FormsModule, NgxsModule.forRoot([], {developmentMode: true}), RouterTestingModule.withRoutes([])],
       providers: [
         ConfigService,
         { provide: VariantReportsService, useValue: variantReportsServiceMock },
         { provide: ActivatedRoute, useValue: activatedRouteMock },
-        { provide: Router, useValue: {} },
+        { provide: Router, useClass: MockRouter },
         { provide: DatasetsService, useValue: datasetsServiceMock },
         { provide: PerfectlyDrawablePedigreeService },
         { provide: ResizeService, useClass: ResizeServiceMock },

--- a/src/app/variant-reports/variant-reports.component.spec.ts
+++ b/src/app/variant-reports/variant-reports.component.spec.ts
@@ -20,9 +20,7 @@ class MockDatasetsService {
   public getSelectedDatasetObservable(): object {
     return of({accessRights: true, commonReport: {enabled: true}});
   }
-  public getDatasetsLoadedObservable = function() {
-    return of();
-  };
+  public getDatasetsLoadedObservable = (): Observable<any> => of();
   public getDataset(): Observable<any> {
     return of({accessRights: true, commonReport: {enabled: true}});
   }
@@ -35,9 +33,7 @@ class MockDatasetsDenovoService {
   public getSelectedDatasetObservable(): object {
     return of({id: 'Denovo', accessRights: true, commonReport: {enabled: true}});
   }
-  public getDatasetsLoadedObservable = function() {
-    return of();
-  };
+  public getDatasetsLoadedObservable = (): Observable<any> => of();
   public getDataset(): Observable<any> {
     return of({id: 'Denovo', accessRights: true, commonReport: {enabled: true}});
   }
@@ -61,7 +57,7 @@ class MockActivatedRoute {
 
   public constructor(datasetId: string = 'test_dataset') {
     this.datasetId = datasetId;
-    this.params = {dataset: this.datasetId, get: () => ''};
+    this.params = {dataset: this.datasetId, get: (): string => ''};
     this.parent = {params: of(this.params)};
     this.queryParamMap = of(this.params);
   }
@@ -214,9 +210,7 @@ class VariantReportsServiceMock {
             groupName: 'Role',
             rows: ['people_male', 'people_female', 'people_total'],
             columns: ['prb', 'mom', 'sib', 'dad'],
-            getChildrenCounter: function() {
-              return 0;
-            }
+            getChildrenCounter: (): number => 0
           }
         ],
       },
@@ -320,9 +314,7 @@ describe('VariantReportsComponent', () => {
     component = fixture.componentInstance;
 
     //Stubbing the function to reduce mock test data
-    component['chunkPedigrees'] = function(a, b) {
-      return null;
-    };
+    component['chunkPedigrees'] = (): null => null;
   });
 
   it('should create', () => {
@@ -340,134 +332,62 @@ describe('VariantReportsComponent', () => {
     expect(component.tags).toStrictEqual(tags);
     expect(component.orderedTagList).toStrictEqual(tags);
     expect(component.tagsModalsNumberOfCols).toBe(2);
-    expect(component.tagsModalsNumberOfRows).toBe(5);
   });
 
-  it('should update selected pedigree tags', () => {
-    component.selectedTags = ['tag1', 'tag2', 'tag3'];
-    const updatePedigreesTable = jest.spyOn(component, 'updateTagFilters')
+  it('should test setting mode', () => {
+    const updateTagsHeaderMock = jest.spyOn(component, 'updateTagsHeader')
       .mockImplementation(() => null);
 
-    const updateFamiliesCountMock = jest.spyOn(component, 'updateFamiliesCount')
-      .mockImplementation(() => null);
+    expect(component.tagIntersection).toBe(true);
 
-    const updateSelectedTagsListMock = jest.spyOn(component, 'updateSelectedTagsList');
-
-    component.selectFilter('tag4');
-    expect(component.filtersButtonsState['tag4']).toBe(1);
-    expect(updateSelectedTagsListMock).toHaveBeenCalledWith('tag4');
-    expect(updatePedigreesTable).toHaveBeenCalledWith();
-    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
-    expect(component.selectedTags).toStrictEqual(['tag1', 'tag2', 'tag3', 'tag4']);
-    expect(component.tagsHeader).toBe('tag1 and tag2 and tag3 and tag4');
-
-    component.selectFilter('tag4');
-    expect(component.filtersButtonsState['tag4']).toBe(0);
-    expect(updateSelectedTagsListMock).toHaveBeenCalledWith('tag4');
-    expect(updatePedigreesTable).toHaveBeenCalledWith();
-    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
-    expect(component.selectedTags).toStrictEqual(['tag1', 'tag2', 'tag3']);
-    expect(component.tagsHeader).toBe('tag1 and tag2 and tag3');
+    component.setTagIntersection(false);
+    expect(component.tagIntersection).toBe(false);
+    expect(updateTagsHeaderMock).toHaveBeenCalledWith();
   });
 
-  it('should update deselected pedigree tags', () => {
-    component.deselectedTags = ['tag1', 'tag2'];
-    const updatePedigreesTable = jest.spyOn(component, 'updateTagFilters')
+  it('should test setting selecting and deselecting pedigree tags', () => {
+    const updateTagsHeaderMock = jest.spyOn(component, 'updateTagsHeader')
       .mockImplementation(() => null);
 
-    const updateFamiliesCountMock = jest.spyOn(component, 'updateFamiliesCount')
-      .mockImplementation(() => null);
-
-    const updateDeselectedTagsListMock = jest.spyOn(component, 'updateDeselectedTagsList');
-
-    component.deselectFilter('tag3');
-    expect(component.filtersButtonsState['tag3']).toBe(-1);
-    expect(updateDeselectedTagsListMock).toHaveBeenCalledWith('tag3');
-    expect(updatePedigreesTable).toHaveBeenCalledWith();
-    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
-    expect(component.deselectedTags).toStrictEqual(['tag1', 'tag2', 'tag3']);
-    expect(component.tagsHeader).toBe('not tag1 and not tag2 and not tag3');
-
-    component.deselectFilter('tag3');
-    expect(component.filtersButtonsState['tag3']).toBe(0);
-    expect(updateDeselectedTagsListMock).toHaveBeenCalledWith('tag3');
-    expect(updatePedigreesTable).toHaveBeenCalledWith();
-    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
-    expect(component.deselectedTags).toStrictEqual(['tag1', 'tag2']);
-    expect(component.tagsHeader).toBe('not tag1 and not tag2');
-  });
-
-  it('should test mixing selecting and deselecting pedigree tags', () => {
-    const updatePedigreesTable = jest.spyOn(component, 'updateTagFilters')
-      .mockImplementation(() => null);
-
-    const updateFamiliesCountMock = jest.spyOn(component, 'updateFamiliesCount')
-      .mockImplementation(() => null);
-
-    component.selectFilter('tag1');
-    component.deselectFilter('tag2');
-    component.selectFilter('tag3');
-    component.deselectFilter('tag4');
+    const tags = {
+      selected: ['tag1', 'tag3'],
+      deselected: ['tag2', 'tag4']
+    };
+    component.setTags(tags);
     expect(component.selectedTags).toStrictEqual(['tag1', 'tag3']);
     expect(component.deselectedTags).toStrictEqual(['tag2', 'tag4']);
-    expect(component.tagsHeader).toBe('tag1 and tag3 and not tag2 and not tag4');
+    expect(updateTagsHeaderMock).toHaveBeenCalledWith();
   });
 
-  it('should test mode "Or" and "And"', () => {
-    const pedigreeCounters: PedigreeCounter[] = [];
-    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag1', 'tag2', 'tag3', 'tag4']));
-    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag2', 'tag3']));
-    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag1', 'tag5']));
+  it('should test updating tags header with mode "and"', () => {
+    const updateTagFiltersMock = jest.spyOn(component, 'updateTagFilters')
+      .mockImplementation(() => null);
 
-    component.familiesCounters = [new FamilyCounter(pedigreeCounters, null, null, null)];
+    const updateFamiliesCountMock = jest.spyOn(component, 'updateFamiliesCount')
+      .mockImplementation(() => null);
 
-    component.pedigreeTables = [
-      new PedigreeTable([pedigreeCounters], null, null, null)];
+    component.selectedTags = ['tag1', 'tag3'];
+    component.deselectedTags = ['tag2', 'tag4'];
+    component.updateTagsHeader();
+    expect(component.tagsHeader).toBe('tag1 and tag3 and not tag2 and not tag4');
+    expect(updateTagFiltersMock).toHaveBeenCalledWith();
+    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
+  });
 
-    component.currentPedigreeTable = new PedigreeTable([pedigreeCounters], null, null, null);
+  it('should test updating tags header with mode "or"', () => {
+    const updateTagFiltersMock = jest.spyOn(component, 'updateTagFilters')
+      .mockImplementation(() => null);
 
-    const updatePedigreesMock = jest.spyOn(component, 'updatePedigrees');
+    const updateFamiliesCountMock = jest.spyOn(component, 'updateFamiliesCount')
+      .mockImplementation(() => null);
 
-    // mode And
-    component.selectFilter('tag1');
-    expect(updatePedigreesMock).toHaveBeenCalledWith(
-      {
-        null: [
-          new PedigreeCounter(null, null, null, null, ['tag1', 'tag2', 'tag3', 'tag4']),
-          new PedigreeCounter(null, null, null, null, ['tag1', 'tag5'])
-        ]
-      }
-    );
-
-    component.deselectFilter('tag4');
-    expect(updatePedigreesMock).toHaveBeenLastCalledWith(
-      {
-        null: [new PedigreeCounter(null, null, null, null, ['tag1', 'tag5'])]
-      }
-    );
-
-    // mode Or
-    component.clearFilters();
-    component.tagIntersection = false;
-    component.selectFilter('tag5');
-    expect(updatePedigreesMock).toHaveBeenCalledWith(
-      {
-        null: [
-          new PedigreeCounter(null, null, null, null, ['tag1', 'tag5'])
-        ]
-      }
-    );
-
-    component.deselectFilter('tag4');
-    expect(updatePedigreesMock).toHaveBeenLastCalledWith(
-      {
-        null: [
-          new PedigreeCounter(null, null, null, null, ['tag2', 'tag3']),
-          new PedigreeCounter(null, null, null, null, ['tag1', 'tag5'])
-
-        ]
-      }
-    );
+    component.selectedTags = ['tag1', 'tag3'];
+    component.deselectedTags = ['tag2', 'tag4'];
+    component.setTagIntersection(false);
+    component.updateTagsHeader();
+    expect(component.tagsHeader).toBe('tag1 or tag3 or not tag2 or not tag4');
+    expect(updateTagFiltersMock).toHaveBeenCalledWith();
+    expect(updateFamiliesCountMock).toHaveBeenCalledWith();
   });
 
   it('should open modal with pedigree tags', () => {
@@ -500,11 +420,69 @@ describe('VariantReportsComponent', () => {
     component.selectedTags = ['tag1', 'tag2'];
     component.deselectedTags = ['tag3', 'tag4'];
     component.tagsHeader = 'tag1 and tag2 and not tag3 and not tag4';
-    component.clearFilters();
+    component.setTags({selected: [], deselected: []});
 
     expect(component.selectedTags).toHaveLength(0);
+    expect(component.deselectedTags).toHaveLength(0);
     expect(component.tagsHeader).toBe('');
     expect(updatePedigreesTable).toHaveBeenCalledWith();
+  });
+
+  it('should update tag filters', () => {
+    const updatePedigreesMock = jest.spyOn(component, 'updatePedigrees')
+      .mockImplementation(() => null);
+
+    const pedigreeCounters: PedigreeCounter[] = [];
+    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag1', 'tag2', 'tag3', 'tag4']));
+    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag2', 'tag3']));
+    pedigreeCounters.push(new PedigreeCounter(null, null, null, null, ['tag1', 'tag5']));
+
+    component.familiesCounters = [new FamilyCounter(pedigreeCounters, null, null, null)];
+
+    component.pedigreeTables = [
+      new PedigreeTable([pedigreeCounters], null, null, null)];
+
+    component.currentPedigreeTable = new PedigreeTable([pedigreeCounters], null, null, null);
+
+    // "and" mode
+    component.selectedTags = ['tag1'];
+    component.deselectedTags = ['tag2'];
+    component.updateTagFilters();
+    expect(updatePedigreesMock).toHaveBeenCalledWith({
+      null: [
+        new PedigreeCounter(
+          null,
+          null,
+          null,
+          null,
+          ['tag1', 'tag5',],
+        ),
+      ],
+    });
+
+    // "or" mode
+    component.selectedTags = ['tag4'];
+    component.deselectedTags = ['tag3'];
+    component.tagIntersection = false;
+    component.updateTagFilters();
+    expect(updatePedigreesMock).toHaveBeenCalledWith({
+      null: [
+        new PedigreeCounter(
+          null,
+          null,
+          null,
+          null,
+          ['tag1', 'tag2', 'tag3', 'tag4'],
+        ),
+        new PedigreeCounter(
+          null,
+          null,
+          null,
+          null,
+          ['tag1', 'tag5',],
+        ),
+      ],
+    });
   });
 
   it('should test count of families in families by pedigree', () => {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -8,7 +8,6 @@ import { DatasetsService } from 'app/datasets/datasets.service';
 import { take } from 'rxjs/operators';
 import { environment } from 'environments/environment';
 import { Dictionary } from 'lodash';
-import * as _ from 'lodash';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ConfigService } from 'app/config/config.service';
 
@@ -39,7 +38,6 @@ export class VariantReportsComponent implements OnInit {
   public modal: NgbModalRef;
   @ViewChild('tagsModal') public tagsModal: ElementRef;
 
-  public tagsModalsNumberOfRows = 9;
   public tagsModalsNumberOfCols = 2;
 
   public variantReport: VariantReport;
@@ -52,7 +50,6 @@ export class VariantReportsComponent implements OnInit {
   public orderedTagList = [];
   public selectedTags: string[] = [];
   public deselectedTags: string[] = [];
-  public filtersButtonsState: Record<string, number> = {};
   public tagIntersection = true; // mode "And"
 
   public denovoVariantsTableWidth: number;
@@ -95,11 +92,9 @@ export class VariantReportsComponent implements OnInit {
         Object.values(data).forEach((tag: string) => {
           this.tags.push(tag);
           this.orderedTagList.push(tag);
-          this.filtersButtonsState[tag] = 0;
         });
         // Calculate square looking grid for the tags (1 column width === ~5 tags height)
         this.tagsModalsNumberOfCols = Math.ceil(Math.sqrt(Math.ceil(this.tags.length / 5)));
-        this.tagsModalsNumberOfRows = Math.ceil(this.tags.length / this.tagsModalsNumberOfCols);
       });
     }
   }
@@ -112,49 +107,14 @@ export class VariantReportsComponent implements OnInit {
     );
   }
 
-  public selectFilter(tag: string): void {
-    if (this.filtersButtonsState[tag] === 1) {
-      this.filtersButtonsState[tag] = 0;
-    } else {
-      this.filtersButtonsState[tag] = 1;
-    }
-    this.updateSelectedTagsList(tag);
-  }
-
-  public deselectFilter(tag: string): void {
-    if (this.filtersButtonsState[tag] === -1) {
-      this.filtersButtonsState[tag] = 0;
-    } else {
-      this.filtersButtonsState[tag] = -1;
-    }
-    this.updateDeselectedTagsList(tag);
-  }
-
-  public updateSelectedTagsList(tag: string): void {
-    if (!this.selectedTags.includes(tag)) {
-      this.selectedTags.push(tag);
-    } else {
-      const index = this.selectedTags.indexOf(tag);
-      this.selectedTags.splice(index, 1);
-    }
-    if (this.deselectedTags.includes(tag)) {
-      const index = this.deselectedTags.indexOf(tag);
-      this.deselectedTags.splice(index, 1);
-    }
+  public setTagIntersection(intersected: boolean): void {
+    this.tagIntersection = intersected;
     this.updateTagsHeader();
   }
 
-  public updateDeselectedTagsList(tag: string): void {
-    if (!this.deselectedTags.includes(tag)) {
-      this.deselectedTags.push(tag);
-    } else {
-      const index = this.deselectedTags.indexOf(tag);
-      this.deselectedTags.splice(index, 1);
-    }
-    if (this.selectedTags.includes(tag)) {
-      const index = this.selectedTags.indexOf(tag);
-      this.selectedTags.splice(index, 1);
-    }
+  public setTags(tags: {selected: []; deselected: []}): void {
+    this.selectedTags = tags.selected;
+    this.deselectedTags = tags.deselected;
     this.updateTagsHeader();
   }
 
@@ -200,15 +160,6 @@ export class VariantReportsComponent implements OnInit {
       this.tagsModal,
       {animation: false, centered: true, windowClass: 'tags-modal'}
     );
-  }
-
-  public clearFilters(): void {
-    this.selectedTags = [];
-    this.deselectedTags = [];
-    this.tagsHeader = '';
-    this.filtersButtonsState = _.mapValues(this.filtersButtonsState, () => 0);
-    this.updateTagFilters();
-    this.updateFamiliesCount();
   }
 
   public updatePedigrees(newCounters: Dictionary<PedigreeCounter[]>): void {

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -112,7 +112,7 @@ export class VariantReportsComponent implements OnInit {
     this.updateTagsHeader();
   }
 
-  public setTags(tags: {selected: []; deselected: []}): void {
+  public setTags(tags: {selected: string[]; deselected: string[]}): void {
     this.selectedTags = tags.selected;
     this.deselectedTags = tags.deselected;
     this.updateTagsHeader();

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -10,6 +10,9 @@ import { environment } from 'environments/environment';
 import { Dictionary } from 'lodash';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ConfigService } from 'app/config/config.service';
+import { Store } from '@ngxs/store';
+import { SetFamilyTags } from 'app/family-tags/family-tags.state';
+import { Router } from '@angular/router';
 
 @Pipe({ name: 'getPeopleCounterRow' })
 export class PeopleCounterRowPipe implements PipeTransform {
@@ -59,8 +62,14 @@ export class VariantReportsComponent implements OnInit {
     public modalService: NgbModal,
     public config: ConfigService,
     private variantReportsService: VariantReportsService,
-    private datasetsService: DatasetsService
-  ) { }
+    private datasetsService: DatasetsService,
+    protected store: Store,
+    private router: Router
+  ) {
+    router.events.subscribe(() => {
+      this.store.dispatch(new SetFamilyTags([], [], true));
+    });
+  }
 
   @HostListener('window:resize')
   public onResize(): void {

--- a/src/app/variant-reports/variant-reports.service.spec.ts
+++ b/src/app/variant-reports/variant-reports.service.spec.ts
@@ -13,7 +13,7 @@ class MockDatasetsService {
   public getSelectedDataset(): object {
     return {id: 'test_dataset'};
   }
-  public getDataset(): Observable<any> {
+  public getDataset(): Observable<object> {
     return of({accessRights: true});
   }
 }

--- a/src/app/variant-reports/variant-reports.service.ts
+++ b/src/app/variant-reports/variant-reports.service.ts
@@ -36,7 +36,7 @@ export class VariantReportsService {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const data = { study_id: datasetId, group_name: groupName, counter_id: counterId };
     const url = `${this.config.baseUrl}${this.familiesUrl}`;
-    const response = this.http.post(url, data, options).pipe(map(response => response as Array<string>));
+    const response = this.http.post(url, data, options).pipe(map(res => res as Array<string>));
     return response;
   }
 

--- a/src/app/variant-reports/variant-reports.spec.ts
+++ b/src/app/variant-reports/variant-reports.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { PedigreeData } from 'app/genotype-preview-model/genotype-preview';
 import {
   ChildrenCounter,
@@ -26,7 +27,7 @@ describe('ChildrenCounter', () => {
       'row1'
     );
 
-    expect(childrenCounter).toEqual(
+    expect(childrenCounter).toStrictEqual(
       new ChildrenCounter('row1', 'fakeColumn', 7)
     );
   });
@@ -46,7 +47,7 @@ describe('GroupCounter', () => {
 
     expect(groupCounter.column).toBe('fakeColumn');
 
-    expect(groupCounter.childrenCounters as ChildrenCounter[]).toStrictEqual([
+    expect(groupCounter.childrenCounters).toStrictEqual([
       new ChildrenCounter('row1', 'fakeColumn', 7),
       new ChildrenCounter('row2', 'fakeColumn', 13),
       new ChildrenCounter('row3', 'fakeColumn', 17),

--- a/src/app/variant-reports/variant-reports.ts
+++ b/src/app/variant-reports/variant-reports.ts
@@ -146,7 +146,7 @@ export class DeNovoData {
 }
 
 export class EffectTypeRow {
-  public static fromJson(json: any): EffectTypeRow {
+  public static fromJson(json: object): EffectTypeRow {
     return new EffectTypeRow(
       json['effect_type'] as string,
       json['row'].map((data: DeNovoData) => DeNovoData.fromJson(data)) as DeNovoData[]
@@ -157,7 +157,7 @@ export class EffectTypeRow {
 }
 
 export class EffectTypeTable {
-  public static fromJson(json: any): EffectTypeTable {
+  public static fromJson(json: object): EffectTypeTable {
     return new EffectTypeTable(
       json['rows'].map((row: EffectTypeRow) => EffectTypeRow.fromJson(row)) as EffectTypeRow[],
       json['group_name'] as string,

--- a/src/styles.css
+++ b/src/styles.css
@@ -502,7 +502,6 @@ summary.details {
 }
 
 .modal-content {
-  /* padding-top: 10px; */
   padding-bottom: 10px;
 }
 
@@ -516,6 +515,7 @@ summary.details {
   text-decoration: underline;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 markdown h1,
 markdown h2,
 markdown h3,
@@ -525,11 +525,13 @@ markdown h6 {
   font-size: 1rem;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 markdown a {
   color: #0645ad;
   text-decoration: none;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 markdown a:hover {
   color: #0645ad;
   text-decoration: underline;

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,6 +105,11 @@ label {
   border-top: 1px solid rgba(0, 0, 0, 12.5%);
 }
 
+.panel-bottom {
+  padding: 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, 12.5%);
+}
+
 .btn {
   cursor: pointer;
 }
@@ -497,7 +502,7 @@ summary.details {
 }
 
 .modal-content {
-  padding-top: 10px;
+  /* padding-top: 10px; */
   padding-bottom: 10px;
 }
 


### PR DESCRIPTION
## Background

Add new tab Family Tags to Family filters block in Genotype browser. Family tags contains the tags which can be found in Families by pedigree modal.

## Aim

To add the new tab.

## Implementation

Make new component which holds the tags, chosen mode and clear filters button. The component is used in Families by pedigree modal and Family Tags.
In Genotype browser/Family Tags the selected/deselected tags + mode are added to the state. 
Add/update unit tests.
