### PR TITLE
Effect details modal view

### DIFF
--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
@@ -49,9 +49,8 @@
                     [style.visibility]="
                       getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help ? 'visible' : 'hidden'
                     "
-                    [modalContent]="
-                      getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help
-                    "></gpf-helper-modal>
+                    [modalContent]="getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help"
+                    [isMarkdown]="true"></gpf-helper-modal>
                 </div>
               </td>
               <ng-container *ngIf="genomicScoresGeneScores.length === gene.genomicScores.length">

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -11,7 +11,8 @@
         <gpf-helper-modal
           style="height: 32px; margin-left: 4px"
           [style.visibility]="this.geneScoresLocalState.score.help ? 'visible' : 'hidden'"
-          [modalContent]="this.geneScoresLocalState.score.help"></gpf-helper-modal>
+          [modalContent]="this.geneScoresLocalState.score.help"
+          [isMarkdown]="true"></gpf-helper-modal>
       </div>
       <div style="margin-top: 5px">
         <a class="download-link" href="{{ downloadUrl }}">Download</a>

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -16,7 +16,8 @@
     <gpf-helper-modal
       style="height: 32px; margin-left: 4px"
       [style.visibility]="this.genomicScoreState.score.help ? 'visible' : 'hidden'"
-      [modalContent]="this.genomicScoreState.score.help"></gpf-helper-modal>
+      [modalContent]="this.genomicScoreState.score.help"
+      [isMarkdown]="true"></gpf-helper-modal>
   </div>
   <div class="col-sm-11">
     <gpf-histogram

--- a/src/app/genotype-preview-field/genotype-preview-field.component.css
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.css
@@ -1,0 +1,20 @@
+#help-icon {
+  color: #b4b4b4;
+  font-size: x-large;
+}
+
+#help-icon:hover {
+  cursor: pointer;
+}
+
+.keybinds-tooltip {
+  border: 1px solid #ddd;
+  text-align: left;
+  position: absolute;
+  padding: 3px 10px;
+  background-color: #fff;
+  border-radius: 0.25rem;
+  line-height: 190%;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}

--- a/src/app/genotype-preview-field/genotype-preview-field.component.css
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.css
@@ -1,20 +1,21 @@
-#help-icon {
-  color: #b4b4b4;
-  font-size: x-large;
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(4, auto);
+  margin: 15px 15px 5px;
 }
 
