### PR TITLE
update pheno browser table scalability for measure description column

### DIFF
--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -17,7 +17,7 @@
         </span>
       </gpf-table-content>
     </gpf-table-column>
-    <gpf-table-column *ngIf="measures.hasDescriptions">
+    <gpf-table-column [columnWidth]="singleColumnWidth" *ngIf="measures.hasDescriptions">
       <gpf-table-header caption="Measure Description" field="description"></gpf-table-header>
       <gpf-table-content>
         <span *gpfTableCellContent="let data">

--- a/src/app/pheno-browser-table/pheno-browser-table.component.ts
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.ts
@@ -26,6 +26,9 @@ export class PhenoBrowserTableComponent implements OnInit, OnChanges {
   ) { }
 
   public ngOnInit(): void {
+    if (this.measures.hasDescriptions) {
+      this.columnsCount = 9;
+    }
     this.onResize();
   }
 


### PR DESCRIPTION
## Background

There is column `Measure description` in Phenotype browser which changes the table style if visible. 
![image](https://github.com/iossifovlab/gpfjs/assets/56651698/8219ff0e-1b5f-477f-a6a9-8444cd3bf1a5)


## Aim

To resize the table.

## Implementation

Make column `Measure description` to have the same width as the oders and increase component variable `columnsCount` if there are measure descriptions.

