### PR TITLE
fix gene profiles sorting

### DIFF
--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -205,9 +205,14 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
         this.tabs = state.openedTabs;
         this.geneInput = state.searchValue;
         this.highlightedGenes = state.highlightedRows;
-        this.sortBy = state.sortBy;
-        this.orderBy = state.orderBy;
         this.config = state.config;
+        this.orderBy = state.orderBy;
+        if (state.sortBy) {
+          this.sortBy = state.sortBy;
+        } else {
+          this.sortBy = this.defaultSortBy;
+          this.store.dispatch(new SetGeneProfilesSortBy(this.sortBy));
+        }
       });
 
     this.search(this.geneInput);

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -58,7 +58,7 @@ export interface GeneProfilesModel {
     searchValue: '',
     highlightedRows: new Set<string>(),
     sortBy: '',
-    orderBy: '',
+    orderBy: 'desc',
     config: null
   },
 })


### PR DESCRIPTION
## Background
First time sorting the first column did not work as intended. Was by default descending but sorting it resulted again in descending.

## Aim
State incorrectly loaded order by and sort by to component when component defaults existed.
State was missing the default data because it was never saved in it on component creation.

## Implementation
Add them to state when loading it (if they are missing).
