### PR TITLE
save gene profiles visible columns to state

### DIFF
--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -5,15 +5,13 @@ import {
   GeneProfilesGenomicScoresCategory,
   GeneProfilesSingleViewConfig} from 'app/gene-profiles-single-view/gene-profiles-single-view';
 import { GeneProfilesService } from 'app/gene-profiles-block/gene-profiles.service';
-import { map, switchMap, take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { QueryService } from 'app/query/query.service';
 import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-table/gene-profiles-table';
 import {
   GeneProfileSingleViewComponent
 } from 'app/gene-profiles-single-view/gene-profiles-single-view.component';
-import { GeneProfilesModel, SetGeneProfilesConfig } from 'app/gene-profiles-table/gene-profiles-table.state';
-import { of } from 'rxjs';
 
 @Component({
   selector: 'gpf-gene-profiles-block',
@@ -31,14 +29,8 @@ export class GeneProfilesBlockComponent implements OnInit {
   ) { }
 
   public ngOnInit(): void {
-    this.store.selectOnce((state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState).pipe(
-      switchMap((state: SetGeneProfilesConfig) => {
-        if (state.config) {
-          return of(state.config);
-        } else {
-          return this.geneProfilesService.getConfig().pipe(map(config => this.createTableConfig(config)));
-        }
-      })
+    this.geneProfilesService.getConfig().pipe(
+      map(config => this.createTableConfig(config))
     ).subscribe((config: GeneProfilesTableConfig) => {
       this.geneProfilesTableConfig = config;
       this.geneProfilesTableSortBy = this.findFirstSortableCategory(config);

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
-import { GeneProfilesTableConfig } from './gene-profiles-table';
 
 export class SetGeneProfilesTabs {
   public static readonly type = '[Genotype] Set gene profiles tabs';
@@ -35,10 +34,10 @@ export class SetGeneProfilesOrderBy {
   ) {}
 }
 
-export class SetGeneProfilesConfig {
+export class SetGeneProfilesHeader {
   public static readonly type = '[Genotype] Set gene profiles config';
   public constructor(
-    public config: GeneProfilesTableConfig
+    public headerLeaves: string[]
   ) {}
 }
 
@@ -48,7 +47,7 @@ export interface GeneProfilesModel {
     highlightedRows: Set<string>;
     sortBy: string;
     orderBy: string;
-    config: GeneProfilesTableConfig;
+    headerLeaves: string[];
 }
 
 @State<GeneProfilesModel>({
@@ -59,7 +58,7 @@ export interface GeneProfilesModel {
     highlightedRows: new Set<string>(),
     sortBy: '',
     orderBy: 'desc',
-    config: null
+    headerLeaves: []
   },
 })
 @Injectable()
@@ -114,13 +113,13 @@ export class GeneProfilesState {
     });
   }
 
-  @Action(SetGeneProfilesConfig)
+  @Action(SetGeneProfilesHeader)
   public setGeneProfilesConfig(
     ctx: StateContext<GeneProfilesModel>,
-    action: SetGeneProfilesConfig
+    action: SetGeneProfilesHeader
   ): void {
     ctx.patchState({
-      config: action.config
+      headerLeaves: action.headerLeaves
     });
   }
 }

--- a/src/app/gene-profiles-table/gene-profiles-table.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.ts
@@ -102,6 +102,24 @@ export class GeneProfilesColumn {
     return result;
   }
 
+  public static allLeaves(
+    columns: GeneProfilesColumn[],
+    parent?: GeneProfilesColumn,
+    depth: number = 1
+  ): GeneProfilesColumn[] {
+    const result: GeneProfilesColumn[] = [];
+    for (const column of columns) {
+      column.parent = parent === null || parent === undefined ? null : parent;
+      column.depth = depth;
+      if (column.columns.length > 0) {
+        result.push(...GeneProfilesColumn.allLeaves(column.columns, column, depth + 1));
+      } else {
+        result.push(column);
+      }
+    }
+    return result;
+  }
+
   public static calculateGridRow(column: GeneProfilesColumn, depth: number): void {
     if (column.gridRow !== null) {
       return;


### PR DESCRIPTION
## Background

Links in Gene profiles which navigates to Genotype browser were broken because the table config was saved in state and caused `TypeError: Converting circular structure to JSON` when the state was passed as string to request.

## Aim

To save list of leaves ids in state instead of config.

## Implementation

Use already implemented leaf toggle visibility methods to load all column visibility only by using visible leaves saved in the state. 
