### PR TITLE
make gene browser filtered family counter to wait for table counter t…

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -187,10 +187,7 @@
             <span class="d-none d-xl-inline">Family variants:</span>
             <span class="d-none d-md-inline d-xl-none d-xxl-none">FV:</span>
             <span id="family-variants-count">
-              <span
-                >{{ this.summaryVariantsArrayFiltered?.totalFamilyVariantsCount }} /
-                {{ this.summaryVariantsArray.totalFamilyVariantsCount }}</span
-              >
+              <span>{{ displayVariantsCount() }} / {{ this.summaryVariantsArray.totalFamilyVariantsCount }}</span>
             </span>
           </span>
           <div *ngIf="selectedGene">

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -15,7 +15,7 @@ import { GeneBrowserComponent } from './gene-browser.component';
 import { SearchableSelectComponent } from '../searchable-select/searchable-select.component';
 import { FormsModule } from '@angular/forms';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { SummaryAllelesArray, SummaryAllelesFilter } from './summary-variants';
+import { SummaryAllele, SummaryAllelesArray, SummaryAllelesFilter } from './summary-variants';
 import { GenePlotComponent } from 'app/gene-plot/gene-plot.component';
 import { GenotypePreviewTableComponent } from 'app/genotype-preview-table/genotype-preview-table.component';
 import { APP_BASE_HREF } from '@angular/common';
@@ -240,6 +240,54 @@ describe('GeneBrowserComponent', () => {
       affectedStatus: ['Affected only', 'Unaffected only', 'Affected and unaffected'],
       variantTypes: ['sub', 'ins', 'del', 'CNV+', 'CNV-', 'comp']
     });
