### PR TITLE
Fix gene browser link single view

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -158,7 +158,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   public async submitGeneRequest(geneSymbol?: string): Promise<void> {
-    (this.searchBox.nativeElement as HTMLElement).blur();
+    (this.searchBox?.nativeElement as HTMLElement)?.blur();
     if (this.showError) {
       return;
     }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -34,7 +34,7 @@
             [(ngModel)]="geneSymbol"
             (keyup)="searchBoxInput$.next(geneSymbol)"
             (focus)="reset()"
-            (onSelectionChange)="openSingleView(geneSymbol)" />
+            (keydown.enter)="openSingleView(geneSymbol)" />
 
           <mat-autocomplete autoActiveFirstOption #geneDropdownHome="matAutocomplete" class="genes-dropdown">
             <mat-option


### PR DESCRIPTION
## Background

There was an error saying the search input is undefined in Gene Browser when navigating with url.
The error message doesn't show when invalid gene is searched in Home page.

## Aim

To fix them.

