### PR TITLE
Add gene profiles reset button

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -78,7 +78,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   public variantsCountDisplay: string;
-  public variantsCount: number;
+  public variantsCount = -1;
 
   public async ngOnInit(): Promise<void> {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(

--- a/src/app/gene-profiles-block/gene-profiles-block.component.html
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.html
@@ -1,5 +1,6 @@
 <gpf-gene-profiles-table
   *ngIf="geneProfilesTableConfig"
   (goToQueryEvent)="goToQueryEventHandler($event)"
+  (resetConfig)="resetConf()"
   [config]="geneProfilesTableConfig">
 </gpf-gene-profiles-table>

--- a/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
@@ -18,6 +18,7 @@ import { GeneProfilesSingleViewConfig } from 'app/gene-profiles-single-view/gene
 import { TruncatePipe } from '../utils/truncate.pipe';
 import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-table/gene-profiles-table';
 import { GeneProfilesState } from 'app/gene-profiles-table/gene-profiles-table.state';
+import { cloneDeep } from 'lodash';
 
 const config = {
   geneLinkTemplates: [
@@ -166,5 +167,16 @@ describe('GeneProfilesBlockComponent', () => {
     component.ngOnInit();
     expect(component.geneProfilesTableConfig).toStrictEqual(geneProfilesTableConfigMock);
     expect(component.geneProfilesSingleViewConfig).toStrictEqual(config);
+  });
+
+  it('should reset table configuration', () => {
+    component.ngOnInit();
+    const oldTableConfig = cloneDeep(component.geneProfilesTableConfig);
+
+    component.geneProfilesTableConfig.columns = [];
+
+    expect(component.geneProfilesTableConfig).not.toStrictEqual(oldTableConfig);
+    component.resetConf();
+    expect(component.geneProfilesTableConfig).toStrictEqual(oldTableConfig);
   });
 });

--- a/src/app/gene-profiles-block/gene-profiles-block.component.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.ts
@@ -13,6 +13,7 @@ import {
   GeneProfileSingleViewComponent
 } from 'app/gene-profiles-single-view/gene-profiles-single-view.component';
 import { DatasetsService } from 'app/datasets/datasets.service';
+import { cloneDeep } from 'lodash';
 
 @Component({
   selector: 'gpf-gene-profiles-block',
@@ -21,6 +22,7 @@ import { DatasetsService } from 'app/datasets/datasets.service';
 export class GeneProfilesBlockComponent implements OnInit {
   public geneProfilesTableConfig: GeneProfilesTableConfig;
   public geneProfilesSingleViewConfig: GeneProfilesSingleViewConfig;
+  private geneProfilesTableConfigOriginal: GeneProfilesTableConfig;
 
   public constructor(
     private geneProfilesService: GeneProfilesService,
@@ -30,15 +32,25 @@ export class GeneProfilesBlockComponent implements OnInit {
   ) { }
 
   public ngOnInit(): void {
-    this.geneProfilesService.getConfig().pipe(
-      map(config => this.createTableConfig(config))
-    ).subscribe((config: GeneProfilesTableConfig) => {
-      this.geneProfilesTableConfig = config;
-    });
+    this.getConfig();
 
     this.geneProfilesService.getConfig().pipe(take(1)).subscribe(config => {
       this.geneProfilesSingleViewConfig = config;
     });
+  }
+
+  public getConfig(): void {
+    this.geneProfilesService.getConfig().pipe(
+      map(config => this.createTableConfig(config)
+      )
+    ).subscribe((config: GeneProfilesTableConfig) => {
+      this.geneProfilesTableConfig = config;
+      this.geneProfilesTableConfigOriginal = cloneDeep(config);
+    });
+  }
+
+  public resetConf(): void {
+    this.geneProfilesTableConfig = cloneDeep(this.geneProfilesTableConfigOriginal);
   }
 
   private createTableConfig(config: GeneProfilesSingleViewConfig): GeneProfilesTableConfig {

--- a/src/app/gene-profiles-table/gene-profiles-table.component.css
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.css
@@ -408,3 +408,11 @@
 .active-tab > .close-tab-button {
   color: white;
 }
+
+#reset-button {
+  margin-left: 10px;
+  font-size: 17px;
+  border: transparent;
+  background-color: transparent;
+  color: #0645ad;
+}

--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -176,8 +176,8 @@
           ><br />
         </div>
 
-        <div id="reset-button" (click)="resetState()">
-          <a>Reset</a>
+        <div>
+          <button id="reset-button" (click)="resetState()">Reset table</button>
         </div>
       </div>
     </div>

--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -175,6 +175,10 @@
           <span class="keybinds-tooltip-command">Compare highlights</span><span class="keybinds-tooltip-key">C</span
           ><br />
         </div>
+
+        <div id="reset-button" (click)="resetState()">
+          <a>Reset</a>
+        </div>
       </div>
     </div>
   </ng-template>

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -4,7 +4,7 @@ import { plainToClass } from 'class-transformer';
 import { Observable, of } from 'rxjs';
 import { cloneDeep } from 'lodash';
 import { GeneProfilesTableService } from './gene-profiles-table.service';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NgxsModule, Store } from '@ngxs/store';
 import { GeneProfilesModel } from './gene-profiles-table.state';
@@ -17,7 +17,7 @@ const column1 = {
   displayVertical: false,
   id: 'column1',
   meta: null,
-  sortable: false,
+  sortable: true,
   visible: true
 };
 
@@ -254,7 +254,9 @@ describe('GeneProfilesTableComponent', () => {
   let component: GeneProfilesTableComponent;
   const geneProfilesTableServiceMock = new GeneProfilesTableServiceMock();
   const mockActivatedRoute = new MockActivatedRoute();
+  let fixture: ComponentFixture<GeneProfilesTableComponent>;
   let store: Store;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [GeneProfilesTableComponent, TruncatePipe],
@@ -265,7 +267,7 @@ describe('GeneProfilesTableComponent', () => {
       imports: [NgxsModule.forRoot([], {developmentMode: true})]
     }).compileComponents();
 
-    const fixture = TestBed.createComponent(GeneProfilesTableComponent);
+    fixture = TestBed.createComponent(GeneProfilesTableComponent);
     component = fixture.componentInstance;
 
     component.sortingButtonsComponents = [];
@@ -484,5 +486,48 @@ describe('GeneProfilesTableComponent', () => {
       'column321',
       'column322']);
     expect(component.sortBy).toBe('column1');
+  });
+
+  it('should reset table state', () => {
+    component.tabs = new Set(['POGZ']);
+    component.loadedSearchValue = 'chd';
+    component.highlightedGenes = new Set(['CHD8']);
+    component.orderBy = 'desc';
+    component.sortBy = 'column1';
+
+    component.hideTable = false;
+    component.config = cloneDeep(configMock);
+    fixture.detectChanges();
+
+
+    component.resetState();
+    expect(component.tabs).toStrictEqual(new Set());
+    expect(component.loadedSearchValue).toBe('');
+    expect(component.highlightedGenes).toStrictEqual(new Set());
+    expect(component.orderBy).toBe('desc');
+    expect(component.sortBy).toBe('column1');
+  });
+
+  it('should reset table header state', () => {
+    component.leavesIds = [
+      'column1',
+      'column21',
+      'column322'];
+
+    component.stateFinishedLoading = true;
+
+    component.config = cloneDeep(configMock);
+    component.ngOnInit();
+
+    component.ngOnChanges();
+    expect(component.leavesIds).toStrictEqual([
+      'column1',
+      'column21',
+      'column22',
+      'column311',
+      'column312',
+      'column321',
+      'column322'
+    ]);
   });
 });

--- a/src/app/gene-profiles-table/gene-profiles-table.service.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.service.ts
@@ -26,14 +26,14 @@ export class GeneProfilesTableService {
   ) {}
 
   public getUserGeneProfilesState(): Observable<GeneProfilesModel> {
-    if (!this.user.cachedUserInfo().loggedIn) {
+    if (!this.user.cachedUserInfo()?.loggedIn) {
       return of(null);
     }
     return this.http.get<GeneProfilesModel>(this.config.baseUrl + this.usersUrl, { withCredentials: true });
   }
 
   public saveUserGeneProfilesState(): void {
-    if (!this.user.cachedUserInfo().loggedIn) {
+    if (!this.user.cachedUserInfo()?.loggedIn) {
       return;
     }
 


### PR DESCRIPTION
## Background

Need to be able to reset gene profiles table state because user changes persist (in backend db) and it is impossible to return the default state.

## Aim

To add reset button above the table which resets the table and the state.

## Implementation

Add reset button and some bug fixes.
