### PR TITLE
gene browser: clear gene symbol on search input focus

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -14,7 +14,7 @@
           spellcheck="false"
           [(ngModel)]="geneSymbol"
           (keyup)="openDropdown(); searchBoxInput$.next(geneSymbol)"
-          (click)="reset(); geneSymbol = ''; showError = false"
+          (focus)="reset(); geneSymbol = ''; showError = false"
           (keydown.enter)="submitGeneRequest()"
           (keydown.escape)="closeDropdown()" />
 


### PR DESCRIPTION
In Gene browser the user could change the gene symbol without the results closing if they use the tab key to focus on the input field instead of clicking on it; this branch patches this
