### PR TITLE
Fix setting genome

### DIFF
--- a/src/app/datasets/datasets.service.ts
+++ b/src/app/datasets/datasets.service.ts
@@ -22,8 +22,6 @@ export class DatasetsService {
   private datasets$ = new ReplaySubject<Array<Dataset>>(1);
   public datasetsLoading = false;
 
-  public static genomeVersion = '';
-
   public static descriptionCache = [];
 
   public constructor(
@@ -61,7 +59,7 @@ export class DatasetsService {
     const details$ = this.http.get(`${this.config.baseUrl}${this.datasetsDetailsUrl}/${datasetId}`, options);
 
     return zip(dataset$, details$).pipe(map(
-      (datasetPack: [any, any]) => Dataset.fromDatasetAndDetailsJson(datasetPack[0]['data'], datasetPack[1]))
+      (datasetPack: [object, object]) => Dataset.fromDatasetAndDetailsJson(datasetPack[0]['data'], datasetPack[1]))
     );
   }
 

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -210,7 +210,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
     ]);
 
     store.selectOnce(state => state).subscribe(state => {
-      state['datasetId'] = datasetId;
+      state['temporaryDatasetId'] = datasetId;
       queryService.saveQuery(state, 'genotype')
         .pipe(take(1))
         .subscribe(urlObject => {

--- a/src/app/load-query/load-query.component.ts
+++ b/src/app/load-query/load-query.component.ts
@@ -50,7 +50,7 @@ export class LoadQueryComponent implements OnInit {
 
   private restoreQuery(state: object, page: string): void {
     if (page in PAGE_TYPE_TO_NAVIGATE) {
-      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['datasetState'].selectedDataset.id);
+      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['temporaryDatasetId']);
       this.store.reset(state);
       this.store.dispatch(new StateReset(ErrorsState));
       this.router.navigate(navigationParams);

--- a/src/app/pedigree/pedigree.component.ts
+++ b/src/app/pedigree/pedigree.component.ts
@@ -24,6 +24,7 @@ export class PedigreeComponent {
   public modal: NgbModalRef;
   public familyIdsList: string[];
   public pedigreeScale = 2.5;
+  public selectedDatasetId = '';
 
   public constructor(
     public modalService: NgbModal,
@@ -39,9 +40,9 @@ export class PedigreeComponent {
 
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => {
-        const selectedDatasetId = state.selectedDataset.id;
+        this.selectedDatasetId = state.selectedDataset.id;
         return this.variantReportsService.getFamilies(
-          selectedDatasetId,
+          this.selectedDatasetId,
           this.groupName,
           this.counterId
         );
@@ -68,7 +69,7 @@ export class PedigreeComponent {
   }
 
   public getDownloadLink(): string {
-    return this.variantReportsService.getDownloadLink();
+    return this.variantReportsService.getDownloadLink() + this.selectedDatasetId;
   }
 
   public onSubmit(event): void {

--- a/src/app/regions-filter/regions-filter.component.ts
+++ b/src/app/regions-filter/regions-filter.component.ts
@@ -10,7 +10,7 @@ import { StatefulComponent } from 'app/common/stateful-component';
   templateUrl: './regions-filter.component.html',
 })
 export class RegionsFilterComponent extends StatefulComponent implements OnInit {
-  @ValidateNested() public regionsFilter = new RegionsFilter();
+  @ValidateNested() public regionsFilter = new RegionsFilter(this.store);
   @ViewChild('textArea') private textArea: ElementRef;
 
   public constructor(protected store: Store) {

--- a/src/app/regions-filter/regions-filter.ts
+++ b/src/app/regions-filter/regions-filter.ts
@@ -1,9 +1,17 @@
 import { RegionsFilterValidator } from './regions-filter.validator';
 import { Validate } from 'class-validator';
-import { DatasetsService } from 'app/datasets/datasets.service';
+import { DatasetModel } from 'app/datasets/datasets.state';
+import { Store } from '@ngxs/store';
 
 export class RegionsFilter {
   @Validate(RegionsFilterValidator)
   public regionsFilter = '';
-  public genome = DatasetsService.genomeVersion;
+  public genome = '';
+
+  public constructor(public store: Store) {
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
+      this.genome = state.selectedDataset.genome;
+    });
+  }
 }
+

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -252,7 +252,7 @@ export class VariantReportsComponent implements OnInit {
   }
 
   public getDownloadLink(): string {
-    return this.variantReportsService.getDownloadLink();
+    return this.variantReportsService.getDownloadLink() + this.selectedDataset.id;
   }
 
   public downloadTags(event): void {

--- a/src/app/variant-reports/variant-reports.service.spec.ts
+++ b/src/app/variant-reports/variant-reports.service.spec.ts
@@ -4,9 +4,6 @@ import { HttpClientModule} from '@angular/common/http';
 import { ConfigService } from 'app/config/config.service';
 import { APP_BASE_HREF } from '@angular/common';
 import { NgxsModule } from '@ngxs/store';
-import { Dataset } from 'app/datasets/datasets';
-import { DatasetModel } from 'app/datasets/datasets.state';
-import { of } from 'rxjs';
 
 
 describe('VariantReportsService', () => {
@@ -23,14 +20,6 @@ describe('VariantReportsService', () => {
     });
 
     service = TestBed.inject(VariantReportsService);
-
-    // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
-
-    service['store'] = {
-      selectOnce: () => of(selectedDatasetMockModel)
-    } as never;
   });
 
   it('should be created', () => {
@@ -38,7 +27,7 @@ describe('VariantReportsService', () => {
   });
 
   it('should get download link', () => {
-    const expectedLink = 'http://localhost:8000/api/v3/common_reports/families_data/testId';
+    const expectedLink = 'http://localhost:8000/api/v3/common_reports/families_data/';
 
     const actualLink = service.getDownloadLink();
 

--- a/src/app/variant-reports/variant-reports.service.ts
+++ b/src/app/variant-reports/variant-reports.service.ts
@@ -6,7 +6,6 @@ import { VariantReport } from './variant-reports';
 import { environment } from '../../environments/environment';
 import { map } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
-import { DatasetModel } from 'app/datasets/datasets.state';
 
 @Injectable()
 export class VariantReportsService {
@@ -28,11 +27,7 @@ export class VariantReportsService {
   }
 
   public getDownloadLink(): string {
-    let selectedDatasetId = '';
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      selectedDatasetId = state.selectedDataset.id;
-    });
-    return `${environment.apiPath}${this.downloadUrl}${selectedDatasetId}`;
+    return `${environment.apiPath}${this.downloadUrl}`;
   }
 
   public getFamilies(datasetId: string, groupName: string, counterId: number): Observable<string[]> {


### PR DESCRIPTION
## Background

Genome was not set (before it was set in datasets service).
When navigating to invalid dataset the error message was not shown.
When navigating to genotype browser from gene profiles single view and when logut while in dataset statistics the state of the selected dataset was null.

## Aim

Fix the issues.

## Implementation

Set the genome by getting it from state in constructor in RegionsFilter.
Add error handling for invalid dataset in url.
Save dataset id string in state which is needed to load genotype browser from single view.