### PR TITLE
fix gene profiles loading search result when loading search value fro…

### DIFF
--- a/src/app/gene-profiles-table/gene-profiles-table.component.html
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.html
@@ -128,7 +128,7 @@
             </label>
             <input
               #searchBox
-              (keyup)="searchKeystrokes$.next(searchBox.value)"
+              (keyup)="searchValue$.next(searchBox.value)"
               id="gene-search-input"
               class="search-input form-control"
               autocomplete="off"
@@ -136,11 +136,11 @@
               placeholder="Search gene"
               type="text"
               spellcheck="false"
-              [value]="loadedSearchValue" />
+              [value]="searchValue$ | async" />
             <span
               *ngIf="searchBox.value !== '' && !showSearchLoading"
               class="material-symbols-outlined search-clear-icon"
-              (click)="searchBox.value = ''; searchKeystrokes$.next(searchBox.value); showSearchLoading = true"
+              (click)="searchBox.value = ''; searchValue$.next(searchBox.value); showSearchLoading = true"
               >close</span
             >
             <span *ngIf="showSearchLoading" class="material-symbols-outlined search-loading-icon"

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -323,7 +323,7 @@ describe('GeneProfilesTableComponent', () => {
     component.ngOnChanges();
     component.search('mockSearch');
 
-    expect(component.geneInput).toBe('mockSearch');
+    expect(component.searchValue$.value).toBe('mockSearch');
     expect(component.genes[0]).toStrictEqual(genesMock[0]);
     expect(component.genes[1]).toStrictEqual(genesMock[1]);
     expect(component.genes[2]).toStrictEqual(genesMock[2]);
@@ -481,7 +481,7 @@ describe('GeneProfilesTableComponent', () => {
 
   it('should load user gene proifles state', () => {
     expect(component.tabs).toStrictEqual(new Set(['DYRK1A,FOXP1,SPAST', 'POGZ']));
-    expect(component.loadedSearchValue).toBe('chd');
+    expect(component.searchValue$.value).toBe('chd');
     expect(component.highlightedGenes).toStrictEqual(new Set(['CHD8']));
     expect(component.orderBy).toBe('desc');
     expect(component.leavesIds).toEqual([
@@ -497,7 +497,7 @@ describe('GeneProfilesTableComponent', () => {
 
   it('should reset table state', () => {
     component.tabs = new Set(['POGZ']);
-    component.loadedSearchValue = 'chd';
+    component.searchValue$.next('chd');
     component.highlightedGenes = new Set(['CHD8']);
     component.orderBy = 'desc';
     component.sortBy = 'column1';
@@ -509,7 +509,7 @@ describe('GeneProfilesTableComponent', () => {
 
     component.resetState();
     expect(component.tabs).toStrictEqual(new Set());
-    expect(component.loadedSearchValue).toBe('');
+    expect(component.searchValue$.value).toBe('');
     expect(component.highlightedGenes).toStrictEqual(new Set());
     expect(component.orderBy).toBe('desc');
     expect(component.sortBy).toBe('column1');


### PR DESCRIPTION
…m state

## Background

When loading the search value from state, the default table shows quickly before the filtered by the search result loads. Sometimes search triggers before the rows are loaded which results in showing the default table data despite having search value in the input (to reproduce that type in the search and reload multiple times)
![image](https://github.com/user-attachments/assets/500dcb9b-8698-44fd-870b-dd00468910c2)


## Aim

To remove the flicker (show directly the filtered result) and to fix the bug.

## Implementation

- there are too much variables saving the search input (`searchKeystrokes$`, `geneInput`, `loadedSearchValue`)  and not all are updated at the same time which causes loading wrong table data - make to use `searchKeystrokes$` only
- rename `searchKeystrokes$` to `searchValue$` and make it `BehaviourSubject`  to access the stored value easily
- call `loadState` method from the subscription of the `getUserGeneProfilesState` to prevent loading the default table
