### PR TITLE
Save dataset id to state

### DIFF
--- a/src/app/categorical-filter/categorical-filter.component.ts
+++ b/src/app/categorical-filter/categorical-filter.component.ts
@@ -30,15 +30,15 @@ export class CategoricalFilterComponent implements OnInit {
   public ngOnInit(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => {
-        const selectedDataset = state.selectedDataset;
+        const selectedDatasetId = state.selectedDatasetId;
 
         if (this.categoricalFilter.from === 'phenodb') {
           this.sourceDescription$ = this.phenoBrowserService.getMeasureDescription(
-            selectedDataset.id, this.categoricalFilter.source
+            selectedDatasetId, this.categoricalFilter.source
           );
         } else if (this.categoricalFilter.from === 'pedigree') {
           this.sourceDescription$ = this.datasetsService.getDatasetPedigreeColumnDetails(
-            selectedDataset.id, this.categoricalFilter.source
+            selectedDatasetId, this.categoricalFilter.source
           );
         }
         return this.sourceDescription$;

--- a/src/app/dataset-description/dataset-description.component.ts
+++ b/src/app/dataset-description/dataset-description.component.ts
@@ -22,8 +22,11 @@ export class DatasetDescriptionComponent implements OnInit {
 
   public ngOnInit(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
-      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId)))
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId as string)))
       .subscribe(dataset => {
+        if (!dataset) {
+          return;
+        }
         this.dataset = dataset;
       });
   }

--- a/src/app/dataset-description/dataset-description.component.ts
+++ b/src/app/dataset-description/dataset-description.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DatasetsService } from '../datasets/datasets.service';
 import { Dataset } from '../datasets/datasets';
-import { take } from 'rxjs/operators';
+import { switchMap, take } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { DatasetModel } from 'app/datasets/datasets.state';
 
@@ -13,7 +13,6 @@ import { DatasetModel } from 'app/datasets/datasets.state';
 })
 export class DatasetDescriptionComponent implements OnInit {
   public dataset: Dataset;
-  public datasetId: string;
 
   public constructor(
     private route: ActivatedRoute,
@@ -22,13 +21,14 @@ export class DatasetDescriptionComponent implements OnInit {
   ) { }
 
   public ngOnInit(): void {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.dataset = state.selectedDataset;
-      this.datasetId = state.selectedDataset.id;
-    });
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId)))
+      .subscribe(dataset => {
+        this.dataset = dataset;
+      });
   }
 
   public writeDataset(markdown: string): void {
-    this.datasetsService.writeDatasetDescription(this.datasetId, markdown).pipe(take(1)).subscribe();
+    this.datasetsService.writeDatasetDescription(this.dataset.id, markdown).pipe(take(1)).subscribe();
   }
 }

--- a/src/app/dataset-node/dataset-node.component.html
+++ b/src/app/dataset-node/dataset-node.component.html
@@ -9,8 +9,8 @@
     >expand_more</span
   ><a
     class="dataset-dropdown-item dropdown-item"
-    *ngIf="selectedDataset"
-    [class.active]="selectedDataset.id === datasetNode.dataset.id"
+    *ngIf="selectedDatasetId"
+    [class.active]="selectedDatasetId === datasetNode.dataset.id"
     [style.opacity]="datasetNode.dataset.accessRights ? 1.0 : 0.3"
     [ngStyle]="{ 'padding-left': datasetNode.children.length ? 0 : 24 }"
     (click)="select()"

--- a/src/app/dataset-node/dataset-node.component.ts
+++ b/src/app/dataset-node/dataset-node.component.ts
@@ -1,12 +1,13 @@
 import { AfterContentChecked, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { Dataset } from 'app/datasets/datasets';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription, switchMap } from 'rxjs';
 import { DatasetNode } from './dataset-node';
 import { Store } from '@ngxs/store';
 import { StatefulComponent } from 'app/common/stateful-component';
 import { DatasetNodeModel, DatasetNodeState, SetExpandedDatasets } from './dataset-node.state';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-dataset-node',
