### PR TITLE
Fix loading query

### DIFF
--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -111,11 +111,11 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
 
   private setupSelectedDataset(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.selectedDataset = state.selectedDataset;
-
-      if (!this.selectedDataset) {
+      if (!state.selectedDataset) {
         return;
       }
+
+      this.selectedDataset = state.selectedDataset;
 
       const firstTool = this.findFirstTool(this.selectedDataset);
 

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -12,6 +12,7 @@ import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-t
 import {
   GeneProfileSingleViewComponent
 } from 'app/gene-profiles-single-view/gene-profiles-single-view.component';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-gene-profiles-block',
@@ -24,6 +25,7 @@ export class GeneProfilesBlockComponent implements OnInit {
   public constructor(
     private geneProfilesService: GeneProfilesService,
     private queryService: QueryService,
+    private datasetsService: DatasetsService,
     private store: Store
   ) { }
 
@@ -174,7 +176,7 @@ export class GeneProfilesBlockComponent implements OnInit {
       .find(ps => ps.id === tokens[1]);
     const statistic = personSet.statistics.find(st => st.id === tokens[2]);
     GeneProfileSingleViewComponent.goToQuery(
-      this.store, this.queryService, $event.geneSymbol, personSet, datasetId, statistic, $event.newTab
+      this.store, this.queryService, this.datasetsService, $event.geneSymbol, personSet, datasetId, statistic, $event.newTab
     );
   }
 }

--- a/src/app/load-query/load-query.component.ts
+++ b/src/app/load-query/load-query.component.ts
@@ -50,7 +50,7 @@ export class LoadQueryComponent implements OnInit {
 
   private restoreQuery(state: object, page: string): void {
     if (page in PAGE_TYPE_TO_NAVIGATE) {
-      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['temporaryDatasetId']);
+      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['datasetState'].selectedDataset.id);
       this.store.reset(state);
       this.store.dispatch(new StateReset(ErrorsState));
       this.router.navigate(navigationParams);


### PR DESCRIPTION
## Background

- Error message when navigating to invalid dataset (like this /datasets/ALL_genotdfdfypes**/gene-browser**) was not shown always.
- Loading query from Datasets tools was broken.


## Aim

To fix the issues.

## Implementation

-  to show error message boolean variable has to be undefined. When the dataset is incorrect its value in state is null and the variable which we expect to be undefined is set to null. To prevent that, if condition as added before setting the variable.
- the method which is used to load queries reads the dataset id from state but the id can be stored in two ways - as string (dataset id only) when navigating from single view to dataset tools and as Dataset object when in Datasets. To prevent adding if condition, in single view we save Dataset object instead of an id only. 
