### PR TITLE
hide gene profiles single view links section if no links

### DIFF
--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
@@ -23,7 +23,7 @@
           style="padding-bottom: 12px; padding-top: 4px">
           <h2 style="padding-left: 0">{{ geneSymbol }}</h2>
         </div>
-        <div class="wrapper" [ngClass]="{ 'compact': compactView }">
+        <div *ngIf="gene.geneLinks" class="wrapper" [ngClass]="{ 'compact': compactView }">
           <table id="links-table">
             <tr>
               <td style="border-right: 1px solid #dee2e6; padding-left: 2px; text-align: center">Links</td>


### PR DESCRIPTION
## Background
If no gene links are provided for single view profile the link section stays empty.

## Aim
Hide the gene links section when empty.

