### PR TITLE
Fix navigating to invalid url

### DIFF
--- a/src/app/datasets/datasets.component.html
+++ b/src/app/datasets/datasets.component.html
@@ -77,3 +77,11 @@
     (activate)="routeChange()"
     class="content"></router-outlet>
 </div>
+
+<div
+  *ngIf="selectedDataset === undefined"
+  class="alert alert-danger"
+  role="alert"
+  style="display: inline-block; margin: 14px; margin-top: 0px; width: 400px">
+  <span>No such dataset found!</span>
+</div>

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -22,7 +22,6 @@ export class DatasetsComponent implements OnInit, OnDestroy {
   public permissionDeniedPrompt: string;
   public toolPageLinks = toolPageLinks;
   public visibleDatasets: string[];
-
   private subscriptions: Subscription[] = [];
 
   public selectedTool: string;
@@ -87,7 +86,6 @@ export class DatasetsComponent implements OnInit, OnDestroy {
 
   private setupSelectedDataset(): void {
     this.selectedDataset = this.datasetsService.getSelectedDataset();
-
     if (!this.selectedDataset) {
       return;
     }

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -12,7 +12,7 @@ import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-t
 import {
   GeneProfileSingleViewComponent
 } from 'app/gene-profiles-single-view/gene-profiles-single-view.component';
-import { GeneProfilesModel, SetGeneProfiles } from 'app/gene-profiles-table/gene-profiles-table.state';
+import { GeneProfilesModel, SetGeneProfilesConfig } from 'app/gene-profiles-table/gene-profiles-table.state';
 import { of } from 'rxjs';
 
 @Component({
@@ -32,7 +32,7 @@ export class GeneProfilesBlockComponent implements OnInit {
 
   public ngOnInit(): void {
     this.store.selectOnce((state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState).pipe(
-      switchMap((state: SetGeneProfiles) => {
+      switchMap((state: SetGeneProfilesConfig) => {
         if (state.config) {
           return of(state.config);
         } else {

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.html
@@ -122,8 +122,7 @@
                 <tr class="card-block">
                   <th style="border-bottom: none">Variant Statistics</th>
                   <th *ngFor="let personSet of dataset.personSets" style="text-align: center; border-bottom: none">
-                    <span
-                      [attr.title]="'children with this phenotype: ' + personSet.childrenCount"
+                    <span [attr.title]="'children with this phenotype: ' + personSet.childrenCount"
                       >{{ personSet.displayName }} ({{ personSet.childrenCount }})</span
                     >
                   </th>

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -22,6 +22,7 @@ import { SetPresentInParentValues } from 'app/present-in-parent/present-in-paren
 import { SetStudyTypes } from 'app/study-types/study-types.state';
 import { SetVariantTypes } from 'app/variant-types/variant-types.state';
 import { EffectTypes } from 'app/effect-types/effect-types';
+import { GeneProfilesModel, SetGeneProfilesTabs } from 'app/gene-profiles-table/gene-profiles-table.state';
 
 @Component({
   selector: 'gpf-gene-profiles-single-view',
@@ -120,12 +121,17 @@ export class GeneProfileSingleViewComponent implements OnInit {
         }
         return zip(...genomicScoresObservables);
       }),
-    ).subscribe(genomicScores => {
-      for (const genomicScore of genomicScores) {
-        this.genomicScoresGeneScores.push({
-          category: genomicScore[0],
-          scores: genomicScore[1]
-        });
+    ).subscribe({
+      next: (genomicScores) => {
+        for (const genomicScore of genomicScores) {
+          this.genomicScoresGeneScores.push({
+            category: genomicScore[0],
+            scores: genomicScore[1]
+          });
+        }
+      },
+      error: () => {
+        this.errorModal = true;
       }
     });
   }
@@ -222,6 +228,18 @@ export class GeneProfileSingleViewComponent implements OnInit {
 
   public errorModalBack(): void {
     this.errorModal = false;
+
+    let tabs = null as Set<string>;
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesTabs) => {
+        tabs = state.openedTabs;
+      });
+
+    tabs.delete(this.geneSymbol);
+
+    this.store.dispatch(new SetGeneProfilesTabs(tabs));
     this.router.navigate(['/gene-profiles']);
   }
 }

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -215,7 +215,6 @@ export class GeneProfileSingleViewComponent implements OnInit {
         .pipe(take(1))
         .subscribe(urlObject => {
           const url = queryService.getLoadUrlFromResponse(urlObject);
-
           if (newTab) {
             const newWindow = window.open('', '_blank');
             newWindow.location.assign(url);
@@ -233,7 +232,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
 
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesTabs) => {
+      .subscribe(state => {
         tabs = state.openedTabs;
       });
 

--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -156,7 +156,7 @@
             #columnFilteringButton
             id="category-filtering-button"
             class="btn btn-default"
-            (click)="openCategoryFilterDropdown($event); backToTable()"
+            (click)="openCategoryFilterDropdown($event)"
             title="Filter categories"
             ><span id="filter-menu-icon" class="material-symbols-outlined">menu</span>
           </button>

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -201,37 +201,12 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
   private loadState(): void {
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesTabs) => {
+      .subscribe(state => {
         this.tabs = state.openedTabs;
-      });
-
-    this.store.selectOnce(
-      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesSearchValue) => {
         this.geneInput = state.searchValue;
-      });
-
-    this.store.selectOnce(
-      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesHighlightedRows) => {
         this.highlightedGenes = state.highlightedRows;
-      });
-
-    this.store.selectOnce(
-      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesSortBy) => {
         this.sortBy = state.sortBy;
-      });
-
-    this.store.selectOnce(
-      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesOrderBy) => {
         this.orderBy = state.orderBy;
-      });
-
-    this.store.selectOnce(
-      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfilesConfig) => {
         this.config = state.config;
       });
 

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -13,7 +13,15 @@ import { environment } from 'environments/environment';
 import { Location } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngxs/store';
-import { GeneProfilesModel, GeneProfilesState, SetGeneProfiles } from './gene-profiles-table.state';
+import {
+  GeneProfilesModel,
+  GeneProfilesState,
+  SetGeneProfilesConfig,
+  SetGeneProfilesHighlightedRows,
+  SetGeneProfilesOrderBy,
+  SetGeneProfilesSearchValue,
+  SetGeneProfilesSortBy,
+  SetGeneProfilesTabs } from './gene-profiles-table.state';
 import { StatefulComponent } from 'app/common/stateful-component';
 
 @Component({
@@ -111,7 +119,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
       this.calculateHeaderLayout();
       this.fillTable();
       if (this.isStateLoaded) {
-        this.saveToState();
+        this.store.dispatch(new SetGeneProfilesConfig(this.config));
       }
     }
   }
@@ -193,29 +201,42 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
   private loadState(): void {
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
-      .subscribe((state: SetGeneProfiles) => {
+      .subscribe((state: SetGeneProfilesTabs) => {
         this.tabs = state.openedTabs;
+      });
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesSearchValue) => {
         this.geneInput = state.searchValue;
+      });
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesHighlightedRows) => {
         this.highlightedGenes = state.highlightedRows;
+      });
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesSortBy) => {
         this.sortBy = state.sortBy;
+      });
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesOrderBy) => {
         this.orderBy = state.orderBy;
+      });
+
+    this.store.selectOnce(
+      (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
+      .subscribe((state: SetGeneProfilesConfig) => {
         this.config = state.config;
       });
+
     this.search(this.geneInput);
     this.isStateLoaded = true;
-  }
-
-  private saveToState(): void {
-    this.store.dispatch(
-      new SetGeneProfiles(
-        this.tabs,
-        this.geneInput,
-        this.highlightedGenes,
-        this.sortBy,
-        this.orderBy,
-        this.config
-      )
-    );
   }
 
   public calculateHeaderLayout(): void {
@@ -237,7 +258,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
 
   public search(value: string): void {
     this.geneInput = value;
-    this.saveToState();
+    this.store.dispatch(new SetGeneProfilesSearchValue(this.geneInput));
     this.fillTable();
   }
 
@@ -342,7 +363,8 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
       sortButton.emitSort();
     }
     this.fillTable();
-    this.saveToState();
+    this.store.dispatch(new SetGeneProfilesOrderBy(this.orderBy));
+    this.store.dispatch(new SetGeneProfilesSortBy(this.sortBy));
   }
 
   private resetSortButtons(): void {
@@ -376,7 +398,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     if (!newTab) {
       this.loadState();
       this.tabs.add(genes);
-      this.saveToState();
+      this.store.dispatch(new SetGeneProfilesTabs(this.tabs));
 
       this.openTab(genes);
     } else {
@@ -400,7 +422,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
 
   public closeTab(tab: string): void {
     this.tabs.delete(tab);
-    this.saveToState();
+    this.store.dispatch(new SetGeneProfilesTabs(this.tabs));
     this.backToTable();
   }
 
@@ -416,7 +438,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     } else {
       this.highlightedGenes.add(geneSymbol);
     }
-    this.saveToState();
+    this.store.dispatch(new SetGeneProfilesHighlightedRows(this.highlightedGenes));
   }
 
   private async waitForSearchBoxToLoad(): Promise<void> {

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -2,14 +2,42 @@ import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { GeneProfilesTableConfig } from './gene-profiles-table';
 
-export class SetGeneProfiles {
-  public static readonly type = '[Genotype] Set gene profiles';
+export class SetGeneProfilesTabs {
+  public static readonly type = '[Genotype] Set gene profiles tabs';
   public constructor(
-    public openedTabs: Set<string>,
-    public searchValue: string,
-    public highlightedRows: Set<string>,
-    public sortBy: string,
-    public orderBy: string,
+    public openedTabs: Set<string>
+  ) {}
+}
+export class SetGeneProfilesSearchValue {
+  public static readonly type = '[Genotype] Set gene profiles search value';
+  public constructor(
+    public searchValue: string
+  ) {}
+}
+export class SetGeneProfilesHighlightedRows {
+  public static readonly type = '[Genotype] Set gene profiles highlighted table rows';
+  public constructor(
+    public highlightedRows: Set<string>
+  ) {}
+}
+
+export class SetGeneProfilesSortBy {
+  public static readonly type = '[Genotype] Set gene profiles sorting element';
+  public constructor(
+    public sortBy: string
+  ) {}
+}
+
+export class SetGeneProfilesOrderBy {
+  public static readonly type = '[Genotype] Set gene profiles sort order';
+  public constructor(
+    public orderBy: string
+  ) {}
+}
+
+export class SetGeneProfilesConfig {
+  public static readonly type = '[Genotype] Set gene profiles config';
+  public constructor(
     public config: GeneProfilesTableConfig
   ) {}
 }
@@ -36,14 +64,62 @@ export interface GeneProfilesModel {
 })
 @Injectable()
 export class GeneProfilesState {
-  @Action(SetGeneProfiles)
-  public setGeneProfiles(ctx: StateContext<GeneProfilesModel>, action: SetGeneProfiles): void {
+  @Action(SetGeneProfilesTabs)
+  public setGeneProfilesTabs(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesTabs
+  ): void {
     ctx.patchState({
-      openedTabs: action.openedTabs,
-      searchValue: action.searchValue,
-      highlightedRows: action.highlightedRows,
-      sortBy: action.sortBy,
-      orderBy: action.orderBy,
+      openedTabs: action.openedTabs
+    });
+  }
+
+  @Action(SetGeneProfilesSearchValue)
+  public setGeneProfilesSearchValue(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesSearchValue
+  ): void {
+    ctx.patchState({
+      searchValue: action.searchValue
+    });
+  }
+
+  @Action(SetGeneProfilesHighlightedRows)
+  public setGeneProfilesHighlightedRows(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesHighlightedRows
+  ): void {
+    ctx.patchState({
+      highlightedRows: action.highlightedRows
+    });
+  }
+
+  @Action(SetGeneProfilesSortBy)
+  public setGeneProfilesSortBy(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesSortBy
+  ): void {
+    ctx.patchState({
+      sortBy: action.sortBy
+    });
+  }
+
+  @Action(SetGeneProfilesOrderBy)
+  public setGeneProfilesOrderBy(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesOrderBy
+  ): void {
+    ctx.patchState({
+      orderBy: action.orderBy
+    });
+  }
+
+  @Action(SetGeneProfilesConfig)
+  public setGeneProfilesConfig(
+    ctx: StateContext<GeneProfilesModel>,
+    action: SetGeneProfilesConfig
+  ): void {
+    ctx.patchState({
       config: action.config
     });
   }


### PR DESCRIPTION
## Background

There is no error indication or redirection when navigating to invalid url for datasets (ex. `http://localhost:4200/datasets/Sasdasd`) or gene profiles (ex. `http://localhost:4200/gene-profiles/sdf`)

## Aim

Add error message to UI.

## Implementation

Show error modal in datasets after validating the dataset.
Show error modal in gene profiles after validating the gene and remove the invalid gene from the list of tabs saved in the state.
Refactor gene profiles state.

closes #963
