### PR TITLE
Fix opening single view tab from home page

### DIFF
--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -23,7 +23,6 @@ import { SetStudyTypes } from 'app/study-types/study-types.state';
 import { SetVariantTypes } from 'app/variant-types/variant-types.state';
 import { LGDS } from 'app/effect-types/effect-types';
 import { GeneProfilesModel, SetGeneProfilesTabs } from 'app/gene-profiles-table/gene-profiles-table.state';
-import { DatasetsService } from 'app/datasets/datasets.service';
 import { DatasetModel } from 'app/datasets/datasets.state';
 
 @Component({

--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -36,10 +36,10 @@
         [hidden]="!showNothingFound">
         <span>Nothing found</span>
       </div>
-    </div>
 
-    <div id="loading" *ngIf="showInitialLoading">
-      <span>Loading...</span>
+      <div id="loading" *ngIf="showInitialLoading">
+        <span>Loading...</span>
+      </div>
     </div>
   </div>
 

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -242,7 +242,14 @@ class GeneProfilesTableServiceMock {
   public saveUserGeneProfilesState(): void { }
 
   public getUserGeneProfilesState(): Observable<object> {
-    return of({});
+    return of({
+      openedTabs: ['POGZ'],
+      searchValue: 'chd',
+      highlightedRows: ['CHD8'],
+      sortBy: 'column1',
+      orderBy: 'desc',
+      headerLeaves: []
+    });
   }
 }
 
@@ -473,7 +480,7 @@ describe('GeneProfilesTableComponent', () => {
   });
 
   it('should load user gene proifles state', () => {
-    expect(component.tabs).toStrictEqual(new Set(['POGZ']));
+    expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST', 'POGZ']));
     expect(component.loadedSearchValue).toBe('chd');
     expect(component.highlightedGenes).toStrictEqual(new Set(['CHD8']));
     expect(component.orderBy).toBe('desc');

--- a/src/app/gene-profiles-table/gene-profiles-table.component.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.ts
@@ -102,16 +102,6 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
 
     this.focusSearchBox();
 
-    if (this.route.snapshot.params.genes as string) {
-      this.currentTabGeneSet = new Set(
-        (this.route.snapshot.params.genes as string)
-          .split(',')
-          .filter(p => p)
-          .map(p => p.trim())
-      );
-      this.loadSingleView(this.currentTabGeneSet);
-    }
-
     this.loadState();
 
     this.geneProfilesTableService.getUserGeneProfilesState().subscribe(state => {
@@ -123,6 +113,16 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
         this.store.dispatch(new SetGeneProfilesOrderBy(state.orderBy));
         this.store.dispatch(new SetGeneProfilesHeader(state.headerLeaves));
         this.loadState();
+      }
+
+      if (this.route.snapshot.params.genes as string) {
+        this.currentTabGeneSet = new Set(
+          (this.route.snapshot.params.genes as string)
+            .split(',')
+            .filter(p => p)
+            .map(p => p.trim())
+        );
+        this.loadSingleView(this.currentTabGeneSet);
       }
     });
   }
@@ -223,7 +223,7 @@ export class GeneProfilesTableComponent extends StatefulComponent implements OnI
     this.store.selectOnce(
       (state: { geneProfilesState: GeneProfilesModel}) => state.geneProfilesState)
       .subscribe(state => {
-        this.tabs = new Set(state.openedTabs);
+        this.tabs = new Set([...state.openedTabs, ...this.tabs]);
         this.loadedSearchValue = state.searchValue;
         this.highlightedGenes = new Set(state.highlightedRows);
         this.orderBy = state.orderBy;

--- a/src/app/gene-profiles-table/gene-profiles-table.service.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.service.ts
@@ -47,7 +47,7 @@ export class GeneProfilesTableService {
           this.http.post(this.config.baseUrl + this.usersUrl, state, { withCredentials: true }).subscribe();
           this.saveStateDebouncer = null;
         });
-    }, 2000);
+    }, 1000);
   }
 
   public getGenes(page: number, searchString?: string, sortBy?: string, order?: string): Observable<any[]> {


### PR DESCRIPTION
## Background

Selecting gene from home page opens gene profiles single view but doesn't add a tab in the tab list and is not saved in state.

## Aim

To add the new tab in the list of opened tabs.

## Implementation

Make the code which reads the url and opens single view tab to execute last so that the state and the user state are already loaded then combine the opened tab and the tabs from state in `this.tabs`.
