### PR TITLE
Fix histogram descriptions width

### DIFF
--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -22,7 +22,7 @@
       <circle cx="10" cy="40" r="3" stroke="red" fill="red" stroke-width="2"></circle>
       <text x="20" y="45">female with hit</text>
       <circle cx="10" cy="55" r="3" stroke="red" fill="white" stroke-width="2"></circle>
-      <text x="20" y="60">male without hit</text>
+      <text x="20" y="60">female without hit</text>
     </g>
   </svg>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -484,8 +484,13 @@ summary.details {
   width: 100%;
   max-width: 560px;
   margin: auto;
-  margin-top: -40px;
+  margin-top: -23px;
   margin-bottom: 10px;
+}
+
+.small-values,
+.large-values {
+  max-width: 170px;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */


### PR DESCRIPTION
## Background

1. In some cases the description texts for small values and large values for helper modal histograms are too long and overlaps with the text of the score in the middle.

2. In phenotype tool there is an error in chart legend - the last (red empty) circle should be 'female without hit' not 'male without hit.

## Aim

1. To reduce the max-width of the descriptions.

2. To fix the text in the legend in pheno tool.

## Implementation

1. Reduce the max-width and move the descriptions a bit lower.
