### PR TITLE
update home page ui

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,18 +14,18 @@
           >Home</a
         >
         <a
-          [routerLink]="'/datasets'"
-          routerLinkActive="highlighted-route"
-          title="Datasets"
-          id="datasets">Datasets</a
-        >
-        <a
           *ngIf="geneProfilesConfig"
           [routerLink]="'/gene-profiles'"
           routerLinkActive="highlighted-route"
           title="Gene Profiles"
           id="gene-profiles"
           >Gene Profiles</a
+        >
+        <a
+        [routerLink]="'/datasets'"
+        routerLinkActive="highlighted-route"
+        title="Datasets"
+        id="datasets">Datasets</a
         >
         <a
           [routerLink]="'/about'"

--- a/src/app/datasets/datasets.component.html
+++ b/src/app/datasets/datasets.component.html
@@ -26,16 +26,6 @@
           </div>
         </div>
       </li>
-      <li [class.disabled-tool]="!(selectedDataset.description || ('' | userInfo)?.isAdministrator)" class="nav-item">
-        <a class="nav-link" routerLink="{{ toolPageLinks.datasetDescription }}" routerLinkActive="active"
-          >Dataset Description</a
-        >
-      </li>
-      <li [class.disabled-tool]="!selectedDataset.commonReport.enabled" class="nav-item">
-        <a class="nav-link" routerLink="{{ toolPageLinks.datasetStatistics }}" routerLinkActive="active"
-          >Dataset Statistics</a
-        >
-      </li>
       <li [class.disabled-tool]="!selectedDataset.geneBrowser.enabled" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.geneBrowser }}" routerLinkActive="active">Gene Browser</a>
       </li>
@@ -56,6 +46,16 @@
       </li>
       <li [class.disabled-tool]="!selectedDataset.phenotypeTool" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.phenotypeTool }}" routerLinkActive="active">Phenotype Tool</a>
+      </li>
+      <li [class.disabled-tool]="!(selectedDataset.description || ('' | userInfo)?.isAdministrator)" class="nav-item">
+        <a class="nav-link" routerLink="{{ toolPageLinks.datasetDescription }}" routerLinkActive="active"
+          >Dataset Description</a
+        >
+      </li>
+      <li [class.disabled-tool]="!selectedDataset.commonReport.enabled" class="nav-item">
+        <a class="nav-link" routerLink="{{ toolPageLinks.datasetStatistics }}" routerLinkActive="active"
+          >Dataset Statistics</a
+        >
       </li>
     </ul>
   </nav>

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -87,20 +87,39 @@ a:hover {
 #gene-profiles-section {
   display: flex;
   width: 100%;
-  align-items: center;
+  flex-direction: column;
+  justify-content: flex-start;
+  margin-bottom: 40px;
+  margin-top: 40px;
 }
 
-#gene-profiles-section h4 {
-  display: flex;
-  width: max-content;
-  margin: 0;
+:host ::ng-deep gpf-markdown-editor markdown {
+  width: 955px;
+}
+
+:host ::ng-deep gpf-markdown-editor #edit-wrapper {
+  margin-left: -35px;
+}
+
+gpf-markdown-editor {
+  width: 100%;
 }
 
 :host ::ng-deep #gene-profiles-section markdown {
-  width: 955px;
+  width: 100%;
 }
 
 :host ::ng-deep #gene-profiles-section .container {
   margin-top: 0;
   padding-bottom: 0;
+}
+
+#all-genes-wrapper {
+  display: flex;
+  align-items: baseline;
+  padding-left: 80px;
+}
+
+#all-genes-wrapper a {
+  margin-left: 7px;
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -4,7 +4,14 @@
     [initialMarkdown]="homeDescription"></gpf-markdown-editor>
 
   <div id="gene-profiles-section" *ngIf="geneProfilesConfig">
-    <a [routerLink]="'/gene-profiles'"><h4>Gene profiles</h4></a>
+    <h3>Gene profiles</h3>
+    <div class="separator"></div>
+
+    <div id="all-genes-wrapper">
+      <span class="material-symbols-outlined sm" style="color: #3ea658">lock_open_right</span>
+      <h4><a [routerLink]="'/gene-profiles'">All genes</a></h4>
+    </div>
+
     <gpf-markdown-editor
       *ngIf="geneProfilesConfig.description"
       [initialMarkdown]="geneProfilesConfig.description"

--- a/src/app/markdown-editor/markdown-editor.component.css
+++ b/src/app/markdown-editor/markdown-editor.component.css
@@ -1,5 +1,9 @@
 .container {
   margin-top: 20px;
+  width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0;
 }
 
 #edit-container {
@@ -30,6 +34,25 @@
 #edit-icon {
   padding: 6px;
   cursor: pointer;
+}
+
+:host::ng-deep markdown h1 {
+  font-size: 1.75rem;
+  border-bottom: 2px solid #9c9c9c;
+  padding-bottom: 8px;
+  margin-bottom: 15px;
+}
+
+:host::ng-deep markdown h2 {
+  font-size: 1.3rem;
+  border-bottom: 2px solid #9c9c9c;
+  padding-bottom: 8px;
+  margin-bottom: 15px;
+}
+
+:host ::ng-deep markdown li {
+  list-style-type: none;
+  margin-bottom: 15px;
 }
 
 :host::ng-deep.md-header {

--- a/src/app/markdown-editor/markdown-editor.component.html
+++ b/src/app/markdown-editor/markdown-editor.component.html
@@ -1,11 +1,11 @@
-<div class="container">
+<div class="container" *ngIf="('' | userInfo)?.isAdministrator || initialMarkdown">
   <div id="edit-container" *ngIf="!editMode">
     <div *ngIf="!initialMarkdown" id="empty-description">
       <span>Empty description. Write a description using the pencil button to the right.</span>
     </div>
     <div id="edit-description">
       <markdown id="markdown-id" [data]="initialMarkdown || ''"></markdown>
-      <div *ngIf="!editMode && editable">
+      <div *ngIf="!editMode && editable" id="edit-wrapper">
         <div style="position: relative">
           <span
             *ngIf="('' | userInfo)?.isAdministrator"


### PR DESCRIPTION
## Background

Home page need some ui changes mainly for description and Gene profiles

## Aim

To make the changes.

## Implementation

- reorder tabs (exchange Datasets and Gene profiles)
- reorder Datasets tools (put Dataset Statistics and Description last)
- change description (Introduction) ui in Home page to look similar to Datasets (title + line) 
   - currently css handles the elements -> list items, h1 and h2 from markdown (the description)
   - the changes are affecting Dataset Description and About
- change Gene profiles ui in Home page to look similar to Datasets (title + line) 
   - change Gene profiles link to **All genes** and add green lock in front of it
- remove empty description when the user has no rights to edit it