### PR TITLE
fix datasets showing error modal

### DIFF
--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -19,7 +19,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
   private static previousUrl = '';
   public registerAlertVisible = false;
   public datasetTrees: DatasetNode[];
-  public selectedDataset: Dataset;
+  public selectedDataset: Dataset = null;
   public permissionDeniedPrompt: string;
   public toolPageLinks = toolPageLinks;
   public visibleDatasets: string[];


### PR DESCRIPTION
## Background

Error modal for invalid datasets was flickering when loading.

## Aim

To fix it.

## Implementation

Set the initial value of the `selectedDataset` variable to be null.
