### PR TITLE
fix gene profiles state resetting

### DIFF
--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -8,6 +8,7 @@ import { isEmpty } from 'lodash';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 import { Store } from '@ngxs/store';
 import { StateResetAll } from 'ngxs-reset-plugin';
+import { GeneProfilesState } from 'app/gene-profiles-table/gene-profiles-table.state';
 
 @Component({
   selector: 'gpf-datasets',
@@ -179,7 +180,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
     /* In order to have state separation between the dataset tools,
     we clear the state if the previous url is from a different dataset tool */
     if (DatasetsComponent.previousUrl !== url && DatasetsComponent.previousUrl.startsWith('/datasets')) {
-      this.store.dispatch(new StateResetAll());
+      this.store.dispatch(new StateResetAll(GeneProfilesState));
     }
 
     this.selectedTool = url.split('/').pop();

--- a/src/app/gene-profiles-block/gene-profiles-block.component.html
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.html
@@ -1,5 +1,5 @@
 <gpf-gene-profiles-table
+  *ngIf="geneProfilesTableConfig"
   (goToQueryEvent)="goToQueryEventHandler($event)"
-  [config]="geneProfilesTableConfig"
-  [sortBy]="geneProfilesTableSortBy">
+  [config]="geneProfilesTableConfig">
 </gpf-gene-profiles-table>

--- a/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
@@ -153,7 +153,6 @@ describe('GeneProfilesBlockComponent', () => {
   it('should create gene profiles table configuration', () => {
     component.ngOnInit();
     expect(component.geneProfilesTableConfig).toStrictEqual(geneProfilesTableConfigMock);
-    expect(component.geneProfilesTableSortBy).toBe('autism_gene_sets_rank');
     expect(component.geneProfilesSingleViewConfig).toStrictEqual(config);
   });
 });

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -19,7 +19,6 @@ import {
 })
 export class GeneProfilesBlockComponent implements OnInit {
   public geneProfilesTableConfig: GeneProfilesTableConfig;
-  public geneProfilesTableSortBy: string;
   public geneProfilesSingleViewConfig: GeneProfilesSingleViewConfig;
 
   public constructor(
@@ -33,7 +32,6 @@ export class GeneProfilesBlockComponent implements OnInit {
       map(config => this.createTableConfig(config))
     ).subscribe((config: GeneProfilesTableConfig) => {
       this.geneProfilesTableConfig = config;
-      this.geneProfilesTableSortBy = this.findFirstSortableCategory(config);
     });
 
     this.geneProfilesService.getConfig().pipe(take(1)).subscribe(config => {
@@ -166,10 +164,6 @@ export class GeneProfilesBlockComponent implements OnInit {
     return new GeneProfilesColumn(
       null, personSetsColumns, dataset.displayName, false, dataset.id, dataset.meta, false, dataset.defaultVisible
     );
-  }
-
-  private findFirstSortableCategory(geneProfilesTableConfig: GeneProfilesTableConfig): string {
-    return geneProfilesTableConfig.columns.filter(column => column.sortable)[0].id;
   }
 
   public goToQueryEventHandler($event: { geneSymbol: string; statisticId: string; newTab: boolean }): void {

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -8,6 +8,7 @@ import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NgxsModule } from '@ngxs/store';
 import { GeneProfilesState } from './gene-profiles-table.state';
+import { TruncatePipe } from 'app/utils/truncate.pipe';
 
 const column1 = {
   clickable: 'createTab',
@@ -254,7 +255,7 @@ describe('GeneProfilesTableComponent', () => {
   const mockActivatedRoute = new MockActivatedRoute();
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [GeneProfilesTableComponent],
+      declarations: [GeneProfilesTableComponent, TruncatePipe],
       providers: [
         {provide: ActivatedRoute, useValue: mockActivatedRoute},
         {provide: GeneProfilesTableService, useValue: geneProfilesTableServiceMock}
@@ -266,6 +267,7 @@ describe('GeneProfilesTableComponent', () => {
     component = fixture.componentInstance;
 
     component.sortingButtonsComponents = [];
+    component.config = configMock;
     fixture.detectChanges();
   });
 
@@ -278,16 +280,10 @@ describe('GeneProfilesTableComponent', () => {
 
     component.ngOnInit();
 
-    expect(component.defaultSortBy).toBe('mockSort');
+    expect(component.config).toBeDefined();
   });
 
   it('should update when change happens', () => {
-    component.ngOnChanges();
-    expect(component.leaves).toBeUndefined();
-    expect(component.pageIndex).toBe(0);
-    expect(component.genes).toStrictEqual([]);
-
-    component.config = cloneDeep(configMock);
     component.ngOnChanges();
 
     component.leaves.forEach((leaf, index) => {

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -31,8 +31,7 @@ import { StatefulComponent } from 'app/common/stateful-component';
 })
 export class GeneProfilesTableComponent extends StatefulComponent implements OnInit, OnChanges, OnDestroy {
   @Input() public config: GeneProfilesTableConfig;
-  @Input() public sortBy: string;
-  public defaultSortBy: string;
+  public sortBy: string;
   @Output() public goToQueryEvent = new EventEmitter();
 
   @ViewChild(NgbDropdownMenu) public ngbDropdownMenu: NgbDropdownMenu;
@@ -86,8 +85,6 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
   }
 
   public ngOnInit(): void {
-    this.defaultSortBy = this.sortBy;
-
     this.keystrokeSubscription = this.searchKeystrokes$.pipe(
       distinctUntilChanged(),
       tap(() => {
@@ -114,12 +111,10 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
   }
 
   public ngOnChanges(): void {
-    if (this.config) {
-      this.viewportPageCount = Math.ceil(window.innerHeight / (this.baseRowHeight * this.config.pageSize));
-      this.setLeavesVisibility();
-      this.calculateHeaderLayout();
-      this.fillTable();
-    }
+    this.viewportPageCount = Math.ceil(window.innerHeight / (this.baseRowHeight * this.config.pageSize));
+    this.setLeavesVisibility();
+    this.calculateHeaderLayout();
+    this.fillTable();
   }
 
   public ngOnDestroy(): void {
@@ -163,6 +158,10 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     this.ngbDropdownMenu.dropdown.close();
   }
 
+  private setDefaultSortableCategory(): void {
+    this.sortBy = this.config.columns.filter(column => column.sortable)[0].id;
+  }
+
   private fillTable(): void {
     const geneProfilesRequests = [];
     this.pageIndex = 1;
@@ -204,13 +203,13 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
         this.geneInput = state.searchValue;
         this.highlightedGenes = state.highlightedRows;
         this.orderBy = state.orderBy;
+        this.leavesIds = state.headerLeaves;
         if (state.sortBy) {
           this.sortBy = state.sortBy;
         } else {
-          this.sortBy = this.defaultSortBy;
+          this.setDefaultSortableCategory();
           this.store.dispatch(new SetGeneProfilesSortBy(this.sortBy));
         }
-        this.leavesIds = state.headerLeaves;
       });
 
     this.search(this.geneInput);
@@ -346,7 +345,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     this.calculateHeaderLayout();
   }
 
-  public sort(sortBy: string, orderBy?: string): void {
+  public sort(sortBy: string, orderBy: string): void {
     if (this.sortBy !== sortBy) {
       this.resetSortButtons();
     }


### PR DESCRIPTION
## Background
Dataset component resets every state when switching between dataset tools. Gene profiles state must not be reset in the same manner.

Sort by is not properly loaded by the state.

## Aim
Make Gene profiles state persistent between pages.

Make sort by loadable by the state.

## Implementation
Replace reset all states with reset all but one.

Refactor "sort by" default value fetching. Refactor gene profiles block and table to not disturb state usage.