### PR TITLE
Effect details view

### DIFF
--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
@@ -51,9 +51,8 @@
                     [style.visibility]="
                       getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help ? 'visible' : 'hidden'
                     "
-                    [modalContent]="
-                      getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help
-                    "></gpf-helper-modal>
+                    [modalContent]="getGeneScoreByKey(genomicScoreCategory.category, score.scoreName).help"
+                    [isMarkdown]="true"></gpf-helper-modal>
                   <gpf-histogram
                     *ngIf="
                       genomicScoresGeneScores &&

--- a/src/app/gene-scores/gene-scores.component.html
+++ b/src/app/gene-scores/gene-scores.component.html
@@ -11,7 +11,8 @@
         <gpf-helper-modal
           style="height: 32px; margin-left: 4px"
           [style.visibility]="this.geneScoresLocalState.score.help ? 'visible' : 'hidden'"
-          [modalContent]="this.geneScoresLocalState.score.help"></gpf-helper-modal>
+          [modalContent]="this.geneScoresLocalState.score.help"
+          [isMarkdown]="true"></gpf-helper-modal>
       </div>
       <div style="margin-top: 5px">
         <a class="download-link" href="{{ downloadUrl }}">Download</a>

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -16,7 +16,8 @@
     <gpf-helper-modal
       style="height: 32px; margin-left: 4px"
       [style.visibility]="this.genomicScoreState.score.help ? 'visible' : 'hidden'"
-      [modalContent]="this.genomicScoreState.score.help"></gpf-helper-modal>
+      [modalContent]="this.genomicScoreState.score.help"
+      [isMarkdown]="true"></gpf-helper-modal>
   </div>
   <div class="col-sm-11">
     <gpf-histogram

--- a/src/app/genotype-preview-field/genotype-preview-field.component.css
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.css
@@ -1,0 +1,20 @@
+#help-icon {
+  color: #b4b4b4;
+  font-size: x-large;
+}
+
+#help-icon:hover {
+  cursor: pointer;
+}
+
+.keybinds-tooltip {
+  border: 1px solid #ddd;
+  text-align: left;
+  position: absolute;
+  padding: 3px 10px;
+  background-color: #fff;
+  border-radius: 0.25rem;
+  line-height: 190%;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}

--- a/src/app/genotype-preview-field/genotype-preview-field.component.css
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.css
@@ -1,20 +1,21 @@
-#help-icon {
-  color: #b4b4b4;
-  font-size: x-large;
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(4, auto);
+  margin: 15px 15px 5px;
 }
 
