### PR TITLE
fix gene profiles typing in search

### DIFF
--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -136,7 +136,7 @@
               placeholder="Search gene"
               type="text"
               spellcheck="false"
-              [value]="geneInput" />
+              [value]="loadedSearchValue" />
             <span
               *ngIf="searchBox.value !== '' && !showSearchLoading"
               class="material-symbols-outlined search-clear-icon"

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -54,6 +54,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
   public orderBy = 'desc';
 
   public geneInput: string = null;
+  public loadedSearchValue: string = null;
   public searchKeystrokes$: Subject<string> = new Subject();
   @ViewChild('searchBox') public searchBox: ElementRef;
   public pageIndex = 0;
@@ -208,7 +209,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
       .subscribe(state => {
         this.tabs = state.openedTabs;
-        this.geneInput = state.searchValue;
+        this.loadedSearchValue = state.searchValue;
         this.highlightedGenes = state.highlightedRows;
         this.orderBy = state.orderBy;
         this.leavesIds = state.headerLeaves;
@@ -223,7 +224,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
         this.prepareTable();
       });
 
-    this.search(this.geneInput);
+    this.search(this.loadedSearchValue);
   }
 
   private reorderHeaderByLeaves(


### PR DESCRIPTION
## Background

When typing fast in gene profiles search input, sometimes the last typed symbol disappears.

## Aim

To fix it.

## Implementation

Because there is one variable (`geneInput`) which stores the current input value and the value stored in the state, the input value is overridden everytime we type. The solution is to use two variables - `geneInput` which stores the current search value and `loadedSearchValue` which stores the value saved in the state and used to set the input when gene profiles is loaded.
