### PR TITLE
Fix unpredictable state data behaviour

### DIFF
--- a/src/app/dataset-node/dataset-node.component.ts
+++ b/src/app/dataset-node/dataset-node.component.ts
@@ -42,7 +42,7 @@ export class DatasetNodeComponent extends StatefulComponent implements OnInit, A
     this.store.selectOnce(
       (state: { datasetNodeState: DatasetNodeModel}) => state.datasetNodeState)
       .subscribe(state => {
-        if (state.expandedDatasets.has(this.datasetNode.dataset.id)) {
+        if (state.expandedDatasets.includes(this.datasetNode.dataset.id)) {
           this.isExpanded = true;
         }
       });
@@ -85,8 +85,10 @@ export class DatasetNodeComponent extends StatefulComponent implements OnInit, A
     this.store.selectOnce(
       (state: { datasetNodeState: DatasetNodeModel}) => state.datasetNodeState)
       .subscribe(state => {
-        state.expandedDatasets.add(nodeId);
-        this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
+        if (!state.expandedDatasets.includes(nodeId)) {
+          state.expandedDatasets.push(nodeId);
+          this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
+        }
       });
   }
 
@@ -94,8 +96,11 @@ export class DatasetNodeComponent extends StatefulComponent implements OnInit, A
     this.store.selectOnce(
       (state: { datasetNodeState: DatasetNodeModel}) => state.datasetNodeState)
       .subscribe(state => {
-        state.expandedDatasets.delete(nodeId);
-        this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
+        if (state.expandedDatasets.includes(nodeId)) {
+          const index = state.expandedDatasets.indexOf(nodeId, 0);
+          state.expandedDatasets.splice(index, 1);
+          this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
+        }
       });
   }
 
