### PR TITLE
make datasets in dropdown collapsable

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -187,6 +187,7 @@ import { MarkdownEditorComponent } from './markdown-editor/markdown-editor.compo
 import { FamilyTagsComponent } from './family-tags/family-tags.component';
 import { FamilyTagsState } from './family-tags/family-tags.state';
 import { GeneProfilesState } from './gene-profiles-table/gene-profiles-table.state';
+import { DatasetNodeState } from './dataset-node/dataset-node.state';
 
 const appRoutes: Routes = [
   {
@@ -432,7 +433,7 @@ const appRoutes: Routes = [
       GeneSymbolsState, FamilyIdsState, FamilyTagsState, RegionsFilterState, StudyTypesState, GeneSetsState,
       GeneScoresState, EnrichmentModelsState, PedigreeSelectorState, FamilyTypeFilterState,
       StudyFiltersState, PersonFiltersState, GenomicScoresBlockState, PhenoToolMeasureState,
-      UniqueFamilyVariantsFilterState, ErrorsState, GeneProfilesState
+      UniqueFamilyVariantsFilterState, ErrorsState, GeneProfilesState, DatasetNodeState
     ], {compatibility: { strictContentSecurityPolicy: true }}
     ),
     NgxsResetPluginModule.forRoot(),

--- a/src/app/dataset-node/dataset-node.component.css
+++ b/src/app/dataset-node/dataset-node.component.css
@@ -14,7 +14,10 @@
 
 .collapse-dataset-icon {
   position: relative;
-  left: 5px;
+  left: 0;
+  top: 7px;
+  width: 20px;
+  height: 20px;
   user-select: none;
   transform: rotate(270deg);
 }
@@ -22,6 +25,7 @@
 .rotate {
   right: 10px;
   transform: translate(-3px, 5px) rotate(0);
+  top: 0;
 }
 
 .dataset-container {

--- a/src/app/dataset-node/dataset-node.component.css
+++ b/src/app/dataset-node/dataset-node.component.css
@@ -1,6 +1,6 @@
 .children-container {
   padding-left: 8px;
-  margin-left: 13px;
+  margin-left: 9px;
   border-left: 1px solid #e4e4e4;
 }
 

--- a/src/app/dataset-node/dataset-node.component.css
+++ b/src/app/dataset-node/dataset-node.component.css
@@ -1,10 +1,11 @@
 .children-container {
-  padding-left: 13px;
+  padding-left: 8px;
   margin-left: 13px;
   border-left: 1px solid #e4e4e4;
 }
 
 .dataset-dropdown-item {
+  padding-left: 24px;
   padding-right: 0;
   white-space: nowrap;
   overflow: hidden;

--- a/src/app/dataset-node/dataset-node.component.css
+++ b/src/app/dataset-node/dataset-node.component.css
@@ -1,11 +1,28 @@
 .children-container {
-  padding-left: 25px;
+  padding-left: 13px;
+  margin-left: 13px;
+  border-left: 1px solid #e4e4e4;
 }
 
 .dataset-dropdown-item {
-  padding-left: 15px;
   padding-right: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.collapse-dataset-icon {
+  position: relative;
+  left: 5px;
+  user-select: none;
+  transform: rotate(270deg);
+}
+
+.rotate {
+  right: 10px;
+  transform: translate(-3px, 5px) rotate(0);
+}
+
+.dataset-container {
+  display: flex;
 }

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -5,7 +5,7 @@
     class="collapse-dataset-icon material-icons material-symbols-outlined"
     [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3"
     [ngClass]="{ rotate: isExpanded }"
-    (click)="toggleDatasetCollapse()"
+    (click)="toggleDatasetCollapse(datasetNode.dataset.id)"
     >expand_more</span
   ><a
     class="dataset-dropdown-item dropdown-item"

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -3,6 +3,7 @@
     #collapseIcon
     *ngIf="datasetNode.children.length"
     class="collapse-dataset-icon material-icons material-symbols-outlined"
+    [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3"
     [ngClass]="{ rotate: isExpanded }"
     (click)="toggleDatasetCollapse()"
     >expand_more</span

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -11,7 +11,7 @@
     *ngIf="selectedDataset$ | async as selectedDataset"
     [class.active]="selectedDataset.id === datasetNode.dataset.id"
     [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3"
-    [style.padding-left]="datasetNode.children.length ? 0 : 25"
+    [ngStyle]="{ 'padding-left': datasetNode.children.length ? 0 : 24 }"
     (click)="select()"
     (middleclick)="select(true)">
     <!-- eslint-disable-next-line prettier/prettier -->

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -23,5 +23,6 @@
   <gpf-dataset-node
     *ngFor="let child of datasetNode.children"
     [datasetNode]="child"
-    (setExpandabilityEvent)="setIsExpanded()"></gpf-dataset-node>
+    (setExpandabilityEvent)="setIsExpanded()"
+    [closeObservable]="closeChildrenSubject.asObservable()"></gpf-dataset-node>
 </div>

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -1,13 +1,27 @@
-<a
-  class="dataset-dropdown-item dropdown-item"
-  *ngIf="selectedDataset$ | async as selectedDataset"
-  [class.active]="selectedDataset.id === datasetNode.dataset.id"
-  (click)="select()"
-  (middleclick)="select(true)"
-  [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3">
-  <span style="user-select: none">{{ datasetNode.dataset.name }}</span>
-</a>
+<div class="dataset-container">
+  <span
+    #collapseIcon
+    *ngIf="datasetNode.children.length"
+    class="collapse-dataset-icon material-icons material-symbols-outlined"
+    [ngClass]="{ rotate: isExpanded }"
+    (click)="toggleDatasetCollapse()"
+    >expand_more</span
+  ><a
+    class="dataset-dropdown-item dropdown-item"
+    *ngIf="selectedDataset$ | async as selectedDataset"
+    [class.active]="selectedDataset.id === datasetNode.dataset.id"
+    [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3"
+    [style.padding-left]="datasetNode.children.length ? 0 : 25"
+    (click)="select()"
+    (middleclick)="select(true)">
+    <!-- eslint-disable-next-line prettier/prettier -->
+    <span style="user-select: none">{{datasetNode.dataset.name}}</span>
+  </a>
+</div>
 
-<div class="children-container">
-  <gpf-dataset-node *ngFor="let child of datasetNode.children" [datasetNode]="child"></gpf-dataset-node>
+<div [hidden]="!isExpanded" class="children-container">
+  <gpf-dataset-node
+    *ngFor="let child of datasetNode.children"
+    [datasetNode]="child"
+    (setExpandabilityEvent)="setIsExpanded()"></gpf-dataset-node>
 </div>

--- a/src/app/dataset-node/dataset-node.component.ts
+++ b/src/app/dataset-node/dataset-node.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { AfterContentChecked, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { Dataset } from 'app/datasets/datasets';
 import { DatasetsService } from 'app/datasets/datasets.service';
@@ -10,17 +10,35 @@ import { DatasetNode } from './dataset-node';
   templateUrl: './dataset-node.component.html',
   styleUrls: ['./dataset-node.component.css']
 })
-export class DatasetNodeComponent implements OnInit {
+export class DatasetNodeComponent implements OnInit, AfterContentChecked {
   @Input() public datasetNode: DatasetNode;
+  @Output() public setExpandabilityEvent = new EventEmitter<boolean>();
   public selectedDataset$: Observable<Dataset>;
+  public isExpanded = false;
 
   public constructor(
     private router: Router,
     private datasetsService: DatasetsService,
+    private changeDetector: ChangeDetectorRef,
   ) { }
 
   public ngOnInit(): void {
     this.selectedDataset$ = this.datasetsService.getSelectedDatasetObservable();
+    this.selectedDataset$.subscribe(dataset => {
+      if (dataset.id === 'ALL_genotypes' && this.datasetNode.dataset.id === 'ALL_genotypes') {
+        this.isExpanded = true;
+      } else if (this.datasetNode.dataset.id === dataset.id) {
+        this.setExpandability();
+      }
+    });
+  }
+
+  public ngAfterContentChecked(): void {
+    this.changeDetector.detectChanges();
+  }
+
+  public setExpandability(): void {
+    this.setExpandabilityEvent.emit(true);
   }
 
   public select(openInNewTab = false): void {
@@ -36,5 +54,14 @@ export class DatasetNodeComponent implements OnInit {
         }
       }
     }
+  }
+
+  public setIsExpanded(): void {
+    this.isExpanded = true;
+    this.setExpandability();
+  }
+
+  public toggleDatasetCollapse(): void {
+    this.isExpanded = !this.isExpanded;
   }
 }

--- a/src/app/dataset-node/dataset-node.state.ts
+++ b/src/app/dataset-node/dataset-node.state.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { State, Action, StateContext } from '@ngxs/store';
+
+export class SetExpandedDatasets {
+  public static readonly type = '[Genotype] Set expanded datasets';
+  public constructor(
+    public expandedDatasets: Set<string>
+  ) {}
+}
+
+export interface DatasetNodeModel {
+    expandedDatasets: Set<string>;
+}
+
+@State<DatasetNodeModel>({
+  name: 'datasetNodeState',
+  defaults: {
+    expandedDatasets: new Set<string>()
+  },
+})
+@Injectable()
+export class DatasetNodeState {
+  @Action(SetExpandedDatasets)
+  public setExpandedDatasets(
+    ctx: StateContext<DatasetNodeModel>,
+    action: SetExpandedDatasets
+  ): void {
+    ctx.patchState({
+      expandedDatasets: action.expandedDatasets
+    });
+  }
+}

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -9,6 +9,7 @@ import { DatasetNode } from 'app/dataset-node/dataset-node';
 import { Store } from '@ngxs/store';
 import { StateResetAll } from 'ngxs-reset-plugin';
 import { GeneProfilesState } from 'app/gene-profiles-table/gene-profiles-table.state';
+import { DatasetNodeState } from 'app/dataset-node/dataset-node.state';
 
 @Component({
   selector: 'gpf-datasets',
@@ -180,7 +181,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
     /* In order to have state separation between the dataset tools,
     we clear the state if the previous url is from a different dataset tool */
     if (DatasetsComponent.previousUrl !== url && DatasetsComponent.previousUrl.startsWith('/datasets')) {
-      this.store.dispatch(new StateResetAll(GeneProfilesState));
+      this.store.dispatch(new StateResetAll(GeneProfilesState, DatasetNodeState));
     }
 
     this.selectedTool = url.split('/').pop();


### PR DESCRIPTION
## Background

Datasets dropdown contains too much datasets and studies which makes the dropdown too long and the user needs to scroll the page.

## Aim

To make datasets which have children to collapse.

## Implementation

Make datasets collapsable. All genotypes is expanded by default.
