### PR TITLE
use gp gene symbols api in home page search

### DIFF
--- a/src/app/gene-profiles-table/gene-profiles-table.service.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.service.ts
@@ -10,6 +10,7 @@ import { map } from 'rxjs/operators';
 })
 export class GeneProfilesTableService {
   private readonly genesUrl = 'gene_profiles/table/rows';
+  private readonly geneSymbolsUrl = 'gene_profiles/table/gene_symbols/';
 
   public constructor(
     private http: HttpClient,
@@ -36,6 +37,21 @@ export class GeneProfilesTableService {
 
     return this.http.get(url).pipe(
       map(res => (res as Array<any>))
+    );
+  }
+
+  public getGeneSymbols(page: number, searchString?: string): Observable<string[]> {
+    let url = this.config.baseUrl + this.geneSymbolsUrl;
+    let params = new HttpParams().set('page', page.toString());
+
+    if (searchString) {
+      params = params.append('symbol', searchString);
+    }
+
+    url += `?${ params.toString() }`;
+
+    return this.http.get(url).pipe(
+      map(res => (res as Array<string>))
     );
   }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -97,14 +97,14 @@ export class HomeComponent implements OnInit, OnDestroy {
         if (!searchTerm) {
           return of(null);
         }
-        return this.geneProfilesTableService.getGenes(1, searchTerm);
+        return this.geneProfilesTableService.getGeneSymbols(1, searchTerm);
       })
-    ).subscribe((response: {geneSymbol: string}[]) => {
+    ).subscribe((response: string[]) => {
       if (!response) {
         this.geneSymbolSuggestions = [];
         return;
       }
-      this.geneSymbolSuggestions = response.map(gene => gene.geneSymbol);
+      this.geneSymbolSuggestions = response;
     });
   }
 


### PR DESCRIPTION
## Background
Home page search is inaccurate.

## Aim
Make shorter gene symbols appear when searching for them by using new gp gene symbols api for this specific search.

## Implementation
New api providing only gp gene symbols, sorted.