+  });
+
+  it('should get family variants count when count is less than 1000', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(5);
+    expect(component.displayVariantsCount()).toBe('~5');
+  });
+
+  it('should get family variants count when count is more than 1000', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(9635);
+    expect(component.displayVariantsCount()).toBe('9635');
+  });
+
+  it('should get family variants count when count is 0', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(0);
+    expect(component.displayVariantsCount()).toBe('0');
+  });
+
+  it('should get family variants count after loading variants is finished', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(35);
+    expect(component.displayVariantsCount()).toBe('~35');
+
+    component.familyVariantsLoaded = true;
+    component.variantsCount = 20;
+    expect(component.displayVariantsCount()).toBe('20');
+  });
+
+  it('should get family variants count when loaded count is 0', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(7412);
+    expect(component.displayVariantsCount()).toBe('7412');
+
+    component.familyVariantsLoaded = true;
+    component.variantsCount = 0;
+    expect(component.displayVariantsCount()).toBe('0');
+  });
+
+  it('should get family variants count when loaded count is more than 1000', () => {
+    component.familyVariantsLoaded = false;
+    jest.spyOn(SummaryAllelesArray.prototype, 'totalFamilyVariantsCount', 'get').mockReturnValue(7412);
+    expect(component.displayVariantsCount()).toBe('7412');
+
+    component.familyVariantsLoaded = true;
+    component.variantsCount = -1;
+    expect(component.displayVariantsCount()).toBe('7412');
   });
 
   it.skip('should test download', () => {

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -15,7 +15,7 @@ import { GeneBrowserComponent } from './gene-browser.component';
 import { SearchableSelectComponent } from '../searchable-select/searchable-select.component';
 import { FormsModule } from '@angular/forms';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { SummaryAllele, SummaryAllelesArray, SummaryAllelesFilter } from './summary-variants';
+import { SummaryAllelesArray, SummaryAllelesFilter } from './summary-variants';
 import { GenePlotComponent } from 'app/gene-plot/gene-plot.component';
 import { GenotypePreviewTableComponent } from 'app/genotype-preview-table/genotype-preview-table.component';
 import { APP_BASE_HREF } from '@angular/common';
@@ -115,7 +115,7 @@ describe('GeneBrowserComponent', () => {
     component = fixture.componentInstance;
     loadingService = TestBed.inject(FullscreenLoadingService);
     component.summaryVariantsArray = new SummaryAllelesArray();
-    jest.spyOn<any, any>(component['queryService'], 'getSummaryVariants');
+    jest.spyOn(component['queryService'], 'getSummaryVariants');
     fixture.detectChanges();
   });
 
@@ -130,9 +130,9 @@ describe('GeneBrowserComponent', () => {
     jest.spyOn<any, any>(component, 'drawTransmittedIcons').mockImplementation(() => null);
     jest.spyOn<any, any>(component, 'drawEffectTypesIcons').mockImplementation(() => null);
     component.filters = null;
-    expect(component['drawDenovoIcons']).toHaveBeenCalled();
-    expect(component['drawTransmittedIcons']).toHaveBeenCalled();
-    expect(component['drawEffectTypesIcons']).toHaveBeenCalled();
+    expect(component['drawDenovoIcons']).toHaveBeenCalledWith();
+    expect(component['drawTransmittedIcons']).toHaveBeenCalledWith();
+    expect(component['drawEffectTypesIcons']).toHaveBeenCalledWith();
   });
 
   it('should select affected status', () => {
@@ -175,14 +175,14 @@ describe('GeneBrowserComponent', () => {
   });
 
   it('should set selected region', () => {
-    jest.spyOn<any, any>(component, 'updateVariants');
+    jest.spyOn(component, 'updateVariants');
     component.setSelectedRegion([1, 2]);
     expect(component.summaryVariantsFilter.selectedRegion).toStrictEqual([1, 2]);
     expect(component['updateVariants']).toHaveBeenCalledWith();
   });
 
   it('should set selected frequencies', () => {
-    jest.spyOn<any, any>(component, 'updateVariants');
+    jest.spyOn(component, 'updateVariants');
     component.setSelectedFrequencies([3, 4]);
     expect(component.summaryVariantsFilter.selectedFrequencies).toStrictEqual([3, 4]);
     expect(component['updateVariants']).toHaveBeenCalledWith();
@@ -300,7 +300,7 @@ describe('GeneBrowserComponent', () => {
       }
     };
 
-    component.onSubmit(mockEvent as any);
+    component.onSubmit(mockEvent as unknown as Event);
 
     expect(mockEvent.target.queryData.value).toStrictEqual(JSON.stringify({
       effectTypes: [

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -75,6 +75,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   public variantsCountDisplay: string;
+  public variantsCount: number;
 
   public async ngOnInit(): Promise<void> {
     this.selectedDataset = this.datasetsService.getSelectedDataset();
@@ -98,6 +99,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       }),
       this.queryService.streamingFinishedSubject.subscribe(() => {
         this.familyVariantsLoaded = true;
+        this.displayVariantsCount();
       }),
       this.route.parent.params.subscribe((params: Params) => {
         this.selectedDatasetId = params['dataset'] as string;
@@ -243,6 +245,14 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     this.variantUpdate$.next();
   }
 
+  public displayVariantsCount(): string {
+    if (this.familyVariantsLoaded && this.variantsCount !== -1) {
+      return this.variantsCount.toString();
+    }
+    const count = this.summaryVariantsArrayFiltered?.totalFamilyVariantsCount;
+    return count < 1000 && count !== 0 ? '~' + count.toString() : count.toString();
+  }
+
   public checkAffectedStatus(affectedStatus: string, value: boolean): void {
     if (value) {
       this.summaryVariantsFilter.selectedAffectedStatus.add(affectedStatus);
@@ -341,7 +351,9 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     };
     this.genotypePreviewVariantsArray = this.queryService.getGenotypePreviewVariantsByFilter(
       this.selectedDataset, params, this.maxFamilyVariants + 1, () => {
-        this.variantsCountDisplay = this.genotypePreviewVariantsArray?.getVariantsCount(this.maxFamilyVariants);
+        this.variantsCountDisplay =
+          this.genotypePreviewVariantsArray?.getVariantsCountFormatted(this.maxFamilyVariants);
+        this.variantsCount = this.genotypePreviewVariantsArray?.getVariantsCount(this.maxFamilyVariants);
       }
     );
   }

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -393,7 +393,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       '#Other': draw.dot
       // eslint-enable
     };
-    let svgElement;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let svgElement: d3.Selection<HTMLElement, undefined, HTMLElement, any>;
     for (const [effect, drawFunc] of Object.entries(effectIcons)) {
       svgElement = d3.select(effect);
       drawFunc(svgElement, 10, 8, '#000000', effect);

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -150,7 +150,7 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
         ? this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount + 1
         : undefined,
       () => {
-        this.variantsCountDisplay = this.genotypePreviewVariantsArray?.getVariantsCount(
+        this.variantsCountDisplay = this.genotypePreviewVariantsArray?.getVariantsCountFormatted(
           this.selectedDataset?.genotypeBrowserConfig?.maxVariantsCount
         );
       }

--- a/src/app/genotype-preview-model/genotype-preview.ts
+++ b/src/app/genotype-preview-model/genotype-preview.ts
@@ -80,7 +80,7 @@ export class GenotypePreviewVariantsArray {
     }
   }
 
-  public getVariantsCount(maxVariantsCount: number): string {
+  public getVariantsCountFormatted(maxVariantsCount: number): string {
     let variantsCount: string;
 
     if (this.genotypePreviews.length > maxVariantsCount) {
@@ -92,6 +92,15 @@ export class GenotypePreviewVariantsArray {
     }
 
     return variantsCount;
+  }
+
+  public getVariantsCount(maxVariantsCount: number): number {
+    let count =-1;
+
+    if (this.genotypePreviews.length <= maxVariantsCount) {
+      count = this.genotypePreviews.length;
+    }
+    return count;
   }
 
   public setGenotypePreviews(genotypePreviews: GenotypePreview[]): void {


### PR DESCRIPTION
…o load

## Background

Depending on the study/group it might happen the count of loaded variants in the table to differ from the count of filtered families which causes misunderstanding.

## Aim

To add `~` sign in front of the filtered families counter (when the counter is less than 1000) until the loading of variants for the table is finished. After that the filtered families counter is replaced with the loaded counter.

## Implementation

Add `~` sign, replace filtered families counter when loading is finished and after some checks and add unit tests.
