### PR TITLE
update pheno browser image modal style

### DIFF
--- a/src/app/gene-plot/gene-plot.component.css
+++ b/src/app/gene-plot/gene-plot.component.css
@@ -76,3 +76,7 @@ label {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+.card {
+  min-width: 1200px;
+}

--- a/src/app/pheno-browser-modal-content/pheno-browser-modal-content.component.css
+++ b/src/app/pheno-browser-modal-content/pheno-browser-modal-content.component.css
@@ -1,3 +1,11 @@
-.modal-header {
-  border-bottom: none;
+button {
+  border: none;
+  background-color: transparent;
+  float: right;
+}
+
+img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/src/app/pheno-browser-modal-content/pheno-browser-modal-content.component.html
+++ b/src/app/pheno-browser-modal-content/pheno-browser-modal-content.component.html
@@ -1,9 +1,6 @@
-<div class="modal-header">
-  <div class="modal-title"></div>
-  <button type="button" class="close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
 <div class="modal-body">
+  <button type="button" class="close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
+    <span aria-hidden="true" class="material-symbols-outlined">close</span>
+  </button>
   <img class="pheno-browser-fullscreen-image" src="{{ imageUrl }}" />
 </div>

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -1,5 +1,5 @@
 <div class="description">{{ phenoToolResults.description }}</div>
-<div style="display: flex; justify-content: center; max-height: 700px">
+<div style="display: flex; justify-content: center; max-height: 700px; min-width: 1000px">
   <svg [attr.max-width]="width" [attr.max-height]="height" [attr.viewBox]="getViewBox()">
     <text x="0" y="45">with hit</text>
     <text x="0" y="65">without hit</text>


### PR DESCRIPTION
## Aim

To update pheno browser image modal button style and center the image and add min-width to gene plot and pheno tool result chart to prevent text getting too small and impossible to read.

closes #1031 
closes #820
