### PR TITLE
Save tabs to state

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -186,6 +186,7 @@ import { AboutComponent } from './about/about.component';
 import { MarkdownEditorComponent } from './markdown-editor/markdown-editor.component';
 import { FamilyTagsComponent } from './family-tags/family-tags.component';
 import { FamilyTagsState } from './family-tags/family-tags.state';
+import { GeneProfilesState } from './gene-profiles-table/gene-profiles-table.state';
 
 const appRoutes: Routes = [
   {
@@ -431,7 +432,7 @@ const appRoutes: Routes = [
       GeneSymbolsState, FamilyIdsState, FamilyTagsState, RegionsFilterState, StudyTypesState, GeneSetsState,
       GeneScoresState, EnrichmentModelsState, PedigreeSelectorState, FamilyTypeFilterState,
       StudyFiltersState, PersonFiltersState, GenomicScoresBlockState, PhenoToolMeasureState,
-      UniqueFamilyVariantsFilterState, ErrorsState
+      UniqueFamilyVariantsFilterState, ErrorsState, GeneProfilesState
     ], {compatibility: { strictContentSecurityPolicy: true }}
     ),
     NgxsResetPluginModule.forRoot(),

--- a/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
@@ -17,6 +17,7 @@ import { Observable, of } from 'rxjs';
 import { GeneProfilesSingleViewConfig } from 'app/gene-profiles-single-view/gene-profiles-single-view';
 import { TruncatePipe } from '../utils/truncate.pipe';
 import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-table/gene-profiles-table';
+import { GeneProfilesState } from 'app/gene-profiles-table/gene-profiles-table.state';
 
 const config = {
   geneLinkTemplates: [
@@ -136,7 +137,7 @@ describe('GeneProfilesBlockComponent', () => {
       ],
       imports: [
         HttpClientTestingModule, NgbNavModule, RouterTestingModule, FormsModule,
-        NgxsModule.forRoot([], {developmentMode: true})
+        NgxsModule.forRoot([GeneProfilesState], {developmentMode: true})
       ]
     }).compileComponents();
 

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -12,7 +12,7 @@ import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-t
 import {
   GeneProfileSingleViewComponent
 } from 'app/gene-profiles-single-view/gene-profiles-single-view.component';
-import { SetGeneProfiles } from 'app/gene-profiles-table/gene-profiles-table.state';
+import { GeneProfilesModel, SetGeneProfiles } from 'app/gene-profiles-table/gene-profiles-table.state';
 import { of } from 'rxjs';
 
 @Component({
@@ -31,7 +31,7 @@ export class GeneProfilesBlockComponent implements OnInit {
   ) { }
 
   public ngOnInit(): void {
-    this.store.selectOnce(state => state.geneProfilesState).pipe(
+    this.store.selectOnce((state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState).pipe(
       switchMap((state: SetGeneProfiles) => {
         if (state.config) {
           return of(state.config);

--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -121,7 +121,8 @@
               autofocus="false"
               placeholder="Search gene"
               type="text"
-              spellcheck="false" />
+              spellcheck="false"
+              [value]="geneInput" />
             <span
               *ngIf="searchBox.value !== '' && !showSearchLoading"
               class="material-symbols-outlined search-clear-icon"

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -6,6 +6,8 @@ import { cloneDeep } from 'lodash';
 import { GeneProfilesTableService } from './gene-profiles-table.service';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { NgxsModule } from '@ngxs/store';
+import { GeneProfilesState } from './gene-profiles-table.state';
 
 const column1 = {
   clickable: 'createTab',
@@ -257,6 +259,7 @@ describe('GeneProfilesTableComponent', () => {
         {provide: ActivatedRoute, useValue: mockActivatedRoute},
         {provide: GeneProfilesTableService, useValue: geneProfilesTableServiceMock}
       ],
+      imports: [NgxsModule.forRoot([GeneProfilesState], {developmentMode: true})]
     }).compileComponents();
 
     const fixture = TestBed.createComponent(GeneProfilesTableComponent);
@@ -375,9 +378,12 @@ describe('GeneProfilesTableComponent', () => {
     expect(component.currentTabString).toBe('');
 
     component.loadSingleView('POGZ');
-    expect(component.tabs).toStrictEqual(['POGZ']);
+    expect(component.tabs).toStrictEqual(new Set(['POGZ']));
 
     expect(openTabSpy).toHaveBeenCalledWith('POGZ');
+
+    component.closeTab('POGZ');
+    expect(component.tabs).toStrictEqual(new Set([]));
   });
 
   it('should load single view tab when comparing', () => {
@@ -389,7 +395,7 @@ describe('GeneProfilesTableComponent', () => {
     mockActivatedRoute.snapshot = {params: {genes: 'SPAST,DYRK1A,FOXP1'}};
 
     component.loadSingleView(new Set(['SPAST', 'DYRK1A', 'FOXP1']));
-    expect(component.tabs).toStrictEqual(['DYRK1A,FOXP1,SPAST']);
+    expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST']));
 
     expect(openTabSpy).toHaveBeenCalledWith('DYRK1A,FOXP1,SPAST');
   });
@@ -400,11 +406,11 @@ describe('GeneProfilesTableComponent', () => {
     mockActivatedRoute.snapshot = {params: {genes: 'SPAST,FOXP1,DYRK1A'}};
 
     component.loadSingleView(new Set(['SPAST', 'FOXP1', 'DYRK1A']));
-    expect(component.tabs).toStrictEqual(['DYRK1A,FOXP1,SPAST']);
+    expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST']));
     expect(openTabSpy).toHaveBeenCalledWith('DYRK1A,FOXP1,SPAST');
 
     component.loadSingleView(new Set(['SPAST', 'DYRK1A', 'FOXP1']));
-    expect(component.tabs).toStrictEqual(['DYRK1A,FOXP1,SPAST']);
+    expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST']));
     expect(openTabSpy).toHaveBeenCalledWith('DYRK1A,FOXP1,SPAST');
   });
 
@@ -427,9 +433,9 @@ describe('GeneProfilesTableComponent', () => {
   it('should close tab', () => {
     const backToTableSpy = jest.spyOn(component, 'backToTable');
 
-    component.tabs = ['DYRK1A,FOXP1,SPAST', 'POGZ'];
+    component.tabs = new Set(['DYRK1A,FOXP1,SPAST', 'POGZ']);
     component.closeTab('POGZ');
-    expect(component.tabs).toStrictEqual(['DYRK1A,FOXP1,SPAST']);
+    expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST']));
     expect(backToTableSpy).toHaveBeenCalledWith();
   });
 
@@ -447,12 +453,12 @@ describe('GeneProfilesTableComponent', () => {
     const openTabSpy = jest.spyOn(component, 'openTab');
     const windowSpy = jest.spyOn(window, 'open');
 
-    component.loadSingleView('POGZ', true);
-    expect(component.tabs).not.toContain('POGZ');
+    component.loadSingleView('PKD1', true);
+    expect(component.tabs).not.toContain('PKD1');
 
     expect(openTabSpy).not.toHaveBeenCalledWith();
 
-    expect(component.currentTabGeneSet).toStrictEqual(new Set(['POGZ']));
-    expect(windowSpy).toHaveBeenCalledWith(`${window.location.href}/POGZ`, '_blank');
+    expect(component.currentTabGeneSet).toStrictEqual(new Set(['PKD1']));
+    expect(windowSpy).toHaveBeenCalledWith(`${window.location.href}/PKD1`, '_blank');
   });
 });

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -166,7 +166,10 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     this.loadMoreGenes = true;
     this.showNothingFound = false;
     // In case of page zoom out where scroll will disappear, load more pages.
-    const initialPageCount = 4 * this.viewportPageCount;
+    let initialPageCount = 0;
+    if (this.viewportPageCount) {
+      initialPageCount = 4 * this.viewportPageCount;
+    }
 
     for (let i = 1; i <= initialPageCount; i++) {
       geneProfilesRequests.push(

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -1,21 +1,37 @@
 import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
+import { GeneProfilesTableConfig } from './gene-profiles-table';
 
 export class SetGeneProfiles {
   public static readonly type = '[Genotype] Set gene profiles';
   public constructor(
-    public openedTabs: Set<string>
+    public openedTabs: Set<string>,
+    public searchValue: string,
+    public highlightedRows: Set<string>,
+    public sortBy: string,
+    public orderBy: string,
+    public config: GeneProfilesTableConfig
   ) {}
 }
 
 export interface GeneProfilesModel {
-  openedTabs: Set<string>;
+    openedTabs: Set<string>;
+    searchValue: string;
+    highlightedRows: Set<string>;
+    sortBy: string;
+    orderBy: string;
+    config: GeneProfilesTableConfig;
 }
 
 @State<GeneProfilesModel>({
   name: 'geneProfilesState',
   defaults: {
-    openedTabs: new Set<string>()
+    openedTabs: new Set<string>(),
+    searchValue: '',
+    highlightedRows: new Set<string>(),
+    sortBy: '',
+    orderBy: '',
+    config: null
   },
 })
 @Injectable()
@@ -24,6 +40,11 @@ export class GeneProfilesState {
   public setGeneProfiles(ctx: StateContext<GeneProfilesModel>, action: SetGeneProfiles): void {
     ctx.patchState({
       openedTabs: action.openedTabs,
+      searchValue: action.searchValue,
+      highlightedRows: action.highlightedRows,
+      sortBy: action.sortBy,
+      orderBy: action.orderBy,
+      config: action.config
     });
   }
 }

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { State, Action, StateContext } from '@ngxs/store';
+
+export class SetGeneProfiles {
+  public static readonly type = '[Genotype] Set gene profiles';
+  public constructor(
+    public openedTabs: Set<string>
+  ) {}
+}
+
+export interface GeneProfilesModel {
+  openedTabs: Set<string>;
+}
+
+@State<GeneProfilesModel>({
+  name: 'geneProfilesState',
+  defaults: {
+    openedTabs: new Set<string>()
+  },
+})
+@Injectable()
+export class GeneProfilesState {
+  @Action(SetGeneProfiles)
+  public setGeneProfiles(ctx: StateContext<GeneProfilesModel>, action: SetGeneProfiles): void {
+    ctx.patchState({
+      openedTabs: action.openedTabs,
+    });
+  }
+}

--- a/src/app/multiple-select-menu/multiple-select-menu.component.ts
+++ b/src/app/multiple-select-menu/multiple-select-menu.component.ts
@@ -32,7 +32,7 @@ export class MultipleSelectMenuComponent implements OnChanges {
 
     // focus search input field
     this.waitForSearchInputToLoad().then(() => {
-      this.searchInput.nativeElement.focus();
+      (this.searchInput.nativeElement as HTMLInputElement).focus();
     });
   }
 


### PR DESCRIPTION
## Background

When navigating from Gene Profiles to other tool for example Datasets, the opened tabs and table's state don't save.

## Aim

Need to save opened tabs and table's state (highlighted rows, search result, columns reordering and their visibility as well as by which column is sorted and in what order).

## Implementation

Add the tabs and the table's state to the state. 
