### PR TITLE
gene browser: coding only checkbox no longer clears gene symbol input

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -35,10 +35,9 @@
         </mat-autocomplete>
 
         <div style="padding-left: 16px">
-          <label>
+          <label onmousedown="event.preventDefault()" (click)="toggleCodingOnly($event)">
             <input
-              (change)="reset()"
-              style="margin-right: 6px"
+              style="margin-right: 6px; pointer-events: none"
               type="checkbox"
               id="coding-only-checkbox"
               [(ngModel)]="summaryVariantsFilter.codingOnly" />Coding only</label

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -166,6 +166,12 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
     this.location.replaceState(`datasets/${this.selectedDatasetId}/gene-browser`);
   }
 
+  public toggleCodingOnly($event): void {
+    $event.preventDefault();
+    this.showResults = false;
+    this.summaryVariantsFilter.codingOnly = !this.summaryVariantsFilter.codingOnly;
+  }
+
   public async submitGeneRequest(geneSymbol?: string): Promise<void> {
     (this.searchBox?.nativeElement as HTMLElement)?.blur();
 


### PR DESCRIPTION
closes #1084

also clicking on the checkbox no longer closes the dropdown