### PR TITLE
add pheno browser download handling for empty downloads

### DIFF
--- a/src/app/pheno-browser/pheno-browser.component.html
+++ b/src/app/pheno-browser/pheno-browser.component.html
@@ -55,16 +55,16 @@
     [measuresLoading]="measuresLoading"></gpf-pheno-browser-table>
 </div>
 
-<div *ngIf="errorModal">
+<div *ngIf="errorModalMsg">
   <div style="display: flex; align-items: center" class="modal" role="dialog" aria-hidden="true">
     <div class="modal-dialog warning-modal">
       <div class="modal-content">
         <div class="modal-header" style="border-bottom: 0">
           <h5 class="modal-title">Warning</h5>
         </div>
-        <div class="modal-body">Too many instruments, select less than 1900!</div>
+        <div class="modal-body">{{ errorModalMsg }}</div>
         <div class="modal-footer" style="border-top: 0">
-          <button type="button" class="btn btn-secondary" (click)="errorModalBack()">Back</button>
+          <button type="button" class="btn btn-secondary" (click)="errorModalMsgBack()">Back</button>
         </div>
       </div>
     </div>

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -264,20 +264,20 @@ describe('PhenoBrowserComponent', () => {
     component.downloadMeasures();
     expect(validateSpy).toHaveBeenCalledWith(data);
     expect(downloadSpy).not.toHaveBeenCalled();
-    expect(component.errorModal).toBe(false);
+    expect(component.errorModalMsg).toBe('');
 
     validateSpy.mockReturnValue(of({ status: 413 }));
     component.downloadMeasures();
     expect(validateSpy).toHaveBeenCalledWith(data);
     expect(downloadSpy).not.toHaveBeenCalled();
-    expect(component.errorModal).toBe(true);
+    expect(component.errorModalMsg).toBe('Too many instruments, select less than 1900!');
 
-    component.errorModal = false;
+    component.errorModalMsg = '';
 
     validateSpy.mockReturnValue(of({ status: 200 }));
     component.downloadMeasures();
     expect(validateSpy).toHaveBeenCalledWith(data);
     expect(downloadSpy).toHaveBeenCalledWith(data);
-    expect(component.errorModal).toBe(false);
+    expect(component.errorModalMsg).toBe('');
   });
 });

--- a/src/app/pheno-browser/pheno-browser.component.ts
+++ b/src/app/pheno-browser/pheno-browser.component.ts
@@ -25,7 +25,7 @@ export class PhenoBrowserComponent implements OnInit, OnDestroy {
   // To trigger child change detection with on push strategy.
   public measuresChangeTick = 0;
   public measuresSubscription: Subscription;
-  public errorModal = false;
+  public errorModalMsg = '';
 
   public instruments: Observable<PhenoInstruments>;
   public selectedDataset: Dataset;
@@ -164,8 +164,10 @@ export class PhenoBrowserComponent implements OnInit, OnDestroy {
       ).subscribe(([data, validity]) => {
         if (validity.status === 200) {
           window.open(this.phenoBrowserService.getDownloadMeasuresLink(data));
+        } else if (validity.status === 204) {
+          this.errorModalMsg = 'No instruments, select more than 0!';
         } else if (validity.status === 413) {
-          this.errorModal = true;
+          this.errorModalMsg = 'Too many instruments, select less than 1900!';
         }
       });
   }
@@ -191,8 +193,8 @@ export class PhenoBrowserComponent implements OnInit, OnDestroy {
     });
   }
 
-  public errorModalBack(): void {
-    this.errorModal = false;
+  public errorModalMsgBack(): void {
+    this.errorModalMsg = '';
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
## Background
Pheno browser download api was changed to return err status code 204 No Content when users download with 0 instruments selected. 

## Aim
Make error modal that handles "Too many instruments!" error to also handle "No instruments selected" error.

