### PR TITLE
update families by pedigree counter ui

### DIFF
--- a/src/app/variant-reports/variant-reports.component.css
+++ b/src/app/variant-reports/variant-reports.component.css
@@ -207,6 +207,17 @@ h5 {
 }
 
 #families-sum {
-  margin-right: 15px;
   min-width: 100px;
+  margin-left: 8px;
+  background-color: #eee;
+  padding: 2px;
+  border: 1px solid rgba(0, 0, 0, 12.5%);
+  text-align: center;
+}
+
+#download-button {
+  margin-left: 10px;
+  padding: 1px;
+  width: 35px;
+  height: 30px;
 }

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -100,14 +100,14 @@
           action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDataset.id }}"
           method="post"
           style="display: flex; align-items: center">
-          <span id="families-sum">All families: {{ familiesCount }}</span>
+          <span>Selected families: </span><span id="families-sum">{{ filteredFamiliesCount + ' / ' + totalFamiliesCount }}</span>
           <input name="queryData" type="hidden" />
           <button
             class="btn btn-md btn-primary btn-right"
             id="download-button"
             [disabled]="currentPedigreeTable.pedigrees.length === 0"
             type="submit"
-            >Download</button
+            ><span class="material-symbols-outlined">download</span></button
           >
         </form>
       </div>

--- a/src/app/variant-reports/variant-reports.component.spec.ts
+++ b/src/app/variant-reports/variant-reports.component.spec.ts
@@ -495,7 +495,7 @@ describe('VariantReportsComponent', () => {
     });
   });
 
-  it('should test count of families in families by pedigree', () => {
+  it('should test updating the count of filtered families in families by pedigree', () => {
     component.ngOnInit();
     const pedigresMock = [
       [new PedigreeCounter(1, 'mock1', [], 12, [])],
@@ -506,6 +506,6 @@ describe('VariantReportsComponent', () => {
 
     component.currentPedigreeTable = currentTableMock;
     component.updateFamiliesCount();
-    expect(component.familiesCount).toBe(20);
+    expect(component.filteredFamiliesCount).toBe(20);
   });
 });

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -13,6 +13,7 @@ import { ConfigService } from 'app/config/config.service';
 import { Store } from '@ngxs/store';
 import { SetFamilyTags } from 'app/family-tags/family-tags.state';
 import { Router } from '@angular/router';
+import { couldStartTrivia } from 'typescript';
 
 @Pipe({ name: 'getPeopleCounterRow' })
 export class PeopleCounterRowPipe implements PipeTransform {
@@ -34,7 +35,8 @@ export class VariantReportsComponent implements OnInit {
   public currentPedigreeTable: PedigreeTable;
   public currentDenovoReport: EffectTypeTable;
   public tagsHeader = '';
-  public familiesCount = 0;
+  public filteredFamiliesCount = 0;
+  public totalFamiliesCount = 0;
   public isAddClicked = false;
   public isRemoveClicked = false;
 
@@ -94,7 +96,9 @@ export class VariantReportsComponent implements OnInit {
         this.currentDenovoReport = this.variantReport.denovoReport.tables[0];
         this.calculateDenovoVariantsTableWidth();
       }
-      this.updateFamiliesCount();
+
+      this.totalFamiliesCount = this.calculateFamilies();
+      this.filteredFamiliesCount = this.totalFamiliesCount;
     });
     if (this.variantReportsService.getTags() !== undefined) {
       this.variantReportsService.getTags().subscribe(data => {
@@ -150,14 +154,20 @@ export class VariantReportsComponent implements OnInit {
 
 
   public updateFamiliesCount(): void {
-    this.familiesCount = 0;
+    this.filteredFamiliesCount = 0;
+    this.filteredFamiliesCount = this.calculateFamilies();
+  }
+
+  private calculateFamilies(): number {
+    let count = 0;
     this.currentPedigreeTable.pedigrees.forEach(pedigrees => {
       pedigrees.forEach(pedigree => {
         if (pedigree) {
-          this.familiesCount += Number(pedigree.count);
+          count += Number(pedigree.count);
         }
       });
     });
+    return count;
   }
 
   public openModal(): void {


### PR DESCRIPTION
## Background

The UI of families by pedigree counter and download button need to be synchronized with other counters and download buttons (for example Gene Browser).

## Implementation

Rename `All families` to `Selected families`.
Use icon instead of text in the download button.
Add the counter of the total families count  -> `filtered families / total families` and make the UI like in Gene Browser.
