### PR TITLE
Datasets routing fixes

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -48,6 +48,8 @@ h3 {
   height: 42px;
   position: relative;
   top: 2px;
+  pointer-events: none;
+  cursor: default;
 }
 
 #separator {


### PR DESCRIPTION
## Background
- Navigating from Dataset page to another while the dataset request is still not finished, returns the user back to the Dataset page when the request finishes. 
- Clicking on `Dataset` button to navigate to dataset page when already in dataset page removes selected tool and doesn't trigger automatic tool selection (page link removes the tool from dataset page without recreating the dataset component).

## Aim
Fix above issues

## Implementation
- Dataset request subscription is now part of the existing subscription list in dataset component. This way on navigation to another page the component's destruction stops ongoing dataset requests.
- Clicking on nav button to go to already loaded page is now not possible. Nothing can be expected to happen when clicking on it this way anyway.