-#help-icon:hover {
-  cursor: pointer;
-}
-
-.keybinds-tooltip {
+.grid-header {
+  min-height: 2rem;
+  line-height: 2rem;
   border: 1px solid #ddd;
-  text-align: left;
-  position: absolute;
-  padding: 3px 10px;
-  background-color: #fff;
-  border-radius: 0.25rem;
-  line-height: 190%;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
+  background-color: #eee;
+  text-align: center;
+  font-weight: bold;
+}
+
+.grid-cell {
+  border: 1px solid #ddd;
+  text-align: center;
+  padding: 7px;
+  text-wrap: nowrap;
 }

--- a/src/app/genotype-preview-field/genotype-preview-field.component.css
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.css
@@ -1,7 +1,14 @@
+.details-header {
+  padding-top: 10px;
+  text-align: center;
+  font-size: large;
+  font-weight: bold;
+}
+
 .grid-container {
   display: grid;
   grid-template-columns: repeat(4, auto);
-  margin: 15px 15px 5px;
+  margin: 25px 25px 15px;
 }
 
 .grid-header {

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -7,18 +7,32 @@
 </span>
 
 <span *ngIf="field === 'full_effect_details'">
-  <gpf-helper-modal title="Full effect details" [modalContent]="effectDetailsModal"></gpf-helper-modal>
+  <gpf-helper-modal
+    title="Full effect details"
+    [modalContent]="effectDetailsModal"
+    [buttonText]="'Show details'"></gpf-helper-modal>
   <ng-template #effectDetailsModal>
-    <span>{{ fullEffectDetails.familyId + ' ' + fullEffectDetails.location }}</span>
-    <div class="grid-container">
+    <span class="details-header">{{ 'Family id: ' + fullEffectDetails.familyId }}</span>
+    <span class="details-header">{{ 'Location: ' + fullEffectDetails.location }}</span>
+    <div class="grid-container" *ngIf="fullEffectDetails.areIncomplete" style="grid-template-columns: repeat(2, auto)">
       <div class="grid-header">Gene</div>
-      <div class="grid-header">Transript</div>
       <div class="grid-header">Effect</div>
+      <ng-container *ngFor="let geneEffect of fullEffectDetails.geneEffects">
+        <div class="grid-cell">{{ geneEffect.gene }}</div>
+        <div class="grid-cell">{{ geneEffect.effect }}</div>
+      </ng-container>
+    </div>
+    <div
+      class="grid-container"
+      [ngStyle]="fullEffectDetails.areIncomplete ? { 'grid-template-columns': 'repeat(2, auto)' } : {}">
+      <div *ngIf="!fullEffectDetails.areIncomplete" class="grid-header">Gene</div>
+      <div class="grid-header">Transript</div>
+      <div *ngIf="!fullEffectDetails.areIncomplete" class="grid-header">Effect</div>
       <div class="grid-header">Details</div>
       <ng-container *ngFor="let effectDetails of fullEffectDetails.effectDetails">
-        <div class="grid-cell">{{ effectDetails.gene }}</div>
+        <div *ngIf="!fullEffectDetails.areIncomplete" class="grid-cell">{{ effectDetails.gene }}</div>
         <div class="grid-cell">{{ effectDetails.transcript }}</div>
-        <div class="grid-cell">{{ effectDetails.effect }}</div>
+        <div *ngIf="!fullEffectDetails.areIncomplete" class="grid-cell">{{ effectDetails.effect }}</div>
         <div class="grid-cell">{{ effectDetails.details }}</div>
       </ng-container>
     </div>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -6,15 +6,16 @@
   <a target="_blank" [attr.href]="UCSCLink">{{ formattedValue }}</a>
 </span>
 
-<span *ngIf="field === 'effect_details'">
-  <gpf-helper-modal title="Effect details" [modalContent]="effectDetailsModal"></gpf-helper-modal>
+<span *ngIf="field === 'full_effect_details'">
+  <gpf-helper-modal title="Full effect details" [modalContent]="effectDetailsModal"></gpf-helper-modal>
   <ng-template #effectDetailsModal>
+    <span>{{ fullEffectDetails.familyId + ' ' + fullEffectDetails.location }}</span>
     <div class="grid-container">
       <div class="grid-header">Gene</div>
       <div class="grid-header">Transript</div>
       <div class="grid-header">Effect</div>
       <div class="grid-header">Details</div>
-      <ng-container *ngFor="let effectDetails of effectDetailsTable">
+      <ng-container *ngFor="let effectDetails of fullEffectDetails.effectDetails">
         <div class="grid-cell">{{ effectDetails.gene }}</div>
         <div class="grid-cell">{{ effectDetails.transcript }}</div>
         <div class="grid-cell">{{ effectDetails.effect }}</div>
@@ -24,4 +25,4 @@
   </ng-template>
 </span>
 
-<span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'effect_details'">{{ formattedValue }}</span>
+<span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'full_effect_details'">{{ formattedValue }}</span>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -7,14 +7,21 @@
 </span>
 
 <span *ngIf="field === 'effect_details'">
-  <span
-    class="material-symbols-outlined lg"
-    id="help-icon"
-    (mouseover)="showEffectDetails = true"
-    (mouseout)="showEffectDetails = false"
-    >info</span
-  >
-  <div *ngIf="showEffectDetails" class="keybinds-tooltip">{{ value }}</div>
+  <gpf-helper-modal title="Effect details" [modalContent]="effectDetailsModal"></gpf-helper-modal>
+  <ng-template #effectDetailsModal>
+    <div class="grid-container">
+      <div class="grid-header">Gene</div>
+      <div class="grid-header">Transript</div>
+      <div class="grid-header">Effect</div>
+      <div class="grid-header">Details</div>
+      <ng-container *ngFor="let effectDetails of effectDetailsTable">
+        <div class="grid-cell">{{ effectDetails.gene }}</div>
+        <div class="grid-cell">{{ effectDetails.transcript }}</div>
+        <div class="grid-cell">{{ effectDetails.effect }}</div>
+        <div class="grid-cell">{{ effectDetails.details }}</div>
+      </ng-container>
+    </div>
+  </ng-template>
 </span>
 
 <span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'effect_details'">{{ formattedValue }}</span>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.html
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.html
@@ -6,4 +6,15 @@
   <a target="_blank" [attr.href]="UCSCLink">{{ formattedValue }}</a>
 </span>
 
-<span *ngIf="field !== 'pedigree' && field !== 'location'">{{ formattedValue }}</span>
+<span *ngIf="field === 'effect_details'">
+  <span
+    class="material-symbols-outlined lg"
+    id="help-icon"
+    (mouseover)="showEffectDetails = true"
+    (mouseout)="showEffectDetails = false"
+    >info</span
+  >
+  <div *ngIf="showEffectDetails" class="keybinds-tooltip">{{ value }}</div>
+</span>
+
+<span *ngIf="field !== 'pedigree' && field !== 'location' && field !== 'effect_details'">{{ formattedValue }}</span>

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -1,5 +1,11 @@
-import { Component, ElementRef, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { sprintf } from 'sprintf-js';
+
+interface FullEffectDetails {
+  familyId: string;
+  location: string;
+  effectDetails: EffectDetail[];
+}
 
 interface EffectDetail {
   gene: string;
@@ -22,12 +28,12 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   public formattedValue: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
-  public effectDetailsTable: EffectDetail[];
+  public fullEffectDetails: FullEffectDetails;
   public pedigreeMaxHeight = 75;
 
   public ngOnInit(): void {
     this.UCSCLink = this.getUCSCLink();
-    if (this.field === 'effect_details') {
+    if (this.field === 'full_effect_details') {
       this.formatEffectDetails();
     }
   }
@@ -37,8 +43,19 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   }
 
   private formatEffectDetails(): void {
-    if (this.value instanceof Array && typeof this.value[0] === 'string') {
-      this.effectDetailsTable = this.value[0].split('|').map(detail => {
+    if (this.value instanceof Array
+      && typeof this.value[0] === 'string'
+      && typeof this.value[1] === 'string'
+      && typeof this.value[2] === 'string'
+    ) {
+      this.fullEffectDetails = {
+        familyId: '',
+        location: '',
+        effectDetails: [],
+      };
+      this.fullEffectDetails.familyId = this.value[0];
+      this.fullEffectDetails.location = this.value[1];
+      this.fullEffectDetails.effectDetails = this.value[2].split('|').map(detail => {
         const details = detail.split(':');
         return {
           gene: details[1],

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -1,25 +1,6 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { sprintf } from 'sprintf-js';
-
-interface FullEffectDetails {
-  familyId: string;
-  location: string;
-  effectDetails: EffectDetail[];
-  geneEffects: GeneEffects[];
-  areIncomplete: boolean;
-}
-
-interface EffectDetail {
-  gene: string;
-  transcript: string;
-  effect: string;
-  details: string;
-}
-
-interface GeneEffects {
-  gene: string;
-  effect: string;
-}
+import { FullEffectDetails } from './genotype-preview-field';
 
 @Component({
   selector: 'gpf-genotype-preview-field',
@@ -50,56 +31,7 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   }
 
   private formatEffectDetails(): void {
-    if (this.value instanceof Array
-      && typeof this.value[0] === 'string'
-      && typeof this.value[1] === 'string'
-      && typeof this.value[2] === 'string'
-      && typeof this.value[3] === 'string'
-    ) {
-      this.fullEffectDetails = {
-        familyId: '',
-        location: '',
-        effectDetails: [],
-        geneEffects: [],
-        areIncomplete: true
-      };
-      this.fullEffectDetails.familyId = this.value[0];
-      this.fullEffectDetails.location = this.value[1];
-      this.fullEffectDetails.effectDetails = this.value[2].split('|').map(detail => {
-        const details = detail.split(':');
-        return {
-          gene: details[1],
-          transcript: details[0],
-          effect: details[2],
-          details: details[3],
-        };
-      }).sort((e1, e2) => {
-        if (e1.gene < e2.gene) {
-          return -1;
-        }
-        if (e1.gene > e2.gene) {
-          return 1;
-        }
-        return 0;
-      });
-
-      // Check if gene and effect columns are both empty
-      for (const ed of this.fullEffectDetails.effectDetails) {
-        // Equal only when both are 'None'
-        if (ed.gene !== ed.effect) {
-          this.fullEffectDetails.areIncomplete = false;
-          break;
-        }
-      }
-
-      this.fullEffectDetails.geneEffects = this.value[3].split('|').map(geneEffect => {
-        const effect = geneEffect.split(':');
-        return {
-          gene: effect[0],
-          effect: effect[1],
-        };
-      });
-    }
+    this.fullEffectDetails = FullEffectDetails.fromGenotypeValue(this.value);
   }
 
   private doFormat(format, value) {

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -13,7 +13,7 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   @Input() public format: string;
   @Input() public genome: string;
 
-  public formattedValue: string;
+  public formattedValue: string | string[];
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
   public fullEffectDetails: FullEffectDetails;
@@ -34,14 +34,14 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
     this.fullEffectDetails = FullEffectDetails.fromGenotypeValue(this.value);
   }
 
-  private doFormat(format, value) {
+  private doFormat(format: string, value: unknown): string {
     if (value === 'nan') {
       return value;
     }
     return sprintf(format, value);
   }
 
-  public formatValue() {
+  public formatValue(): string | string[] {
     if (this.value) {
       if (this.format) {
         if (this.value.constructor === Array) {

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -1,5 +1,12 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { sprintf } from 'sprintf-js';
+
+interface EffectDetail {
+  gene: string;
+  transcript: string;
+  effect: string;
+  details: string;
+}
 
 @Component({
   selector: 'gpf-genotype-preview-field',
@@ -15,7 +22,7 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   public formattedValue: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
-  public showEffectDetails = false;
+  public effectDetailsTable: EffectDetail[];
   public pedigreeMaxHeight = 75;
 
   public ngOnInit(): void {
@@ -31,10 +38,23 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
 
   private formatEffectDetails(): void {
     if (this.value instanceof Array && typeof this.value[0] === 'string') {
-      let formattedDetails = this.value[0];
-      formattedDetails = formattedDetails.replaceAll('|', '\n');
-      formattedDetails = formattedDetails.replaceAll(':', ': ');
-      this.value[0] = formattedDetails;
+      this.effectDetailsTable = this.value[0].split('|').map(detail => {
+        const details = detail.split(':');
+        return {
+          gene: details[1],
+          transcript: details[0],
+          effect: details[2],
+          details: details[3],
+        };
+      }).sort((e1, e2) => {
+        if (e1.gene < e2.gene) {
+          return -1;
+        }
+        if (e1.gene > e2.gene) {
+          return 1;
+        }
+        return 0;
+      });
     }
   }
 

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -5,6 +5,8 @@ interface FullEffectDetails {
   familyId: string;
   location: string;
   effectDetails: EffectDetail[];
+  geneEffects: GeneEffects[];
+  areIncomplete: boolean;
 }
 
 interface EffectDetail {
@@ -12,6 +14,11 @@ interface EffectDetail {
   transcript: string;
   effect: string;
   details: string;
+}
+
+interface GeneEffects {
+  gene: string;
+  effect: string;
 }
 
 @Component({
@@ -47,11 +54,14 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
       && typeof this.value[0] === 'string'
       && typeof this.value[1] === 'string'
       && typeof this.value[2] === 'string'
+      && typeof this.value[3] === 'string'
     ) {
       this.fullEffectDetails = {
         familyId: '',
         location: '',
         effectDetails: [],
+        geneEffects: [],
+        areIncomplete: true
       };
       this.fullEffectDetails.familyId = this.value[0];
       this.fullEffectDetails.location = this.value[1];
@@ -71,6 +81,23 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
           return 1;
         }
         return 0;
+      });
+
+      // Check if gene and effect columns are both empty
+      for (const ed of this.fullEffectDetails.effectDetails) {
+        // Equal only when both are 'None'
+        if (ed.gene !== ed.effect) {
+          this.fullEffectDetails.areIncomplete = false;
+          break;
+        }
+      }
+
+      this.fullEffectDetails.geneEffects = this.value[3].split('|').map(geneEffect => {
+        const effect = geneEffect.split(':');
+        return {
+          gene: effect[0],
+          effect: effect[1],
+        };
       });
     }
   }

--- a/src/app/genotype-preview-field/genotype-preview-field.component.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.component.ts
@@ -3,7 +3,8 @@ import { sprintf } from 'sprintf-js';
 
 @Component({
   selector: 'gpf-genotype-preview-field',
-  templateUrl: './genotype-preview-field.component.html'
+  templateUrl: './genotype-preview-field.component.html',
+  styleUrls: ['./genotype-preview-field.component.css']
 })
 export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   @Input() public value;
@@ -14,14 +15,27 @@ export class GenotypePreviewFieldComponent implements OnInit, OnChanges {
   public formattedValue: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public UCSCLink: string;
+  public showEffectDetails = false;
   public pedigreeMaxHeight = 75;
 
   public ngOnInit(): void {
     this.UCSCLink = this.getUCSCLink();
+    if (this.field === 'effect_details') {
+      this.formatEffectDetails();
+    }
   }
 
   public ngOnChanges(): void {
     this.formattedValue = this.formatValue();
+  }
+
+  private formatEffectDetails(): void {
+    if (this.value instanceof Array && typeof this.value[0] === 'string') {
+      let formattedDetails = this.value[0];
+      formattedDetails = formattedDetails.replaceAll('|', '\n');
+      formattedDetails = formattedDetails.replaceAll(':', ': ');
+      this.value[0] = formattedDetails;
+    }
   }
 
   private doFormat(format, value) {

--- a/src/app/genotype-preview-field/genotype-preview-field.ts
+++ b/src/app/genotype-preview-field/genotype-preview-field.ts
@@ -1,0 +1,79 @@
+export class FullEffectDetails {
+  public constructor(
+    public familyId: string,
+    public location: string,
+    public effectDetails: EffectDetail[],
+    public geneEffects: GeneEffects[],
+    public areIncomplete: boolean) { }
+
+  public static fromGenotypeValue(value: unknown): FullEffectDetails {
+    if (value instanceof Array
+        && typeof value[0] === 'string'
+        && typeof value[1] === 'string'
+        && typeof value[2] === 'string'
+        && typeof value[3] === 'string'
+    ) {
+      const fullEffectDetails = new FullEffectDetails('', '', [], [], true);
+      fullEffectDetails.familyId = value[0];
+      fullEffectDetails.location = value[1];
+      fullEffectDetails.effectDetails = EffectDetail.fromDetailValue(value[2]);
+
+      // Check if gene and effect columns are both empty
+      for (const ed of fullEffectDetails.effectDetails) {
+        // Equal only when both are 'None'
+        if (ed.gene !== ed.effect) {
+          fullEffectDetails.areIncomplete = false;
+          break;
+        }
+      }
+
+      fullEffectDetails.geneEffects = GeneEffects.fromEffectValue(value[3]);
+
+      return fullEffectDetails;
+    }
+  }
+}
+
+export class EffectDetail {
+  public constructor(
+    public gene: string,
+    public transcript: string,
+    public effect: string,
+    public details: string) { }
+
+  public static fromDetailValue(value: string): EffectDetail[] {
+    return value.split('|').map(detail => {
+      const details = detail.split(':');
+      return {
+        gene: details[1],
+        transcript: details[0],
+        effect: details[2],
+        details: details[3],
+      };
+    }).sort((e1, e2) => {
+      if (e1.gene < e2.gene) {
+        return -1;
+      }
+      if (e1.gene > e2.gene) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+}
+
+export class GeneEffects {
+  public constructor(
+    public gene: string,
+    public effect: string) { }
+
+  public static fromEffectValue(value: string): GeneEffects[] {
+    return value.split('|').map(geneEffect => {
+      const effect = geneEffect.split(':');
+      return {
+        gene: effect[0],
+        effect: effect[1],
+      };
+    });
+  }
+}

--- a/src/app/genotype-preview-table/genotype-preview-table.component.html
+++ b/src/app/genotype-preview-table/genotype-preview-table.component.html
@@ -9,7 +9,7 @@
         <gpf-table-header>
           <ng-container *ngFor="let slot of column.columns">
             <gpf-table-subheader
-              *ngIf="slot.source !== 'pedigree' && slot.source !== 'effect_details'"
+              *ngIf="slot.source !== 'pedigree' && slot.source !== 'full_effect_details'"
               caption="{{ slot.name }}"
               [comparator]="slot.source | compare">
             </gpf-table-subheader>

--- a/src/app/genotype-preview-table/genotype-preview-table.component.html
+++ b/src/app/genotype-preview-table/genotype-preview-table.component.html
@@ -9,7 +9,7 @@
         <gpf-table-header>
           <ng-container *ngFor="let slot of column.columns">
             <gpf-table-subheader
-              *ngIf="slot.source !== 'pedigree'"
+              *ngIf="slot.source !== 'pedigree' && slot.source !== 'effect_details'"
               caption="{{ slot.name }}"
               [comparator]="slot.source | compare">
             </gpf-table-subheader>

--- a/src/app/helper-modal/helper-modal.component.css
+++ b/src/app/helper-modal/helper-modal.component.css
@@ -11,3 +11,16 @@
 ::ng-deep .modal-content {
   width: fit-content;
 }
+
+#help-button {
+  border: none;
+  background: none;
+  font-weight: 500;
+  color: steelblue;
+}
+
+#help-button:hover {
+  border: none;
+  background-color: transparent;
+  color: #b4b4b4;
+}

--- a/src/app/helper-modal/helper-modal.component.css
+++ b/src/app/helper-modal/helper-modal.component.css
@@ -1,7 +1,13 @@
 #help-icon {
   color: #b4b4b4;
+  font-size: 26px;
 }
 
 #help-icon:hover {
   cursor: pointer;
+  color: steelblue;
+}
+
+::ng-deep .modal-content {
+  width: fit-content;
 }

--- a/src/app/helper-modal/helper-modal.component.html
+++ b/src/app/helper-modal/helper-modal.component.html
@@ -1,1 +1,1 @@
-<span class="material-symbols-outlined lg" id="help-icon" (click)="showHelp()">info</span>
+<span class="material-symbols-outlined" id="help-icon" (click)="showHelp()">info</span>

--- a/src/app/helper-modal/helper-modal.component.html
+++ b/src/app/helper-modal/helper-modal.component.html
@@ -1,1 +1,3 @@
-<span class="material-symbols-outlined" id="help-icon" (click)="showHelp()">info</span>
+<span *ngIf="!buttonText" class="material-symbols-outlined" id="help-icon" (click)="showHelp()">info</span>
+
+<button *ngIf="buttonText" id="help-button" (click)="showHelp()">{{ buttonText }}</button>

--- a/src/app/helper-modal/helper-modal.component.spec.ts
+++ b/src/app/helper-modal/helper-modal.component.spec.ts
@@ -26,15 +26,31 @@ describe('HelperModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show help', () => {
-    component.modalContent = 'modalContentTest';
+  it('should show help content made from markdown', () => {
+    component.modalContent = '<markdown><markdown/>';
+    component.isMarkdown = true;
+    fixture.detectChanges();
     jest.spyOn(modalService, 'open').mockReturnValue(modalRef);
     component.showHelp();
     expect(modalService.open).toHaveBeenCalledWith(PopupComponent, {
       size: 'lg',
       centered: true
     });
-    expect((modalRef.componentInstance as PopupComponent).data).toBe('modalContentTest');
+    expect((modalRef.componentInstance as PopupComponent).data).toBe('<markdown><markdown/>');
+
+    modalRef.close();
+  });
+
+  it('should not show invalid help content', () => {
+    component.modalContent = '<div><div/>';
+    component.isMarkdown = false;
+    fixture.detectChanges();
+    jest.spyOn(modalService, 'open').mockReturnValue(modalRef);
+    component.showHelp();
+    expect(modalService.open).toHaveBeenCalledWith('Error: invalid modal content!', {
+      size: 'lg',
+      centered: true
+    });
 
     modalRef.close();
   });

--- a/src/app/helper-modal/helper-modal.component.ts
+++ b/src/app/helper-modal/helper-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PopupComponent } from 'app/popup/popup.component';
 
@@ -8,18 +8,35 @@ import { PopupComponent } from 'app/popup/popup.component';
   styleUrls: ['./helper-modal.component.css']
 })
 export class HelperModalComponent {
-  @Input() public modalContent: string;
+  @Input() public modalContent: TemplateRef<unknown> | string;
+  @Input() public isMarkdown = false;
 
   public constructor(
     private modalService: NgbModal
   ) {}
 
   public showHelp(): void {
-    const modalRef = this.modalService.open(PopupComponent, {
-      size: 'lg',
-      centered: true
-    });
+    if (this.isMarkdown && typeof this.modalContent === 'string') {
+      const modalRef = this.modalService.open(PopupComponent, {
+        size: 'lg',
+        centered: true
+      });
 
-    (modalRef.componentInstance as PopupComponent).data = this.modalContent;
+      (modalRef.componentInstance as PopupComponent).data = this.modalContent;
+    } else if (!this.isMarkdown && this.modalContent instanceof TemplateRef) {
+      this.modalService.open(
+        this.modalContent,
+        {
+          animation: false,
+          centered: true,
+          modalDialogClass: 'modal-dialog-centered'
+        }
+      );
+    } else {
+      this.modalService.open('Error: invalid modal content!', {
+        size: 'lg',
+        centered: true
+      });
+    }
   }
 }

--- a/src/app/helper-modal/helper-modal.component.ts
+++ b/src/app/helper-modal/helper-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, TemplateRef } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PopupComponent } from 'app/popup/popup.component';
 
@@ -32,7 +32,7 @@ export class HelperModalComponent {
           centered: true,
           modalDialogClass: 'modal-dialog-centered'
         }
-      ); 
+      );
     } else {
       this.modalService.open('Error: invalid modal content!', {
         size: 'lg',

--- a/src/app/helper-modal/helper-modal.component.ts
+++ b/src/app/helper-modal/helper-modal.component.ts
@@ -10,6 +10,7 @@ import { PopupComponent } from 'app/popup/popup.component';
 export class HelperModalComponent {
   @Input() public modalContent: TemplateRef<unknown> | string;
   @Input() public isMarkdown = false;
+  @Input() public buttonText = '';
 
   public constructor(
     private modalService: NgbModal
@@ -31,7 +32,7 @@ export class HelperModalComponent {
           centered: true,
           modalDialogClass: 'modal-dialog-centered'
         }
-      );
+      ); 
     } else {
       this.modalService.open('Error: invalid modal content!', {
         size: 'lg',

--- a/src/app/table/view/cell.component.html
+++ b/src/app/table/view/cell.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{ 'fixed-height': !noScrollOptimization }">
+<div [ngClass]="{ 'fixed-height': !noScrollOptimization }" style="overflow-y: hidden">
   <ng-template [ngTemplateOutlet]="cellContent.contentTemplateRef" [ngTemplateOutletContext]="{ $implicit: data }">
   </ng-template>
   <span *ngIf="!cellContent.contentTemplateRef" [attr.title]="data[cellContent.field]">{{


### PR DESCRIPTION
## Background
Effect column in genotype browser shows worst effect and genes that have that effect. Effect details are not shown in this column but appear in downloaded file.

## Aim
Effect details now must be included in the column. The details should appear in a secondary view (modal) in a well formatted structure.

## Implementation
Add effect details to the table through `data/defaultConfiguration.conf` in genotype_browser.column_groups section, effect.columns subsection:
```
effect.columns = [
    "worst_effect",
    "genes",
    "effectdetails"
]
```
Move the new details in the table to a modal view where the details can appear in a formatted table. The table can be accessed through Information button in the Effect column. 
