### PR TITLE
Refactor dataset description

### DIFF
--- a/src/app/dataset-description/dataset-description.component.css
+++ b/src/app/dataset-description/dataset-description.component.css
@@ -1,8 +1,19 @@
-:host::ng-deep markdown ul {
+ul {
   list-style-type: none;
 }
 
-:host::ng-deep markdown li {
+li {
   margin-bottom: 20px;
   margin-top: 20px;
+}
+
+a {
+  color: #0645ad;
+  text-decoration: none;
+  font-weight: 1000;
+  margin-right: 5px;
+}
+
+:host::ng-deep markdown p {
+  display: inline;
 }

--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -10,7 +10,7 @@
     >No dataset description available</span
   >
 
-  <div class="container" style="display: block; padding: 0; width: auto">
+  <div class="container" style="display: block; padding: 20px 0; width: auto">
     <p>This dataset includes:</p>
     <ul class="container">
       <ng-container

--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -22,7 +22,7 @@
 </ng-container>
 
 <ng-template #Recursion let-data>
-  <li>
+  <li *ngIf="data.visibility">
     <p>
       <a [href]="'datasets/' + data.id">{{ data.name }}</a>
       <markdown *ngIf="data.description">

--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -24,7 +24,7 @@
 <ng-template #Recursion let-data>
   <li *ngIf="data.visibility">
     <p>
-      <a [href]="'datasets/' + data.id">{{ data.name }}</a>
+      <a [id]="'description-link-' + data.id" [href]="'datasets/' + data.id">{{ data.name }}</a>
       <markdown *ngIf="data.description">
         {{ getFirstParagraph(data.description) }}
       </markdown>

--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -1,14 +1,39 @@
-<ng-container *ngIf="dataset">
+<ng-container *ngIf="descriptionHierarchy">
   <gpf-markdown-editor
-    [initialMarkdown]="dataset.description"
-    [editable]="dataset.descriptionEditable"
-    (writeEvent)="writeDataset($event)"></gpf-markdown-editor>
+    [initialMarkdown]="descriptionHierarchy.description"
+    [editable]="editable"
+    (writeEvent)="writeDataset(descriptionHierarchy.id, $event)"></gpf-markdown-editor>
 
   <span
-    *ngIf="!dataset.description && !('' | userInfo)?.isAdministrator"
+    *ngIf="!descriptionHierarchy.description && !('' | userInfo)?.isAdministrator"
     style="display: block; font-style: italic; opacity: 75%; text-align: center; padding-top: 15px"
     >No dataset description available</span
   >
 
-  <markdown class="container" style="display: block; padding: 0; width: auto;">{{ dataset.childrenDescription }}</markdown>
+  <div class="container" style="display: block; padding: 0; width: auto">
+    <p>This dataset includes:</p>
+    <ul class="container">
+      <ng-container
+        *ngFor="let child of descriptionHierarchy.children"
+        [ngTemplateOutlet]="Recursion"
+        [ngTemplateOutletContext]="{ $implicit: child }"></ng-container>
+    </ul>
+  </div>
 </ng-container>
+
+<ng-template #Recursion let-data>
+  <li>
+    <p>
+      <a [href]="'datasets/' + data.id">{{ data.name }}</a>
+      <markdown *ngIf="data.description">
+        {{ getFirstParagraph(data.description) }}
+      </markdown>
+    </p>
+    <ul *ngIf="data.children.length > 0">
+      <ng-container
+        *ngFor="let child of data.children"
+        [ngTemplateOutlet]="Recursion"
+        [ngTemplateOutletContext]="{ $implicit: child }"></ng-container>
+    </ul>
+  </li>
+</ng-template>

--- a/src/app/dataset-description/dataset-description.component.ts
+++ b/src/app/dataset-description/dataset-description.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { DatasetsService } from '../datasets/datasets.service';
-import { Dataset } from '../datasets/datasets';
 import { switchMap, take } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { DatasetModel } from 'app/datasets/datasets.state';
+import { DatasetHierarchy } from 'app/datasets/datasets';
 
 @Component({
   selector: 'gpf-dataset-description',
@@ -12,26 +11,60 @@ import { DatasetModel } from 'app/datasets/datasets.state';
   styleUrls: ['./dataset-description.component.css']
 })
 export class DatasetDescriptionComponent implements OnInit {
-  public dataset: Dataset;
+  public descriptionHierarchy: DatasetHierarchy;
+  public editable: boolean;
+
 
   public constructor(
-    private route: ActivatedRoute,
     private datasetsService: DatasetsService,
     private store: Store
   ) { }
 
   public ngOnInit(): void {
-    this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
-      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId as string)))
-      .subscribe(dataset => {
-        if (!dataset) {
-          return;
-        }
-        this.dataset = dataset;
+    const subscription = this.store.selectOnce((state: { datasetState: DatasetModel}) => state.datasetState).pipe(
+      switchMap((state: DatasetModel) => this.datasetsService.getDataset(state.selectedDatasetId)),
+      switchMap(dataset => {
+        this.editable = dataset.descriptionEditable;
+        return this.datasetsService.getSingleDatasetHierarchy(dataset.id);
+      }))
+      .subscribe((hierarchy: DatasetHierarchy) => {
+        this.addDescriptions(hierarchy);
+        this.descriptionHierarchy = hierarchy;
+        subscription.unsubscribe();
       });
   }
 
-  public writeDataset(markdown: string): void {
-    this.datasetsService.writeDatasetDescription(this.dataset.id, markdown).pipe(take(1)).subscribe();
+  public addDescriptions(hierarchy: DatasetHierarchy): void {
+    const subscription = this.datasetsService.getDatasetDescription(hierarchy.id)
+      .subscribe(desc => {
+        hierarchy.description = desc;
+        subscription.unsubscribe();
+      });
+
+    for (const child of hierarchy.children) {
+      this.addDescriptions(child);
+    }
+  }
+
+  public getFirstParagraph(text: string): string {
+    const paragraphs = text.split('\n\n');
+
+    let result = '';
+    if (paragraphs[0].startsWith('#')) {
+      const regexp = new RegExp(/^##((?:\n|.)*?)$\n/);
+      if (regexp.test(paragraphs[0])) {
+        result = paragraphs[0].replace(regexp, '');
+      } else {
+        result = paragraphs[1];
+      }
+    } else {
+      result = paragraphs[0];
+    }
+
+    return result.replace('\n', ' ').trim();
+  }
+
+  public writeDataset(datasetId: string, text: string): void {
+    this.datasetsService.writeDatasetDescription(datasetId, text).pipe(take(1)).subscribe();
   }
 }

--- a/src/app/dataset-description/dataset-description.component.ts
+++ b/src/app/dataset-description/dataset-description.component.ts
@@ -43,9 +43,7 @@ export class DatasetDescriptionComponent implements OnInit {
       .subscribe(desc => {
         if (visibleDatasets.includes(hierarchy.id)) {
           hierarchy.description = desc;
-        } else {
-          // Remove whole dataset from hierarchy if its not visible.
-          hierarchy = null;
+          hierarchy.visibility = true;
         }
         subscription.unsubscribe();
       });

--- a/src/app/dataset-node/dataset-node.spec.ts
+++ b/src/app/dataset-node/dataset-node.spec.ts
@@ -7,8 +7,6 @@ import { DatasetNode } from './dataset-node';
 
 const datasetMock = new Dataset(
   'id1',
-  'desc1',
-  '',
   'name1',
   ['parent1', 'parent2'],
   false,

--- a/src/app/datasets/datasets-tree.service.spec.ts
+++ b/src/app/datasets/datasets-tree.service.spec.ts
@@ -10,22 +10,22 @@ import { Dataset } from './datasets';
 import { DatasetNode } from 'app/dataset-node/dataset-node';
 
 const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
-  null, '', null, ['id11', 'id12'], null, null, null, null, null,
+  null, ['id11', 'id12'], null, null, null, null, null,
   null, null, null, null, null, null, null, null, null, null, null, null
 ), [
   new Dataset(
     'id2',
-    null, '', null, ['id1', 'parent2'], null, null, null, null, null,
+    null, ['id1', 'parent2'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id3',
-    null, '', null, ['id1', 'parent3'], null, null, null, null, null,
+    null, ['id1', 'parent3'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
     'id4',
-    null, '', null, ['id4', 'parent4'], null, null, null, null, null,
+    null, ['id4', 'parent4'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   )
 ]);
@@ -56,22 +56,22 @@ describe('DatasetService', () => {
     expect(service.findNodeById(datasetNodeMock1, 'id3')).toStrictEqual(new DatasetNode(
       new Dataset(
         'id3',
-        null, '', null, ['id1', 'parent3'], null, null, null, null, null,
+        null, ['id1', 'parent3'], null, null, null, null, null,
         null, null, null, null, null, null, null, null, null, null, null, null
       ), [
         new Dataset(
           'id2',
-          null, '', null, ['id1', 'parent2'], null, null, null, null, null,
+          null, ['id1', 'parent2'], null, null, null, null, null,
           null, null, null, null, null, null, null, null, null, null, null, null
         ),
         new Dataset(
           'id3',
-          null, '', null, ['id1', 'parent3'], null, null, null, null, null,
+          null, ['id1', 'parent3'], null, null, null, null, null,
           null, null, null, null, null, null, null, null, null, null, null, null
         ),
         new Dataset(
           'id4',
-          null, '', null, ['id4', 'parent4'], null, null, null, null, null,
+          null, ['id4', 'parent4'], null, null, null, null, null,
           null, null, null, null, null, null, null, null, null, null, null, null
         )]
     ));

--- a/src/app/datasets/datasets.component.spec.ts
+++ b/src/app/datasets/datasets.component.spec.ts
@@ -34,7 +34,7 @@ class MockDatasetService {
 }
 
 const mockDataset1 = new Dataset(
-  'id1', 'desc1', '', 'name1', [], true,
+  'id1', 'name1', [], true,
   ['study1'], ['studyName1'], ['studyType1'], 'phenotypeData1',
   false, true, true, false, {enabled: true},
   new GenotypeBrowser(

--- a/src/app/datasets/datasets.component.ts
+++ b/src/app/datasets/datasets.component.ts
@@ -139,7 +139,8 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
     let result: boolean;
     switch (toolName) {
       case 'dataset-description':
-        result = dataset.description !== undefined;
+        // Always true.
+        result = true;
         break;
       case 'dataset-statistics':
         result = dataset.commonReport.enabled;
@@ -183,10 +184,10 @@ export class DatasetsComponent extends StatefulComponent implements OnInit, OnDe
       firstTool = toolPageLinks.enrichmentTool;
     } else if (selectedDataset.phenotypeTool) {
       firstTool = toolPageLinks.phenotypeTool;
-    } else if (selectedDataset.description) {
-      firstTool = toolPageLinks.datasetDescription;
     } else if (selectedDataset.commonReport.enabled) {
       firstTool = toolPageLinks.datasetStatistics;
+    } else {
+      firstTool = toolPageLinks.datasetDescription;
     }
 
     return firstTool;

--- a/src/app/datasets/datasets.service.ts
+++ b/src/app/datasets/datasets.service.ts
@@ -135,7 +135,7 @@ export class DatasetsService {
   }
 
   public getSingleDatasetHierarchy(datasetId: string): Observable<DatasetHierarchy> {
-    return this.http.get(`${this.config.baseUrl}datasets/dataset-hierarchy/${datasetId}`).pipe(
+    return this.http.get(`${this.config.baseUrl}datasets/hierarchy/${datasetId}`).pipe(
       map((json: {data: object}) => DatasetHierarchy.fromJson(json.data))
     );
   }

--- a/src/app/datasets/datasets.service.ts
+++ b/src/app/datasets/datasets.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable, ReplaySubject, zip, of } from 'rxjs';
 
-import { Dataset } from '../datasets/datasets';
+import { Dataset, DatasetHierarchy } from '../datasets/datasets';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '../config/config.service';
-import { distinctUntilChanged, map, share, take } from 'rxjs/operators';
+import { distinctUntilChanged, map, take } from 'rxjs/operators';
 import { DatasetPermissions } from 'app/datasets-table/datasets-table';
 
 @Injectable()
@@ -124,11 +124,19 @@ export class DatasetsService {
     return this.http.get(`${this.config.baseUrl}${this.visibleDatasetsUrl}`, options);
   }
 
-  public getDatasetDescription(datasetId: string): Observable<object> {
+  public getDatasetDescription(datasetId: string): Observable<string> {
     const options = { headers: this.headers, withCredentials: true };
-    const description$ = this.http.get(
+    return this.http.get<{description: string}>(
       `${this.config.baseUrl}${this.descriptionUrl}/${datasetId}`, options
-    ).pipe(take(1), share());
-    return description$;
+    ).pipe(
+      take(1),
+      map((res: {description: string}) => res.description)
+    );
+  }
+
+  public getSingleDatasetHierarchy(datasetId: string): Observable<object> {
+    return this.http.get(`${this.config.baseUrl}datasets/dataset-hierarchy/${datasetId}`).pipe(
+      map((json: {data: object}) => DatasetHierarchy.fromJson(json.data))
+    );
   }
 }

--- a/src/app/datasets/datasets.service.ts
+++ b/src/app/datasets/datasets.service.ts
@@ -119,9 +119,9 @@ export class DatasetsService {
     );
   }
 
-  public getVisibleDatasets(): Observable<object> {
+  public getVisibleDatasets(): Observable<string[]> {
     const options = { headers: this.headers, withCredentials: true };
-    return this.http.get(`${this.config.baseUrl}${this.visibleDatasetsUrl}`, options);
+    return this.http.get<string[]>(`${this.config.baseUrl}${this.visibleDatasetsUrl}`, options);
   }
 
   public getDatasetDescription(datasetId: string): Observable<string> {
@@ -134,7 +134,7 @@ export class DatasetsService {
     );
   }
 
-  public getSingleDatasetHierarchy(datasetId: string): Observable<object> {
+  public getSingleDatasetHierarchy(datasetId: string): Observable<DatasetHierarchy> {
     return this.http.get(`${this.config.baseUrl}datasets/dataset-hierarchy/${datasetId}`).pipe(
       map((json: {data: object}) => DatasetHierarchy.fromJson(json.data))
     );

--- a/src/app/datasets/datasets.spec.ts
+++ b/src/app/datasets/datasets.spec.ts
@@ -490,8 +490,6 @@ describe('GeneBrowser', () => {
 describe('Dataset', () => {
   const datasetMock1 = new Dataset(
     'id1',
-    'desc1',
-    '',
     'name1',
     ['parent1', 'parent2'],
     false,
@@ -572,8 +570,6 @@ describe('Dataset', () => {
 
   const datasetMock2 = new Dataset(
     'id2',
-    'desc2',
-    '',
     'name2',
     ['parent2', 'parent2'],
     true,

--- a/src/app/datasets/datasets.ts
+++ b/src/app/datasets/datasets.ts
@@ -340,7 +340,7 @@ export class Dataset extends IdName {
 }
 
 export class DatasetHierarchy {
-  public description = '';
+  public description;
   public visibility = false;
 
   public constructor(

--- a/src/app/datasets/datasets.ts
+++ b/src/app/datasets/datasets.ts
@@ -246,8 +246,6 @@ export class Dataset extends IdName {
     }
     return new Dataset(
       json['id'] as string,
-      json['description'] as string,
-      json['children_description'] as string,
       json['name'] as string,
       json['parents'] as string[],
       json['access_rights'] as boolean,
@@ -276,8 +274,6 @@ export class Dataset extends IdName {
     }
     return new Dataset(
       datasetJson['id'] as string,
-      datasetJson['description'] as string,
-      datasetJson['children_description'] as string,
       datasetJson['name'] as string,
       datasetJson['parents'] as string[],
       datasetJson['access_rights'] as boolean,
@@ -319,8 +315,6 @@ export class Dataset extends IdName {
 
   public constructor(
     public readonly id: string,
-    public readonly description: string,
-    public readonly childrenDescription: string,
     public readonly name: string,
     public readonly parents: string[],
     public readonly accessRights: boolean,
@@ -342,5 +336,35 @@ export class Dataset extends IdName {
     public readonly descriptionEditable: boolean
   ) {
     super(id, name);
+  }
+}
+
+export class DatasetHierarchy {
+  public description: string;
+
+  public constructor(
+    public id: string,
+    public name: string,
+    public accessRights: boolean,
+    public children: DatasetHierarchy[],
+  ) { }
+
+  public static fromJson(json: object): DatasetHierarchy {
+    if (!json) {
+      return undefined;
+    }
+
+    let children: DatasetHierarchy[] = [];
+    if (json['children']) {
+      children = (json['children'] as object[])
+        .map(child => DatasetHierarchy.fromJson(child));
+    }
+
+    return new DatasetHierarchy(
+      json['dataset'] as string,
+      json['name'] as string,
+      json['access_rights'] as boolean,
+      children
+    );
   }
 }

--- a/src/app/datasets/datasets.ts
+++ b/src/app/datasets/datasets.ts
@@ -340,7 +340,8 @@ export class Dataset extends IdName {
 }
 
 export class DatasetHierarchy {
-  public description: string;
+  public description = '';
+  public visibility = false;
 
   public constructor(
     public id: string,

--- a/src/app/family-filters-block/family-filters-block.component.spec.ts
+++ b/src/app/family-filters-block/family-filters-block.component.spec.ts
@@ -260,7 +260,7 @@ describe('FamilyFiltersBlockComponent', () => {
     // eslint-disable-next-line max-len
     const genotypeBrowserMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, [], [], [], null, null, null, null, 0);
     // eslint-disable-next-line max-len
-    const datasetMock = new Dataset('datasetId', '', '', 'dataset', [], true, [], [], [], '', true, true, true, true, {enabled: true}, genotypeBrowserMock, null, null, null, true, null, false);
+    const datasetMock = new Dataset('datasetId', 'dataset', [], true, [], [], [], '', true, true, true, true, {enabled: true}, genotypeBrowserMock, null, null, null, true, null, false);
     component.dataset = datasetMock;
 
     // eslint-disable-next-line max-len

--- a/src/app/genotype-browser/genotype-browser.component.spec.ts
+++ b/src/app/genotype-browser/genotype-browser.component.spec.ts
@@ -204,7 +204,7 @@ describe('GenotypeBrowserComponent', () => {
       }
     };
     // eslint-disable-next-line max-len
-    component.selectedDataset = new Dataset('datasetId', 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeMock, null, [], null, null, '', null);
+    component.selectedDataset = new Dataset('datasetId', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeMock, null, [], null, null, '', null);
 
     component.onSubmit(mockEvent);
     expect(mockEvent.target.queryData.value).toStrictEqual(JSON.stringify({

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -145,9 +145,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   public attachDatasetDescription(entry: object): void {
     entry['children']?.forEach((d: object) => this.attachDatasetDescription(d));
-    this.subscription.add(this.datasetsService.getDatasetDescription(entry['dataset'] as string).subscribe(res => {
-      if (res['description']) {
-        entry['description'] = this.getFirstParagraph(res['description'] as string);
+    this.subscription.add(this.datasetsService.getDatasetDescription(entry['dataset'] as string).subscribe(desc => {
+      if (desc) {
+        entry['description'] = this.getFirstParagraph(desc);
       }
 
       this.studiesLoaded++;

--- a/src/app/markdown-editor/markdown-editor.component.html
+++ b/src/app/markdown-editor/markdown-editor.component.html
@@ -17,17 +17,6 @@
           >
         </div>
       </div>
-
-      <div *ngIf="editMode">
-        <div class="editor">
-          <angular-markdown-editor textareaId="editor1" [options]="editorOptions" [(ngModel)]="markdown">
-          </angular-markdown-editor>
-          <button (click)="save()" id="save-btn" class="btn btn-success" title="Save (ctrl+enter)">Save</button>
-          <button (click)="close()" id="close-btn" class="btn" title="Close">Close</button>
-        </div>
-      </div>
-
-      <hr *ngIf="!initialMarkdown && !editMode" style="margin-top: 5px" />
     </div>
   </div>
 

--- a/src/app/markdown-editor/markdown-editor.component.ts
+++ b/src/app/markdown-editor/markdown-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, OnChanges, Output } from '@angular/core';
 import { EditorOption } from 'angular-markdown-editor';
 import DOMPurify from 'dompurify';
 import { MarkdownService } from 'ngx-markdown';
@@ -8,7 +8,7 @@ import { MarkdownService } from 'ngx-markdown';
   templateUrl: './markdown-editor.component.html',
   styleUrls: ['./markdown-editor.component.css']
 })
-export class MarkdownEditorComponent implements OnInit {
+export class MarkdownEditorComponent implements OnChanges {
   @Input() public initialMarkdown: string;
   @Input() public editable = true;
 
@@ -40,7 +40,7 @@ export class MarkdownEditorComponent implements OnInit {
     }
   }
 
-  public ngOnInit(): void {
+  public ngOnChanges(): void {
     this.markdown = this.initialMarkdown;
   }
 

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -78,7 +78,7 @@ class MockPhenoBrowserService {
 class MockDatasetsService {
   public getDataset(datasetId: string): Observable<Dataset> {
     // eslint-disable-next-line max-len
-    return of(new Dataset(datasetId, 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null));
+    return of(new Dataset(datasetId, 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null));
   }
 }
 
@@ -236,7 +236,7 @@ describe('PhenoBrowserComponent', () => {
       /* eslint-enable */
     };
     // eslint-disable-next-line max-len
-    component.selectedDataset = new Dataset(data.dataset_id, '', '', '', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, true, '', null);
+    component.selectedDataset = new Dataset(data.dataset_id, '', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, true, '', null);
     component.selectedInstrument$ = new BehaviorSubject(data.instrument);
     component.searchTermObs$ = of(data.search_term);
 

--- a/src/app/pheno-tool/pheno-tool.component.spec.ts
+++ b/src/app/pheno-tool/pheno-tool.component.spec.ts
@@ -38,7 +38,7 @@ class MockDatasetsService {
     // eslint-disable-next-line max-len
     const genotypeBrowserConfigMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, new Array<object>(), new Array<PersonFilter>(), new Array<PersonFilter>(), [], [], [], [], 0);
     // eslint-disable-next-line max-len
-    return of(new Dataset(datasetId, 'desc', '', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeBrowserConfigMock, null, [], null, null, '', null));
+    return of(new Dataset(datasetId, 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeBrowserConfigMock, null, [], null, null, '', null));
   }
 }
 
@@ -75,10 +75,10 @@ describe('PhenoToolComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
-    
+
     fixture = TestBed.createComponent(PhenoToolComponent);
     component = fixture.componentInstance;
-    
+
     // eslint-disable-next-line max-len
     // eslint-disable-next-line max-len
     const selectedDatasetMockModel: DatasetModel = {selectedDatasetId: 'testId'};

--- a/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
+++ b/src/app/treelist-checkbox/treelist-checkbox.component.spec.ts
@@ -8,22 +8,19 @@ import { HttpClientModule } from '@angular/common/http';
 import { ConfigService } from 'app/config/config.service';
 
 const datasetNodeMock1 = new DatasetNode(new Dataset('id1',
-  null, '', null, ['id11', 'id12'], null, null, null, null, null,
+  null, ['id11', 'id12'], null, null, null, null, null,
   null, null, null, null, null, null, null, null, null, null, null, null
 ), [
   new Dataset(
-    'id2',
-    null, '', null, ['id1', 'parent2'], null, null, null, null, null,
+    'id2', null, ['id1', 'parent2'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
-    'id3',
-    null, '', null, ['id1', 'parent3'], null, null, null, null, null,
+    'id3', null, ['id1', 'parent3'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   ),
   new Dataset(
-    'id4',
-    null, '', null, ['id4', 'parent4'], null, null, null, null, null,
+    'id4', null, ['id4', 'parent4'], null, null, null, null, null,
     null, null, null, null, null, null, null, null, null, null, null, null
   )
 ]);
@@ -52,13 +49,11 @@ describe('StudyFiltersTreeComponent', () => {
 
   it('should get all childrens of dataset', () => {
     const datasetNodeMock2 = new DatasetNode(new Dataset(
-      'id2',
-      null, '', null, ['id21', 'id22'], null, null, null, null, null,
+      'id2', null, ['id21', 'id22'], null, null, null, null, null,
       null, null, null, null, null, null, null, null, null, null, null, null
     ), [
       new Dataset(
-        'id4',
-        null, '', null, ['id23', 'id24'], null, null, null, null, null,
+        'id4', null, ['id23', 'id24'], null, null, null, null, null,
         null, null, null, null, null, null, null, null, null, null, null, null
       )
     ]);


### PR DESCRIPTION
## Background
- The dataset description that comes with a dataset is problematic for dataset cashing because it can be frequently updated.

- The same goes for children dataset descriptions that also come with the dataset api.

## Aim

- Switch dataset description page to use dataset description api.

- Create short children descriptions with visual hierarchy (previously was directly provided as markdown text with the dataset api) 
