### PR TITLE
fix datasets component dataset loading race condition

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,7 +22,7 @@
           >Gene Profiles</a
         >
         <a
-        [routerLink]="'/datasets'"
+        [routerLink]="'/datasets/' + datasetId"
         routerLinkActive="highlighted-route"
         title="Datasets"
         id="datasets">Datasets</a

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,8 @@ import { switchMap } from 'rxjs/operators';
 import { GeneProfilesService } from './gene-profiles-block/gene-profiles.service';
 import { GeneProfilesSingleViewConfig } from './gene-profiles-single-view/gene-profiles-single-view';
 import { NgbConfig } from '@ng-bootstrap/ng-bootstrap';
+import { Store } from '@ngxs/store';
+import { DatasetModel } from './datasets/datasets.state';
 
 @Component({
   selector: 'gpf-root',
@@ -15,6 +17,7 @@ import { NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 export class AppComponent implements OnInit {
   public title = 'GPF: Genotypes and Phenotypes in Families';
   public imgPathPrefix = environment.imgPathPrefix;
+  public datasetId = '';
   public geneProfilesConfig: GeneProfilesSingleViewConfig;
   private sessionTimeoutInSeconds = 7 * 24 * 60 * 60; // 1 week
 
@@ -32,7 +35,8 @@ export class AppComponent implements OnInit {
     private geneProfilesService: GeneProfilesService,
     private bnIdle: BnNgIdleService,
     private usersService: UsersService,
-    private ngbConfig: NgbConfig
+    private ngbConfig: NgbConfig,
+    protected store: Store,
   ) {
     ngbConfig.animation = false;
   }
@@ -43,6 +47,10 @@ export class AppComponent implements OnInit {
         switchMap(() => this.usersService.logout()),
         switchMap(() => this.usersService.getUserInfo()),
       ).subscribe();
+    this.store.select((state: { datasetState: DatasetModel}) => state.datasetState)
+      .subscribe(datasetState => {
+        this.datasetId = datasetState.selectedDatasetId;
+      });
 
     this.geneProfilesService.getConfig().subscribe(res => {
       this.geneProfilesConfig = res;

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -83,9 +83,6 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
           this.router.navigate(['/', 'datasets', this.datasetTrees[0].dataset.id]);
         }
       }),
-      this.usersService.getUserInfoObservable().subscribe(() => {
-        this.setupSelectedDataset();
-      }),
       this.datasetsService.getPermissionDeniedPrompt().subscribe(aprompt => {
         this.permissionDeniedPrompt = aprompt;
       }),


### PR DESCRIPTION
## Background
When a dataset id is saved in the state, navigating to datasets page triggered both logics for selecting current dataset: selecting first dataset because url is empty and selecting dataset id from the state.

## Aim
Fix datasets page using two methods to load a dataset when state is used.

## Implementation
When navigating through the main navbar the datasets page url includes the current dataset id that is saved in the state. This way the dataset page reads the id through the url and the "load first dataset" logic is skipped.
