### PR TITLE
fix gene browser unique family checkbox disabling

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -183,7 +183,7 @@
           <input
             id="unique-family-variants-checkbox"
             type="checkbox"
-            [disabled]="!isUniqueFamilyFilterEnabled"
+            [disabled]="!isUniqueFamilyFilterEnabled || !this.summaryVariantsArrayFiltered?.totalFamilyVariantsCount"
             (click)="checkUniqueFamilyVariantsFilter()" />
         </div>
         <div id="family-variants-wrapper">

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -74,6 +74,8 @@ class MockQueryService {
     return of([] as any);
   }
 
+
+  public streamingStartSubject = new Subject();
   public streamingFinishedSubject = new Subject();
   public summaryStreamingFinishedSubject = new Subject();
 
@@ -94,8 +96,8 @@ describe('GeneBrowserComponent', () => {
   const mockQueryService = new MockQueryService();
   let loadingService: FullscreenLoadingService;
 
-  beforeEach(async() => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       declarations: [
         GeneBrowserComponent, GenePlotComponent,
         GenotypePreviewTableComponent,

--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
-import { ActivatedRoute, NavigationStart, Params, Router } from '@angular/router';
+import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { GeneService } from 'app/gene-browser/gene.service';
 import { Gene } from 'app/gene-browser/gene';
@@ -80,7 +80,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   public variantsCountDisplay: string;
   public variantsCount = -1;
 
-  public async ngOnInit(): Promise<void> {
+  public ngOnInit(): void {
     this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
       switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId))
     ).subscribe(dataset => {
@@ -96,6 +96,8 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       if (this.route.snapshot.params.gene && typeof this.route.snapshot.params.gene === 'string') {
         this.geneSymbol = this.route.snapshot.params.gene;
       }
+
+      this.enableUniqueFamilyVarinats();
     });
 
     this.route.queryParams.subscribe(params => {
@@ -142,7 +144,9 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       this.location.replaceState(`datasets/${this.selectedDatasetId}/gene-browser`);
       this.interruptSummaryVariants$.next(true);
     });
+  }
 
+  private async enableUniqueFamilyVarinats(): Promise<void> {
     const childLeaves = await this.datasetsTreeService.getUniqueLeafNodes(this.selectedDatasetId);
     if (childLeaves.size > 1) {
       this.isUniqueFamilyFilterEnabled = true;


### PR DESCRIPTION
## Background

The logic that enables Unique family varinats checkbox was executing before getting the selected dataset id.
Also the checkbox was enabled when there are no families.


## Aim

To fix the issues

## Implementation

Move enabling the checkbox in private async method `enableUniqueFamilyVarinats()`  and call it in the subscribe of `getDataset()` and put it. 
Add checking if there are families in the template and if no families, the checkbox will be disabled.