@@ -16,7 +17,7 @@ import { DatasetModel } from 'app/datasets/datasets.state';
 export class DatasetNodeComponent extends StatefulComponent implements OnInit, AfterContentChecked {
   @Input() public datasetNode: DatasetNode;
   @Output() public setExpandabilityEvent = new EventEmitter<boolean>();
-  public selectedDataset: Dataset;
+  public selectedDatasetId: string;
   public isExpanded = false;
   public closeChildrenSubject: Subject<void> = new Subject<void>();
   @Input() public closeObservable: Observable<void> = new Observable<void>();
@@ -25,15 +26,16 @@ export class DatasetNodeComponent extends StatefulComponent implements OnInit, A
   public constructor(
     private router: Router,
     private changeDetector: ChangeDetectorRef,
-    protected store: Store
+    protected store: Store,
+    private datasetService: DatasetsService
   ) {
     super(store, DatasetNodeState, 'datasetNode');
   }
 
   public ngOnInit(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.selectedDataset = state.selectedDataset;
-      if (this.datasetNode.dataset.id === this.selectedDataset.id) {
+      this.selectedDatasetId = state.selectedDatasetId;
+      if (this.datasetNode.dataset.id === this.selectedDatasetId) {
         this.setExpandability();
       }
     });

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -10,7 +10,7 @@ import { Store } from '@ngxs/store';
 import { StateResetAll } from 'ngxs-reset-plugin';
 import { GeneProfilesState } from 'app/gene-profiles-table/gene-profiles-table.state';
 import { DatasetNodeModel, DatasetNodeState, SetExpandedDatasets } from 'app/dataset-node/dataset-node.state';
-import { DatasetModel, DatasetState, SetDataset } from './datasets.state';
+import { DatasetModel, DatasetState, SetDatasetId } from './datasets.state';
 import { StatefulComponent } from 'app/common/stateful-component';
 
 @Component({
@@ -52,7 +52,7 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
 
         this.datasetsService.getDataset(params['dataset'] as string).subscribe({
           next: dataset => {
-            this.store.dispatch(new SetDataset(dataset.id));
+            this.store.dispatch(new SetDatasetId(dataset.id));
             this.setupSelectedDataset();
           },
           error: () => {

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -52,8 +52,10 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
 
         this.datasetsService.getDataset(params['dataset'] as string).subscribe({
           next: dataset => {
-            this.store.dispatch(new SetDatasetId(dataset.id));
-            this.setupSelectedDataset();
+            if (dataset) {
+              this.store.dispatch(new SetDatasetId(dataset.id));
+              this.setupSelectedDataset();
+            }
           },
           error: () => {
             this.selectedDataset = undefined;

--- a/src/app/datasets/datasets.service.ts
+++ b/src/app/datasets/datasets.service.ts
@@ -52,6 +52,9 @@ export class DatasetsService {
   }
 
   public getDataset(datasetId: string): Observable<Dataset> {
+    if (!datasetId) {
+      return of();
+    }
     const url = `${this.datasetUrl}/${datasetId}`;
     const options = { headers: this.headers, withCredentials: true };
 

--- a/src/app/datasets/datasets.state.ts
+++ b/src/app/datasets/datasets.state.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 
-export class SetDataset {
+export class SetDatasetId {
   public static readonly type = '[Genotype] Set current dataset';
   public constructor(
     public selectedDatasetId: string
@@ -20,10 +20,10 @@ export interface DatasetModel {
 })
 @Injectable()
 export class DatasetState {
-  @Action(SetDataset)
+  @Action(SetDatasetId)
   public setDataset(
     ctx: StateContext<DatasetModel>,
-    action: SetDataset
+    action: SetDatasetId
   ): void {
     ctx.patchState({
       selectedDatasetId: action.selectedDatasetId

--- a/src/app/datasets/datasets.state.ts
+++ b/src/app/datasets/datasets.state.ts
@@ -1,22 +1,21 @@
 import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
-import { Dataset } from './datasets';
 
 export class SetDataset {
   public static readonly type = '[Genotype] Set current dataset';
   public constructor(
-    public selectedDataset: Dataset
+    public selectedDatasetId: string
   ) {}
 }
 
 export interface DatasetModel {
-    selectedDataset: Dataset;
+    selectedDatasetId: string;
 }
 
 @State<DatasetModel>({
   name: 'datasetState',
   defaults: {
-    selectedDataset: null
+    selectedDatasetId: ''
   },
 })
 @Injectable()
@@ -27,7 +26,7 @@ export class DatasetState {
     action: SetDataset
   ): void {
     ctx.patchState({
-      selectedDataset: action.selectedDataset
+      selectedDatasetId: action.selectedDatasetId
     });
   }
 }

--- a/src/app/enrichment-tool/enrichment-tool.component.html
+++ b/src/app/enrichment-tool/enrichment-tool.component.html
@@ -1,6 +1,6 @@
-<div *ngIf="selectedDataset" class="container" style="margin-bottom: 20px">
+<div *ngIf="selectedDatasetId" class="container" style="margin-bottom: 20px">
   <gpf-genes-block [showAllTab]="false"></gpf-genes-block>
-  <gpf-enrichment-models-block [selectedDatasetId]="selectedDataset.id"></gpf-enrichment-models-block>
+  <gpf-enrichment-models-block [selectedDatasetId]="selectedDatasetId"></gpf-enrichment-models-block>
 
   <div class="form-block button" style="display: inline-flex">
     <input

--- a/src/app/enrichment-tool/enrichment-tool.component.ts
+++ b/src/app/enrichment-tool/enrichment-tool.component.ts
@@ -5,7 +5,6 @@ import { Observable, of, Subscription, switchMap, zip } from 'rxjs';
 import { EnrichmentResults } from '../enrichment-query/enrichment-result';
 import { EnrichmentQueryService } from '../enrichment-query/enrichment-query.service';
 import { FullscreenLoadingService } from '../fullscreen-loading/fullscreen-loading.service';
-import { Dataset } from 'app/datasets/datasets';
 import { Select, Selector, Store } from '@ngxs/store';
 import { GenesBlockComponent } from 'app/genes-block/genes-block.component';
 import { EnrichmentModelsState } from 'app/enrichment-models/enrichment-models.state';

--- a/src/app/enrichment-tool/enrichment-tool.component.ts
+++ b/src/app/enrichment-tool/enrichment-tool.component.ts
@@ -19,7 +19,7 @@ import { DatasetModel } from 'app/datasets/datasets.state';
 })
 export class EnrichmentToolComponent implements OnInit, OnDestroy {
   public enrichmentResults: EnrichmentResults;
-  public selectedDataset: Dataset;
+  public selectedDatasetId: string;
   public disableQueryButtons = false;
 
   @Select(EnrichmentToolComponent.enrichmentToolStateSelector) public state$: Observable<object[]>;
@@ -40,9 +40,9 @@ export class EnrichmentToolComponent implements OnInit, OnDestroy {
         return zip(of(enrichmentState), datasetState$);
       })
     ).subscribe(([enrichmentState, datasetState]) => {
-      this.selectedDataset = datasetState.selectedDataset;
+      this.selectedDatasetId = datasetState.selectedDatasetId;
       this.enrichmentToolState = {
-        datasetId: this.selectedDataset.id,
+        datasetId: this.selectedDatasetId,
         ...enrichmentState
       };
       this.enrichmentResults = null;

--- a/src/app/family-filters-block/family-filters-block.component.spec.ts
+++ b/src/app/family-filters-block/family-filters-block.component.spec.ts
@@ -264,8 +264,7 @@ describe('FamilyFiltersBlockComponent', () => {
     component.dataset = datasetMock;
 
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel)

--- a/src/app/family-filters-block/family-filters-block.component.ts
+++ b/src/app/family-filters-block/family-filters-block.component.ts
@@ -59,8 +59,8 @@ export class FamilyFiltersBlockComponent implements OnInit, AfterViewInit {
 
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => {
-        const selectedDataset = state.selectedDataset;
-        return this.variantReportsService.getVariantReport(selectedDataset.id);
+        const selectedDatasetId = state.selectedDatasetId;
+        return this.variantReportsService.getVariantReport(selectedDatasetId);
       }),
       take(1)
     ).subscribe({

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -25,7 +25,6 @@ import {
   MatAutocomplete,
   MatAutocompleteOrigin,
   MatAutocompleteTrigger } from '@angular/material/autocomplete';
-import { Dataset } from 'app/datasets/datasets';
 import { DatasetModel } from 'app/datasets/datasets.state';
 
 jest.mock('../utils/svg-drawing');
@@ -126,8 +125,7 @@ describe('GeneBrowserComponent', () => {
     jest.spyOn(component['queryService'], 'getSummaryVariants');
 
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel)

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -84,6 +84,9 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
     ).subscribe(dataset => {
+      if (!dataset) {
+        return;
+      }
       this.selectedDataset = dataset;
       this.selectedDatasetId = dataset.id;
       this.legend = this.selectedDataset.personSetCollections

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -176,7 +176,13 @@ export class GeneProfilesBlockComponent implements OnInit {
       .find(ps => ps.id === tokens[1]);
     const statistic = personSet.statistics.find(st => st.id === tokens[2]);
     GeneProfileSingleViewComponent.goToQuery(
-      this.store, this.queryService, this.datasetsService, $event.geneSymbol, personSet, datasetId, statistic, $event.newTab
+      this.store,
+      this.queryService,
+      $event.geneSymbol,
+      personSet,
+      datasetId,
+      statistic,
+      $event.newTab
     );
   }
 }

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -68,7 +68,6 @@ export class GeneProfileSingleViewComponent implements OnInit {
     private router: Router,
     private queryService: QueryService,
     private store: Store,
-    private datasetsService: DatasetsService
   ) { }
 
   public errorModal = false;
@@ -167,7 +166,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
     statistic: GeneProfilesDatasetStatistic
   ): void {
     GeneProfileSingleViewComponent.goToQuery(
-      this.store, this.queryService, this.datasetsService, geneSymbol, personSet, datasetId, statistic
+      this.store, this.queryService, geneSymbol, personSet, datasetId, statistic
     );
   }
 
@@ -175,7 +174,6 @@ export class GeneProfileSingleViewComponent implements OnInit {
     store: Store,
     queryService:
     QueryService,
-    datasetsService: DatasetsService,
     geneSymbol: string,
     personSet: GeneProfilesDatasetPersonSet,
     datasetId: string,
@@ -220,13 +218,8 @@ export class GeneProfileSingleViewComponent implements OnInit {
     ]);
 
 
-    store.selectOnce((state: object) => state).pipe(
-      switchMap((state: object) => {
-        const dataset$ = datasetsService.getDataset(datasetId);
-        return zip(of(state), dataset$);
-      })
-    ).subscribe(([state, dataset]) => {
-      (state['datasetState'] as DatasetModel).selectedDataset = dataset;
+    store.selectOnce((state: object) => state).subscribe((state) => {
+      (state['datasetState'] as DatasetModel).selectedDatasetId = datasetId;
       queryService.saveQuery(state, 'genotype')
         .pipe(take(1))
         .subscribe(urlObject => {

--- a/src/app/gene-sets/gene-sets.component.spec.ts
+++ b/src/app/gene-sets/gene-sets.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgxsModule } from '@ngxs/store';
 import { ConfigService } from 'app/config/config.service';
-import { DatasetsService } from 'app/datasets/datasets.service';
 import { UsersService } from 'app/users/users.service';
 import { GeneSetsComponent } from './gene-sets.component';
 import { GeneSetsService } from './gene-sets.service';
@@ -20,7 +19,6 @@ import {
   MatAutocomplete,
   MatAutocompleteTrigger,
   MAT_AUTOCOMPLETE_SCROLL_STRATEGY } from '@angular/material/autocomplete';
-import { Dataset } from 'app/datasets/datasets';
 import { DatasetModel } from 'app/datasets/datasets.state';
 
 class MockGeneSetsService {
@@ -246,8 +244,7 @@ describe('GeneSetsComponent MockedGeneSetsService', () => {
     component = fixture.componentInstance;
 
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel),

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -61,7 +61,7 @@ export class GeneSetsComponent extends StatefulComponent implements OnInit {
         this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState),
       ))
     ).subscribe(([geneSetsCollections, geneSetsState, datasetState]) => {
-      this.selectedDatasetId = datasetState.selectedDataset.id;
+      this.selectedDatasetId = datasetState.selectedDatasetId;
 
       const denovoGeneSetTypes = geneSetsCollections.filter(
         geneSetCollection => geneSetCollection.name === 'denovo'

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div *ngIf="selectedDataset" class="container">
   <gpf-genes-block></gpf-genes-block>
   <gpf-regions-block></gpf-regions-block>
   <gpf-genotype-block [dataset]="selectedDataset"></gpf-genotype-block>

--- a/src/app/genotype-browser/genotype-browser.component.html
+++ b/src/app/genotype-browser/genotype-browser.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="selectedDataset" class="container">
   <gpf-genes-block></gpf-genes-block>
-  <gpf-regions-block></gpf-regions-block>
+  <gpf-regions-block [genome]="selectedDataset.genome"></gpf-regions-block>
   <gpf-genotype-block [dataset]="selectedDataset"></gpf-genotype-block>
   <gpf-study-filters-block *ngIf="selectedDataset?.genotypeBrowserConfig?.hasStudyFilters" [dataset]="selectedDataset">
   </gpf-study-filters-block>

--- a/src/app/genotype-browser/genotype-browser.component.spec.ts
+++ b/src/app/genotype-browser/genotype-browser.component.spec.ts
@@ -180,8 +180,7 @@ describe('GenotypeBrowserComponent', () => {
     loadingService = TestBed.inject(FullscreenLoadingService);
 
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeMock, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel)
@@ -204,6 +203,9 @@ describe('GenotypeBrowserComponent', () => {
         submit: jest.fn()
       }
     };
+    // eslint-disable-next-line max-len
+    component.selectedDataset = new Dataset('datasetId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeMock, null, [], null, null, '', null);
+
     component.onSubmit(mockEvent);
     expect(mockEvent.target.queryData.value).toStrictEqual(JSON.stringify({
       datasetId: component.selectedDataset.id,

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -14,11 +14,12 @@ import { FamilyFiltersBlockComponent } from 'app/family-filters-block/family-fil
 import { PersonFiltersBlockComponent } from 'app/person-filters-block/person-filters-block.component';
 import { UniqueFamilyVariantsFilterState } from 'app/unique-family-variants-filter/unique-family-variants-filter.state';
 import { ErrorsState, ErrorsModel } from '../common/errors.state';
-import { filter, take } from 'rxjs/operators';
+import { filter, switchMap, take } from 'rxjs/operators';
 import { StudyFiltersState } from 'app/study-filters/study-filters.state';
 import { clone } from 'lodash';
 import { NavigationStart, Router } from '@angular/router';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-genotype-browser',
@@ -85,7 +86,8 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
     public readonly configService: ConfigService,
     private loadingService: FullscreenLoadingService,
     private router: Router,
-    private store: Store
+    private store: Store,
+    private datasetsService: DatasetsService
   ) {
     this.routerSubscription = this.router.events.pipe(
       filter(event => event instanceof NavigationStart)
@@ -98,8 +100,10 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.genotypeBrowserState = {};
 
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.selectedDataset = state.selectedDataset;
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
+    ).subscribe(dataset => {
+      this.selectedDataset = dataset;
     });
 
     this.state$.subscribe(state => {

--- a/src/app/genotype-browser/genotype-browser.component.ts
+++ b/src/app/genotype-browser/genotype-browser.component.ts
@@ -103,6 +103,9 @@ export class GenotypeBrowserComponent implements OnInit, OnDestroy {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
     ).subscribe(dataset => {
+      if (!dataset) {
+        return;
+      }
       this.selectedDataset = dataset;
     });
 

--- a/src/app/load-query/load-query.component.ts
+++ b/src/app/load-query/load-query.component.ts
@@ -50,7 +50,7 @@ export class LoadQueryComponent implements OnInit {
 
   private restoreQuery(state: object, page: string): void {
     if (page in PAGE_TYPE_TO_NAVIGATE) {
-      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['datasetState'].selectedDataset.id);
+      const navigationParams: string[] = PAGE_TYPE_TO_NAVIGATE[page](state['datasetState'].selectedDatasetId);
       this.store.reset(state);
       this.store.dispatch(new StateReset(ErrorsState));
       this.router.navigate(navigationParams);

--- a/src/app/pedigree/pedigree.component.spec.ts
+++ b/src/app/pedigree/pedigree.component.spec.ts
@@ -5,7 +5,6 @@ import { VariantReportsService } from 'app/variant-reports/variant-reports.servi
 import { Observable, of } from 'rxjs';
 import { PedigreeComponent } from './pedigree.component';
 import { NgxsModule } from '@ngxs/store';
-import { Dataset } from 'app/datasets/datasets';
 import { DatasetModel } from 'app/datasets/datasets.state';
 
 class MockVariantReportsService {
@@ -35,9 +34,7 @@ describe('PedigreeComponent', () => {
     fixture = TestBed.createComponent(PedigreeComponent);
     component = fixture.componentInstance;
 
-    // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel)

--- a/src/app/pedigree/pedigree.component.ts
+++ b/src/app/pedigree/pedigree.component.ts
@@ -40,7 +40,7 @@ export class PedigreeComponent {
 
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => {
-        this.selectedDatasetId = state.selectedDataset.id;
+        this.selectedDatasetId = state.selectedDatasetId;
         return this.variantReportsService.getFamilies(
           this.selectedDatasetId,
           this.groupName,
@@ -74,7 +74,7 @@ export class PedigreeComponent {
 
   public onSubmit(event): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      const selectedDatasetId = state.selectedDataset.id;
+      const selectedDatasetId = state.selectedDatasetId;
       const args = {
         study_id: selectedDatasetId,
         group_name: this.groupName,

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -33,6 +33,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { NgxsModule } from '@ngxs/store';
 import { Dataset } from 'app/datasets/datasets';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 const fakeJsonMeasurei1 = JSON.parse(JSON.stringify(fakeJsonMeasureOneRegression)) as object;
 fakeJsonMeasurei1['instrument_name'] = 'i1';
@@ -69,6 +70,12 @@ class MockPhenoBrowserService {
 
   public getDownloadMeasuresLink(): string {
     return '';
+  }
+}
+class MockDatasetsService {
+  public getDataset(datasetId: string): Observable<Dataset> {
+    // eslint-disable-next-line max-len
+    return of(new Dataset(datasetId, 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null));
   }
 }
 
@@ -110,6 +117,7 @@ describe('PhenoBrowserComponent', () => {
   let location: Location;
   const activatedRoute = new MockActivatedRoute();
   const phenoBrowserServiceMock = new MockPhenoBrowserService();
+  const mockDatasetsService = new MockDatasetsService();
 
   let locationSpy;
   const resizeSpy = {
@@ -136,6 +144,7 @@ describe('PhenoBrowserComponent', () => {
         HttpClient,
         HttpHandler,
         { provide: PhenoBrowserService, useValue: phenoBrowserServiceMock },
+        { provide: DatasetsService, useValue: mockDatasetsService },
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useClass: MockRouter },
         { provide: Location, useValue: locationSpy as object},
@@ -151,9 +160,7 @@ describe('PhenoBrowserComponent', () => {
     fixture = TestBed.createComponent(PhenoBrowserComponent);
     component = fixture.componentInstance;
 
-    // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel)

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -11,6 +11,7 @@ import { ConfigService } from 'app/config/config.service';
 import { HttpClient } from '@angular/common/http';
 import { Store } from '@ngxs/store';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-pheno-browser',
@@ -41,12 +42,15 @@ export class PhenoBrowserComponent implements OnInit {
     private phenoBrowserService: PhenoBrowserService,
     private location: Location,
     public configService: ConfigService,
-    private store: Store
+    private store: Store,
+    private datasetsService: DatasetsService
   ) { }
 
   public ngOnInit(): void {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.selectedDataset = state.selectedDataset;
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
+    ).subscribe(dataset => {
+      this.selectedDataset = dataset;
 
       this.initInstruments(this.selectedDataset.id);
       this.initMeasuresToShow(this.selectedDataset.id);

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -50,6 +50,9 @@ export class PhenoBrowserComponent implements OnInit {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
     ).subscribe(dataset => {
+      if (!dataset) {
+        return;
+      }
       this.selectedDataset = dataset;
 
       this.initInstruments(this.selectedDataset.id);

--- a/src/app/pheno-tool-measure/pheno-tool-measure.component.spec.ts
+++ b/src/app/pheno-tool-measure/pheno-tool-measure.component.spec.ts
@@ -9,9 +9,9 @@ import { UsersService } from 'app/users/users.service';
 import { APP_BASE_HREF } from '@angular/common';
 
 import { PhenoToolMeasureComponent } from './pheno-tool-measure.component';
-import { Dataset } from 'app/datasets/datasets';
 import { DatasetModel } from 'app/datasets/datasets.state';
 import { of } from 'rxjs';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 describe('PhenoToolMeasureComponent', () => {
   let component: PhenoToolMeasureComponent;
@@ -28,6 +28,7 @@ describe('PhenoToolMeasureComponent', () => {
         HttpHandler,
         ConfigService,
         UsersService,
+        DatasetsService,
         { provide: APP_BASE_HREF, useValue: '' }
       ],
       imports: [RouterTestingModule, NgxsModule.forRoot([], {developmentMode: true})],
@@ -38,8 +39,7 @@ describe('PhenoToolMeasureComponent', () => {
     component = fixture.componentInstance;
 
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     component['store'] = {
       selectOnce: () => of(selectedDatasetMockModel),

--- a/src/app/pheno-tool-measure/pheno-tool-measure.component.ts
+++ b/src/app/pheno-tool-measure/pheno-tool-measure.component.ts
@@ -11,6 +11,7 @@ import { switchMap, take } from 'rxjs/operators';
 import { Dataset } from 'app/datasets/datasets';
 import { PhenoMeasureSelectorComponent } from 'app/pheno-measure-selector/pheno-measure-selector.component';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 interface Regression {
   display_name: string;
@@ -41,6 +42,7 @@ export class PhenoToolMeasureComponent extends StatefulComponent implements OnIn
   public constructor(
     protected store: Store,
     private measuresService: MeasuresService,
+    private datasetsService: DatasetsService
   ) {
     super(store, PhenoToolMeasureState, 'phenoToolMeasure');
   }
@@ -49,8 +51,9 @@ export class PhenoToolMeasureComponent extends StatefulComponent implements OnIn
     super.ngOnInit();
 
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
-      switchMap((state: DatasetModel) => {
-        this.dataset = state.selectedDataset;
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId)),
+      switchMap(dataset => {
+        this.dataset = dataset;
         if (this.dataset?.phenotypeData) {
           return this.measuresService.getRegressions(this.dataset.id).pipe(take(1));
         } else {

--- a/src/app/pheno-tool-measure/pheno-tool-measure.component.ts
+++ b/src/app/pheno-tool-measure/pheno-tool-measure.component.ts
@@ -53,6 +53,9 @@ export class PhenoToolMeasureComponent extends StatefulComponent implements OnIn
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId)),
       switchMap(dataset => {
+        if (!dataset) {
+          return;
+        }
         this.dataset = dataset;
         if (this.dataset?.phenotypeData) {
           return this.measuresService.getRegressions(this.dataset.id).pipe(take(1));

--- a/src/app/pheno-tool/pheno-tool.component.spec.ts
+++ b/src/app/pheno-tool/pheno-tool.component.spec.ts
@@ -21,6 +21,7 @@ import { HttpResponse } from '@angular/common/http';
 import { PhenoToolResults } from './pheno-tool-results';
 import { Dataset, GenotypeBrowser, PersonFilter } from 'app/datasets/datasets';
 import { DatasetModel, DatasetState } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 class PhenoToolServiceMock {
   public getPhenoToolResults(): Observable<PhenoToolResults> {
@@ -32,11 +33,21 @@ class PhenoToolServiceMock {
   }
 }
 
+class MockDatasetsService {
+  public getDataset(datasetId: string): Observable<Dataset> {
+    // eslint-disable-next-line max-len
+    const genotypeBrowserConfigMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, new Array<object>(), new Array<PersonFilter>(), new Array<PersonFilter>(), [], [], [], [], 0);
+    // eslint-disable-next-line max-len
+    return of(new Dataset(datasetId, 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeBrowserConfigMock, null, [], null, null, '', null));
+  }
+}
+
 describe('PhenoToolComponent', () => {
   let component: PhenoToolComponent;
   let fixture: ComponentFixture<PhenoToolComponent>;
   let store: Store;
   const phenoToolMockService = new PhenoToolServiceMock();
+  const mockDatasetsService = new MockDatasetsService();
 
   beforeEach(waitForAsync(() => {
     const configMock = { baseUrl: 'testUrl/' };
@@ -51,6 +62,7 @@ describe('PhenoToolComponent', () => {
         {provide: ActivatedRoute, useValue: new ActivatedRoute()},
         {provide: ConfigService, useValue: configMock},
         {provide: PhenoToolService, useValue: phenoToolMockService},
+        { provide: DatasetsService, useValue: mockDatasetsService },
         UsersService,
         FullscreenLoadingService,
         MeasuresService,
@@ -63,15 +75,13 @@ describe('PhenoToolComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
-
+    
     fixture = TestBed.createComponent(PhenoToolComponent);
     component = fixture.componentInstance;
-
+    
     // eslint-disable-next-line max-len
-    const genotypeBrowserConfigMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, new Array<object>(), new Array<PersonFilter>(), new Array<PersonFilter>(), [], [], [], [], 0);
     // eslint-disable-next-line max-len
-    const selectedDatasetMock = new Dataset('testId', 'desc', '', 'testDataset', [], true, [], [], [], 'phenotypeData', true, false, true, true, null, genotypeBrowserConfigMock, null, [], null, null, '', null);
-    const selectedDatasetMockModel: DatasetModel = {selectedDataset: selectedDatasetMock};
+    const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};
 
     store = TestBed.inject(Store);
     jest.spyOn(store, 'selectOnce').mockReturnValue(of(selectedDatasetMockModel));

--- a/src/app/pheno-tool/pheno-tool.component.ts
+++ b/src/app/pheno-tool/pheno-tool.component.ts
@@ -65,6 +65,9 @@ export class PhenoToolComponent implements OnInit, OnDestroy {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
     ).subscribe(dataset => {
+      if (!dataset) {
+        return;
+      }
       this.selectedDataset = dataset;
       this.variantTypesSet = new Set(this.selectedDataset.genotypeBrowserConfig.variantTypes);
     });

--- a/src/app/pheno-tool/pheno-tool.component.ts
+++ b/src/app/pheno-tool/pheno-tool.component.ts
@@ -4,7 +4,7 @@ import { FullscreenLoadingService } from '../fullscreen-loading/fullscreen-loadi
 import { PhenoToolService } from './pheno-tool.service';
 import { PhenoToolResults } from './pheno-tool-results';
 import { ConfigService } from '../config/config.service';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, switchMap } from 'rxjs';
 import { GenesBlockComponent } from 'app/genes-block/genes-block.component';
 import { PhenoToolGenotypeBlockComponent } from 'app/pheno-tool-genotype-block/pheno-tool-genotype-block.component';
 import { FamilyFiltersBlockComponent } from 'app/family-filters-block/family-filters-block.component';
@@ -15,6 +15,7 @@ import {
   PHENO_TOOL_CNV, PHENO_TOOL_LGDS, PHENO_TOOL_OTHERS
 } from 'app/pheno-tool-effect-types/pheno-tool-effect-types';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-pheno-tool',
@@ -39,7 +40,8 @@ export class PhenoToolComponent implements OnInit, OnDestroy {
     private loadingService: FullscreenLoadingService,
     private phenoToolService: PhenoToolService,
     public readonly configService: ConfigService,
-    private store: Store
+    private store: Store,
+    private datasetsService: DatasetsService
   ) { }
 
   @Selector([
@@ -60,8 +62,10 @@ export class PhenoToolComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): void {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.selectedDataset = state.selectedDataset;
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
+    ).subscribe(dataset => {
+      this.selectedDataset = dataset;
       this.variantTypesSet = new Set(this.selectedDataset.genotypeBrowserConfig.variantTypes);
     });
 

--- a/src/app/regions-block/regions-block.component.html
+++ b/src/app/regions-block/regions-block.component.html
@@ -8,7 +8,7 @@
       <li [ngbNavItem]="'regionsFilter'" id="regions-filter">
         <a ngbNavLink>Regions Filter</a>
         <ng-template ngbNavContent>
-          <gpf-regions-filter></gpf-regions-filter>
+          <gpf-regions-filter [genome]="genome"></gpf-regions-filter>
         </ng-template>
       </li>
     </ul>

--- a/src/app/regions-block/regions-block.component.ts
+++ b/src/app/regions-block/regions-block.component.ts
@@ -1,7 +1,7 @@
-import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, ViewChild, AfterViewInit, Input } from '@angular/core';
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngxs/store';
-import { RegionsFilterState } from 'app/regions-filter/regions-filter.state';
+import { RegionsFilterModel, RegionsFilterState } from 'app/regions-filter/regions-filter.state';
 import { StateReset } from 'ngxs-reset-plugin';
 
 @Component({
@@ -11,11 +11,12 @@ import { StateReset } from 'ngxs-reset-plugin';
 })
 export class RegionsBlockComponent implements AfterViewInit {
   @ViewChild('nav') public ngbNav: NgbNav;
+  @Input() public genome: string;
 
   public constructor(private store: Store) { }
 
   public ngAfterViewInit(): void {
-    this.store.selectOnce(RegionsFilterState).subscribe(state => {
+    this.store.selectOnce(RegionsFilterState).subscribe((state: RegionsFilterModel) => {
       if (state.regionsFilters.length) {
         setTimeout(() => this.ngbNav.select('regionsFilter'));
       }

--- a/src/app/regions-filter/regions-filter.component.ts
+++ b/src/app/regions-filter/regions-filter.component.ts
@@ -4,16 +4,17 @@ import { Store } from '@ngxs/store';
 import { RegionsFilterState, SetRegionsFilter } from './regions-filter.state';
 import { ValidateNested } from 'class-validator';
 import { StatefulComponent } from 'app/common/stateful-component';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-regions-filter',
   templateUrl: './regions-filter.component.html',
 })
 export class RegionsFilterComponent extends StatefulComponent implements OnInit {
-  @ValidateNested() public regionsFilter = new RegionsFilter(this.store);
+  @ValidateNested() public regionsFilter = new RegionsFilter(this.store, this.datsetsService);
   @ViewChild('textArea') private textArea: ElementRef;
 
-  public constructor(protected store: Store) {
+  public constructor(protected store: Store, private datsetsService: DatasetsService) {
     super(store, RegionsFilterState, 'regionsFilter');
   }
 

--- a/src/app/regions-filter/regions-filter.component.ts
+++ b/src/app/regions-filter/regions-filter.component.ts
@@ -4,7 +4,6 @@ import { Store } from '@ngxs/store';
 import { RegionsFilterModel, RegionsFilterState, SetRegionsFilter } from './regions-filter.state';
 import { ValidateNested } from 'class-validator';
 import { StatefulComponent } from 'app/common/stateful-component';
-import { DatasetsService } from 'app/datasets/datasets.service';
 
 @Component({
   selector: 'gpf-regions-filter',
@@ -15,7 +14,7 @@ export class RegionsFilterComponent extends StatefulComponent implements OnInit 
   @ValidateNested() public regionsFilter = new RegionsFilter();
   @ViewChild('textArea') private textArea: ElementRef;
 
-  public constructor(protected store: Store, private datsetsService: DatasetsService) {
+  public constructor(protected store: Store) {
     super(store, RegionsFilterState, 'regionsFilter');
   }
 

--- a/src/app/regions-filter/regions-filter.component.ts
+++ b/src/app/regions-filter/regions-filter.component.ts
@@ -1,7 +1,7 @@
 import { RegionsFilter } from './regions-filter';
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { Store } from '@ngxs/store';
-import { RegionsFilterState, SetRegionsFilter } from './regions-filter.state';
+import { RegionsFilterModel, RegionsFilterState, SetRegionsFilter } from './regions-filter.state';
 import { ValidateNested } from 'class-validator';
 import { StatefulComponent } from 'app/common/stateful-component';
 import { DatasetsService } from 'app/datasets/datasets.service';
@@ -11,7 +11,8 @@ import { DatasetsService } from 'app/datasets/datasets.service';
   templateUrl: './regions-filter.component.html',
 })
 export class RegionsFilterComponent extends StatefulComponent implements OnInit {
-  @ValidateNested() public regionsFilter = new RegionsFilter(this.store, this.datsetsService);
+  @Input() public genome = '';
+  @ValidateNested() public regionsFilter = new RegionsFilter();
   @ViewChild('textArea') private textArea: ElementRef;
 
   public constructor(protected store: Store, private datsetsService: DatasetsService) {
@@ -21,9 +22,11 @@ export class RegionsFilterComponent extends StatefulComponent implements OnInit 
   public ngOnInit(): void {
     super.ngOnInit();
     this.focusTextInputArea();
-    this.store.selectOnce(state => state.regionsFiltersState).subscribe(state => {
-      this.setRegionsFilter(state.regionsFilters.join('\n'));
-    });
+    this.regionsFilter.genome = this.genome;
+    this.store.selectOnce((state: { regionsFiltersState: RegionsFilterModel}) => state.regionsFiltersState)
+      .subscribe(state => {
+        this.setRegionsFilter(state.regionsFilters.join('\n'));
+      });
   }
 
   public setRegionsFilter(regionsFilter: string): void {

--- a/src/app/regions-filter/regions-filter.ts
+++ b/src/app/regions-filter/regions-filter.ts
@@ -2,15 +2,19 @@ import { RegionsFilterValidator } from './regions-filter.validator';
 import { Validate } from 'class-validator';
 import { DatasetModel } from 'app/datasets/datasets.state';
 import { Store } from '@ngxs/store';
+import { switchMap } from 'rxjs';
+import { DatasetsService } from 'app/datasets/datasets.service';
 
 export class RegionsFilter {
   @Validate(RegionsFilterValidator)
   public regionsFilter = '';
   public genome = '';
 
-  public constructor(public store: Store) {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(state => {
-      this.genome = state.selectedDataset.genome;
+  public constructor(public store: Store, private datasetsService: DatasetsService) {
+    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap(state => this.datasetsService.getDataset(state.selectedDatasetId))
+    ).subscribe(dataset => {
+      this.genome = dataset.genome;
     });
   }
 }

--- a/src/app/regions-filter/regions-filter.ts
+++ b/src/app/regions-filter/regions-filter.ts
@@ -1,21 +1,9 @@
 import { RegionsFilterValidator } from './regions-filter.validator';
 import { Validate } from 'class-validator';
-import { DatasetModel } from 'app/datasets/datasets.state';
-import { Store } from '@ngxs/store';
-import { switchMap } from 'rxjs';
-import { DatasetsService } from 'app/datasets/datasets.service';
 
 export class RegionsFilter {
   @Validate(RegionsFilterValidator)
   public regionsFilter = '';
   public genome = '';
-
-  public constructor(public store: Store, private datasetsService: DatasetsService) {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
-      switchMap(state => this.datasetsService.getDataset(state.selectedDatasetId))
-    ).subscribe(dataset => {
-      this.genome = dataset.genome;
-    });
-  }
 }
 

--- a/src/app/regions-filter/regions-filter.validator.ts
+++ b/src/app/regions-filter/regions-filter.validator.ts
@@ -3,6 +3,7 @@ import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface 
 @ValidatorConstraint({ name: 'customText', async: false })
 export class RegionsFilterValidator implements ValidatorConstraintInterface {
   public validate(text: string, args: ValidationArguments): boolean {
+    const genome = args.object['genome'] as string;
     if (!text) {
       return null;
     }
@@ -19,9 +20,8 @@ export class RegionsFilterValidator implements ValidatorConstraintInterface {
     }
 
     for (const region of regions) {
-      valid = valid && this.isRegionValid(region, args.object['genome'] as string);
+      valid = valid && this.isRegionValid(region, genome);
     }
-
     return valid;
   }
 
@@ -32,7 +32,6 @@ export class RegionsFilterValidator implements ValidatorConstraintInterface {
       chromRegex = 'chr' + chromRegex;
     }
     const lineRegex = `${chromRegex}:([0-9]+)(?:-([0-9]+))?|${chromRegex}`;
-
     const match = region.match(new RegExp(lineRegex, 'i'));
     if (match === null || match[0] !== region) {
       return false;

--- a/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
+++ b/src/app/unique-family-variants-filter/unique-family-variants-filter.component.ts
@@ -38,7 +38,7 @@ export class UniqueFamilyVariantsFilterComponent extends StatefulComponent imple
     });
 
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).subscribe(async state => {
-      const selectedDatasetId = state.selectedDataset.id;
+      const selectedDatasetId = state.selectedDatasetId;
       const childLeaves = await this.datasetsTreeService.getUniqueLeafNodes(selectedDatasetId);
       if (childLeaves.size > 1) {
         this.isVisible = true;

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -97,7 +97,7 @@
         <form
           id="dl-form"
           (ngSubmit)="downloadTags($event)"
-          action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDataset.id }}"
+          action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDatasetId }}"
           method="post"
           style="display: flex; align-items: center">
           <span>Selected families: </span><span id="families-sum">{{ filteredFamiliesCount + ' / ' + totalFamiliesCount }}</span>

--- a/src/app/variant-reports/variant-reports.component.ts
+++ b/src/app/variant-reports/variant-reports.component.ts
@@ -49,7 +49,7 @@ export class VariantReportsComponent implements OnInit {
   public familiesCounters: FamilyCounter[];
   public pedigreeTables: PedigreeTable[];
 
-  public selectedDataset: Dataset;
+  public selectedDatasetId: string;
 
   public imgPathPrefix = environment.imgPathPrefix;
   public orderedTagList = [];
@@ -81,8 +81,8 @@ export class VariantReportsComponent implements OnInit {
   public ngOnInit(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => {
-        this.selectedDataset = state.selectedDataset;
-        return this.variantReportsService.getVariantReport(this.selectedDataset.id);
+        this.selectedDatasetId = state.selectedDatasetId;
+        return this.variantReportsService.getVariantReport(this.selectedDatasetId);
       }),
       take(1)
     ).subscribe(params => {
@@ -252,7 +252,7 @@ export class VariantReportsComponent implements OnInit {
   }
 
   public getDownloadLink(): string {
-    return this.variantReportsService.getDownloadLink() + this.selectedDataset.id;
+    return this.variantReportsService.getDownloadLink() + this.selectedDatasetId;
   }
 
   public downloadTags(event): void {


### PR DESCRIPTION
## Background

Saving Dataset object in state causes bugs.

## Aim

To save dataset id only in state.

## Implementation

Save dataset id in state and if the component need the dataset it makes request using datasetsService method getDataset(datasetId: string) when it loads the id from state. This led to issues when validating regions filter after loading a query (share/save query) - genome wasn't passed on time. So the way of passing the genome is changed.