-#help-icon:hover {
-  cursor: pointer;
-}
-
-.keybinds-tooltip {
+.grid-header {
+  min-height: 2rem;
+  line-height: 2rem;
   border: 1px solid #ddd;
-  text-align: left;
-  position: absolute;
-  padding: 3px 10px;
-  background-color: #fff;
-  border-radius: 0.25rem;
-  line-height: 190%;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
+  background-color: #eee;
+  text-align: center;
+  font-weight: bold;
+}
+
+.grid-cell {
+  border: 1px solid #ddd;
+  text-align: center;
+  padding: 7px;
+  text-wrap: nowrap;
 }

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -7,14 +7,21 @@
 </span>
 
 <span *ngIf="field === 'effect_details'">
-  <span
-    class="material-symbols-outlined lg"
-    id="help-icon"
-    (mouseover)="showEffectDetails = true"
-    (mouseout)="showEffectDetails = false"
-    >info</span
-  >
-  <div *ngIf="showEffectDetails" class="keybinds-tooltip">{{ value }}</div>
+  <gpf-helper-modal title="Effect details" [modalContent]="effectDetailsModal"></gpf-helper-modal>
+  <ng-template #effectDetailsModal>
+    <div class="grid-container">
+      <div class="grid-header">Gene</div>
+      <div class="grid-header">Transript</div>
+      <div class="grid-header">Effect</div>
+      <div class="grid-header">Details</div>
+      <ng-container *ngFor="let effectDetails of effectDetailsTable">
+        <div class="grid-cell">{{ effectDetails.gene }}</div>
+        <div class="grid-cell">{{ effectDetails.transcript }}</div>
+        <div class="grid-cell">{{ effectDetails.effect }}</div>
+        <div class="grid-cell">{{ effectDetails.details }}</div>
+      </ng-container>
+    </div>
+  </ng-template>
 </span>
 
 <span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'effect_details'">{{ formattedValue }}</span>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -6,4 +6,15 @@
   <a target="_blank" [attr.href]="UCSCLink">{{ formattedValue }}</a>
 </span>
 
-<span *ngIf="field !== 'pedigree' && field !== 'location'">{{ formattedValue }}</span>
+<span *ngIf="field === 'effect_details'">
+  <span
+    class="material-symbols-outlined lg"
+    id="help-icon"
+    (mouseover)="showEffectDetails = true"
+    (mouseout)="showEffectDetails = false"
+    >info</span
+  >
+  <div *ngIf="showEffectDetails" class="keybinds-tooltip">{{ value }}</div>
+</span>
+
+<span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'effect_details'">{{ formattedValue }}</span>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -1,5 +1,12 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { sprintf } from 'sprintf-js';
+
+interface EffectDetail {
+  gene: string;
+  transcript: string;
+  effect: string;
+  details: string;
+}
 
 @Component({
   selector: 'gpf-genotype-preview-field',
@@ -15,7 +22,7 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   public formattedValue: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
-  public showEffectDetails = false;
+  public effectDetailsTable: EffectDetail[];
   public pedigreeMaxHeight = 75;
 
   public ngOnInit(): void {
@@ -31,10 +38,23 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
 
   private formatEffectDetails(): void {
     if (this.value instanceof Array && typeof this.value[0] === 'string') {
-      let formattedDetails = this.value[0];
-      formattedDetails = formattedDetails.replaceAll('|', '\n');
-      formattedDetails = formattedDetails.replaceAll(':', ': ');
-      this.value[0] = formattedDetails;
+      this.effectDetailsTable = this.value[0].split('|').map(detail => {
+        const details = detail.split(':');
+        return {
+          gene: details[1],
+          transcript: details[0],
+          effect: details[2],
+          details: details[3],
+        };
+      }).sort((e1, e2) => {
+        if (e1.gene < e2.gene) {
+          return -1;
+        }
+        if (e1.gene > e2.gene) {
+          return 1;
+        }
+        return 0;
+      });
     }
   }
 

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -3,7 +3,8 @@ import { sprintf } from 'sprintf-js';
 
 @Component({
   selector: 'gpf-genotype-preview-field',
-  templateUrl: './genotype-preview-field.component.html'
+  templateUrl: './genotype-preview-field.component.html',
+  styleUrls: ['./genotype-preview-field.component.css']
 })
 export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   @Input() public value;
@@ -14,14 +15,27 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   public formattedValue: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
+  public showEffectDetails = false;
   public pedigreeMaxHeight = 75;
 
   public ngOnInit(): void {
     this.UCSCLink = this.getUCSCLink();
+    if (this.field === 'effect_details') {
+      this.formatEffectDetails();
+    }
   }
 
   public ngOnChanges(): void {
     this.formattedValue = this.formatValue();
+  }
+
+  private formatEffectDetails(): void {
+    if (this.value instanceof Array && typeof this.value[0] === 'string') {
+      let formattedDetails = this.value[0];
+      formattedDetails = formattedDetails.replaceAll('|', '\n');
+      formattedDetails = formattedDetails.replaceAll(':', ': ');
+      this.value[0] = formattedDetails;
+    }
   }
 
   private doFormat(format, value) {

--- a/src/app/genotype-preview-table/genotype-preview-table.component.html
+++ b/src/app/genotype-preview-table/genotype-preview-table.component.html
@@ -9,7 +9,7 @@
         <gpf-table-header>
           <ng-container *ngFor="let slot of column.columns">
             <gpf-table-subheader
-              *ngIf="slot.source !== 'pedigree'"
+              *ngIf="slot.source !== 'pedigree' && slot.source !== 'effect_details'"
               caption="{{ slot.name }}"
               [comparator]="slot.source | compare">
             </gpf-table-subheader>

--- a/src/app/helper-modal/helper-modal.component.css
+++ b/src/app/helper-modal/helper-modal.component.css
@@ -1,7 +1,13 @@
 #help-icon {
   color: #b4b4b4;
+  font-size: 26px;
 }
 
 #help-icon:hover {
   cursor: pointer;
+  color: steelblue;
+}
+
+::ng-deep .modal-content {
+  width: fit-content;
 }

--- a/src/app/helper-modal/helper-modal.component.html
+++ b/src/app/helper-modal/helper-modal.component.html
@@ -1,1 +1,1 @@
-<span class="material-symbols-outlined lg" id="help-icon" (click)="showHelp()">info</span>
+<span class="material-symbols-outlined" id="help-icon" (click)="showHelp()">info</span>

--- a/src/app/helper-modal/helper-modal.component.ts
+++ b/src/app/helper-modal/helper-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PopupComponent } from 'app/popup/popup.component';
 
@@ -8,18 +8,35 @@ import { PopupComponent } from 'app/popup/popup.component';
   styleUrls: ['./helper-modal.component.css']
 })
 export class HelperModalComponent {
-  @Input() public modalContent: string;
+  @Input() public modalContent: TemplateRef<unknown> | string;
+  @Input() public isMarkdown = false;
 
   public constructor(
     private modalService: NgbModal
   ) {}
 
   public showHelp(): void {
-    const modalRef = this.modalService.open(PopupComponent, {
-      size: 'lg',
-      centered: true
-    });
+    if (this.isMarkdown && typeof this.modalContent === 'string') {
+      const modalRef = this.modalService.open(PopupComponent, {
+        size: 'lg',
+        centered: true
+      });
 
-    (modalRef.componentInstance as PopupComponent).data = this.modalContent;
+      (modalRef.componentInstance as PopupComponent).data = this.modalContent;
+    } else if (!this.isMarkdown && this.modalContent instanceof TemplateRef) {
+      this.modalService.open(
+        this.modalContent,
+        {
+          animation: false,
+          centered: true,
+          modalDialogClass: 'modal-dialog-centered'
+        }
+      );
+    } else {
+      this.modalService.open('Error: invalid modal content!', {
+        size: 'lg',
+        centered: true
+      });
+    }
   }
 }

--- a/src/app/table/view/cell.component.html
+++ b/src/app/table/view/cell.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{ 'fixed-height': !noScrollOptimization }">
+<div [ngClass]="{ 'fixed-height': !noScrollOptimization }" style="overflow-y: hidden">
   <ng-template [ngTemplateOutlet]="cellContent.contentTemplateRef" [ngTemplateOutletContext]="{ $implicit: data }">
   </ng-template>
   <span *ngIf="!cellContent.contentTemplateRef" [attr.title]="data[cellContent.field]">{{


### PR DESCRIPTION
## Background
Effect column in genotype browser shows worst effect and genes that have that effect. Effect details are not shown in this column but appear in downloaded file.

## Aim
Effect details now must be included in the column. The details should appear in a secondary view (modal) in a well formatted structure.

## Implementation
Add effect details to the table through `data/defaultConfiguration.conf` in genotype_browser.column_groups section, effect.columns subsection:
```
effect.columns = [
    "worst_effect",
    "genes",
    "effectdetails"
]
```
Move the new details in the table to a modal view where the details can appear in a formatted table. The table can be accessed through Information button in the Effect column. 