@@ -103,10 +108,11 @@ export class DatasetNodeComponent extends StatefulComponent implements OnInit, A
     this.store.selectOnce(
       (state: { datasetNodeState: DatasetNodeModel}) => state.datasetNodeState)
       .subscribe(state => {
-        if (state.expandedDatasets.has(nodeId)) {
-          state.expandedDatasets.delete(nodeId);
+        if (state.expandedDatasets.includes(nodeId)) {
+          const index = state.expandedDatasets.indexOf(nodeId, 0);
+          state.expandedDatasets.splice(index, 1);
         } else {
-          state.expandedDatasets.add(nodeId);
+          state.expandedDatasets.push(nodeId);
         }
         this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
       });

--- a/src/app/dataset-node/dataset-node.state.ts
+++ b/src/app/dataset-node/dataset-node.state.ts
@@ -4,18 +4,18 @@ import { State, Action, StateContext } from '@ngxs/store';
 export class SetExpandedDatasets {
   public static readonly type = '[Genotype] Set expanded datasets';
   public constructor(
-    public expandedDatasets: Set<string>
+    public expandedDatasets: string[]
   ) {}
 }
 
 export interface DatasetNodeModel {
-    expandedDatasets: Set<string>;
+    expandedDatasets: string[];
 }
 
 @State<DatasetNodeModel>({
   name: 'datasetNodeState',
   defaults: {
-    expandedDatasets: new Set<string>()
+    expandedDatasets: []
   },
 })
 @Injectable()

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -85,7 +85,7 @@ export class DatasetsComponent implements OnInit, OnDestroy {
       (state: { datasetNodeState: DatasetNodeModel}) => state.datasetNodeState)
       .subscribe(state => {
         this.datasetTrees.forEach(node => {
-          state.expandedDatasets.add(node.dataset.id);
+          state.expandedDatasets.push(node.dataset.id);
         });
         this.store.dispatch(new SetExpandedDatasets(state.expandedDatasets));
       });

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -228,7 +228,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
   public errorModalBack(): void {
     this.errorModal = false;
 
-    let tabs = null as Set<string>;
+    let tabs = [] as string[];
 
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
@@ -236,7 +236,8 @@ export class GeneProfileSingleViewComponent implements OnInit {
         tabs = state.openedTabs;
       });
 
-    tabs.delete(this.geneSymbol);
+    const index = tabs.indexOf(this.geneSymbol, 0);
+    tabs.splice(index, 1);
 
     this.store.dispatch(new SetGeneProfilesTabs(tabs));
     this.router.navigate(['/gene-profiles']);

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -271,9 +271,9 @@ describe('GeneProfilesTableComponent', () => {
     component.config = configMock;
     store = TestBed.inject(Store);
     jest.spyOn(store, 'selectOnce').mockReturnValue(of({
-      openedTabs: new Set<string>(),
+      openedTabs: [],
       searchValue: '',
-      highlightedRows: new Set<string>(),
+      highlightedRows: [],
       sortBy: 'column1',
       orderBy: 'desc',
       headerLeaves: []

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -208,9 +208,9 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
       .subscribe(state => {
-        this.tabs = state.openedTabs;
+        this.tabs = new Set(state.openedTabs);
         this.loadedSearchValue = state.searchValue;
-        this.highlightedGenes = state.highlightedRows;
+        this.highlightedGenes = new Set(state.highlightedRows);
         this.orderBy = state.orderBy;
         this.leavesIds = state.headerLeaves;
         this.reorderHeaderByLeaves(this.config.columns);
@@ -419,7 +419,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     if (!newTab) {
       this.loadState();
       this.tabs.add(genes);
-      this.store.dispatch(new SetGeneProfilesTabs(this.tabs));
+      this.store.dispatch(new SetGeneProfilesTabs([...this.tabs.values()]));
 
       this.openTab(genes);
     } else {
@@ -443,7 +443,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
 
   public closeTab(tab: string): void {
     this.tabs.delete(tab);
-    this.store.dispatch(new SetGeneProfilesTabs(this.tabs));
+    this.store.dispatch(new SetGeneProfilesTabs([...this.tabs.values()]));
     this.backToTable();
   }
 
@@ -459,7 +459,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     } else {
       this.highlightedGenes.add(geneSymbol);
     }
-    this.store.dispatch(new SetGeneProfilesHighlightedRows(this.highlightedGenes));
+    this.store.dispatch(new SetGeneProfilesHighlightedRows([...this.highlightedGenes.values()]));
   }
 
   private async waitForSearchBoxToLoad(): Promise<void> {

--- a/src/app/gene-profiles-table/gene-profiles-table.state.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.state.ts
@@ -4,7 +4,7 @@ import { State, Action, StateContext } from '@ngxs/store';
 export class SetGeneProfilesTabs {
   public static readonly type = '[Genotype] Set gene profiles tabs';
   public constructor(
-    public openedTabs: Set<string>
+    public openedTabs: string[]
   ) {}
 }
 export class SetGeneProfilesSearchValue {
@@ -16,7 +16,7 @@ export class SetGeneProfilesSearchValue {
 export class SetGeneProfilesHighlightedRows {
   public static readonly type = '[Genotype] Set gene profiles highlighted table rows';
   public constructor(
-    public highlightedRows: Set<string>
+    public highlightedRows: string[]
   ) {}
 }
 
@@ -42,9 +42,9 @@ export class SetGeneProfilesHeader {
 }
 
 export interface GeneProfilesModel {
-    openedTabs: Set<string>;
+    openedTabs: string[];
     searchValue: string;
-    highlightedRows: Set<string>;
+    highlightedRows: string[];
     sortBy: string;
     orderBy: string;
     headerLeaves: string[];
@@ -53,9 +53,9 @@ export interface GeneProfilesModel {
 @State<GeneProfilesModel>({
   name: 'geneProfilesState',
   defaults: {
-    openedTabs: new Set<string>(),
+    openedTabs: [],
     searchValue: '',
-    highlightedRows: new Set<string>(),
+    highlightedRows: [],
     sortBy: '',
     orderBy: 'desc',
     headerLeaves: []


### PR DESCRIPTION
## Background

Some of the properties saved in the state are sets which lead to unpredictable behaviour because sets cannot deserialize.

## Aim

To use arrays instead of sets.

## Implementation

Change datasets state and gene profiles state to use arrays.
