### PR TITLE
hide gene browser when selected dataset is not set

### DIFF
--- a/src/app/gene-browser/gene-browser.component.html
+++ b/src/app/gene-browser/gene-browser.component.html
@@ -1,4 +1,4 @@
-<div style="padding: 30px">
+<div *ngIf="selectedDataset" style="padding: 30px">
   <div class="effect-card card">
     <div style="font-family: Roboto; font-weight: 500; border-bottom: none" class="card-header card-title"
       >Gene Symbol</div


### PR DESCRIPTION
## Background

It is possible to send query that requires the selected dataset id without the id if there is a delay in getting the id. The query is invalid and causes error.

## Aim

To fix it.

## Implementation

Hide gene browser template content when the selected dataset is not set.
