### PR TITLE
make gene profiles wait for getting user info

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable @stylistic/max-len */
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, ErrorHandler, APP_INITIALIZER } from '@angular/core';
 import { FormsModule } from '@angular/forms';

--- a/src/app/family-filters-block/family-filters-block.component.spec.ts
+++ b/src/app/family-filters-block/family-filters-block.component.spec.ts
@@ -268,9 +268,9 @@ describe('FamilyFiltersBlockComponent', () => {
     fixture = TestBed.createComponent(FamilyFiltersBlockComponent);
     component = fixture.componentInstance;
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     const genotypeBrowserMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, [], [], [], null, null, null, null, 0);
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     const datasetMock = new Dataset('datasetId', 'dataset', [], true, [], [], [], '', true, true, true, true, {enabled: true}, genotypeBrowserMock, null, null, null, true, null, false);
     component.dataset = datasetMock;
 

--- a/src/app/gene-browser/gene-browser.component.spec.ts
+++ b/src/app/gene-browser/gene-browser.component.spec.ts
@@ -131,7 +131,6 @@ describe('GeneBrowserComponent', () => {
     component.summaryVariantsArray = new SummaryAllelesArray();
     jest.spyOn(component['queryService'], 'getSummaryVariants');
 
-    // eslint-disable-next-line max-len
     const selectedDatasetMockModel = {selectedDatasetId: 'testId'};
 
     store = TestBed.inject(Store);

--- a/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
@@ -19,6 +19,8 @@ import { GeneProfilesColumn, GeneProfilesTableConfig } from 'app/gene-profiles-t
 import { geneProfilesReducer } from 'app/gene-profiles-table/gene-profiles-table.state';
 import { cloneDeep } from 'lodash';
 import { StoreModule } from '@ngrx/store';
+import { User } from 'app/users/users';
+
 
 const config = {
   geneLinkTemplates: [
@@ -112,6 +114,17 @@ class UsersServiceMock {
   public getUserInfoObservable(): Observable<object> {
     return of({});
   }
+
+  public getUserInfo(): Observable<User> {
+    return of(new User(
+      1,
+      'userMame',
+      'userEmail',
+      ['group'],
+      true,
+      [{datasetId: 'datasetId', datasetName: 'datasetName'}]
+    ));
+  }
 }
 
 /* eslint-disable max-len */
@@ -146,7 +159,7 @@ describe('GeneProfilesBlockComponent', () => {
         UsersService,
         { provide: APP_BASE_HREF, useValue: '' },
         { provide: GeneProfilesService, useValue: geneProfilesServiceMock },
-        { provide: UsersService, useValue: usersServiceMock}
+        { provide: UsersService, useValue: usersServiceMock }
       ],
       imports: [
         HttpClientTestingModule, NgbNavModule, RouterTestingModule, FormsModule,

--- a/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles-block.component.spec.ts
@@ -127,7 +127,7 @@ class UsersServiceMock {
   }
 }
 
-/* eslint-disable max-len */
+/* eslint-disable @stylistic/max-len */
 const geneColumn = new GeneProfilesColumn('createTab', [], 'Gene', false, 'geneSymbol', null, false, true);
 const geneSetSetsCol = new GeneProfilesColumn(null, [], 'SFARI ALL', true, 'autism_gene_sets_rank.SFARI ALL', null, true, true);
 const geneSetCol = new GeneProfilesColumn(null, [geneSetSetsCol], 'Autism Gene Sets', false, 'autism_gene_sets_rank', null, true, true);
@@ -136,7 +136,7 @@ const geneScoreCol = new GeneProfilesColumn(null, [geneScoreScoresCol], 'Autism 
 const datasetPersonSetsStatisticsCol = new GeneProfilesColumn('goToQuery', [], 'dn LGDs', false, 'sequencing_de_novo.autism.denovo_lgds', null, true, true);
 const datasetPersonSetsCol = new GeneProfilesColumn(null, [datasetPersonSetsStatisticsCol], 'autism (21775)', false, 'sequencing_de_novo.autism', null, false, true);
 const datasetCol = new GeneProfilesColumn(null, [datasetPersonSetsCol], 'Sequencing de Novo', false, 'sequencing_de_novo', null, false, true);
-/* eslint-enable max-len */
+/* eslint-enable @stylistic/max-len */
 
 const geneProfilesTableConfigMock= new GeneProfilesTableConfig();
 geneProfilesTableConfigMock.columns = [geneColumn, geneSetCol, geneScoreCol, datasetCol];

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -10,6 +10,8 @@ import { Store, StoreModule } from '@ngrx/store';
 import { GeneProfiles } from './gene-profiles-table.state';
 import { TruncatePipe } from 'app/utils/truncate.pipe';
 import { Location } from '@angular/common';
+import { User } from 'app/users/users';
+import { UsersService } from 'app/users/users.service';
 
 const column1 = {
   clickable: 'createTab',
@@ -234,6 +236,19 @@ const genesMock = [
 ];
 /* eslint-enable */
 
+class UsersServiceMock {
+  public getUserInfo(): Observable<User> {
+    return of(new User(
+      1,
+      'userMame',
+      'userEmail',
+      ['group'],
+      true,
+      [{datasetId: 'datasetId', datasetName: 'datasetName'}]
+    ));
+  }
+}
+
 class GeneProfilesTableServiceMock {
   public getGenes(pageIndex: number, geneInput: string): Observable<Record<string, any>> {
     const res = cloneDeep(genesMock);
@@ -265,13 +280,16 @@ describe('GeneProfilesTableComponent', () => {
   const mockActivatedRoute = new MockActivatedRoute();
   let fixture: ComponentFixture<GeneProfilesTableComponent>;
   let store: Store;
+  const usersServiceMock = new UsersServiceMock();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [GeneProfilesTableComponent, TruncatePipe],
       providers: [
         {provide: ActivatedRoute, useValue: mockActivatedRoute},
-        {provide: GeneProfilesTableService, useValue: geneProfilesTableServiceMock}
+        {provide: GeneProfilesTableService, useValue: geneProfilesTableServiceMock},
+        { provide: UsersService, useValue: usersServiceMock }
+
       ],
       imports: [StoreModule.forRoot({})]
     }).compileComponents();

--- a/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.component.spec.ts
@@ -505,7 +505,7 @@ describe('GeneProfilesTableComponent', () => {
     expect(component.searchValue$.value).toBe('chd');
     expect(component.highlightedGenes).toStrictEqual(new Set(['CHD8']));
     expect(component.orderBy).toBe('desc');
-    expect(component.leavesIds).toEqual([
+    expect(component.leavesIds).toStrictEqual([
       'column1',
       'column21',
       'column22',

--- a/src/app/gene-profiles-table/gene-profiles-table.service.spec.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.service.spec.ts
@@ -68,7 +68,7 @@ describe('GeneProfilesTableService', () => {
     );
 
     const res$ = service.getUserGeneProfilesState();
-    expect(getUserGeneProfilesStateMock.mock.calls).toEqual([
+    expect(getUserGeneProfilesStateMock.mock.calls).toStrictEqual([
       [service['config'].baseUrl + service['usersUrl'], {withCredentials: true}]
     ]);
 
@@ -93,10 +93,10 @@ describe('GeneProfilesTableService', () => {
 
     service.saveUserGeneProfilesState(); // Expected to be cancelled
     service.saveUserGeneProfilesState(); // Expected to cancel the first one
-    expect(saveUserGeneProfilesStateSpy.mock.calls).toEqual([]);
+    expect(saveUserGeneProfilesStateSpy.mock.calls).toStrictEqual([]);
 
     tick(5000);
-    expect(saveUserGeneProfilesStateSpy.mock.calls).toEqual([
+    expect(saveUserGeneProfilesStateSpy.mock.calls).toStrictEqual([
       [service['config'].baseUrl + service['usersUrl'], state, {withCredentials: true}]
     ]);
   }));

--- a/src/app/gene-profiles-table/gene-profiles-table.service.ts
+++ b/src/app/gene-profiles-table/gene-profiles-table.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from 'app/config/config.service';
-// eslint-disable-next-line no-restricted-imports
 import { Observable, of } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { Store } from '@ngrx/store';

--- a/src/app/gene-sets/gene-sets.component.html
+++ b/src/app/gene-sets/gene-sets.component.html
@@ -28,7 +28,9 @@
             </div>
 
             <div id="filters" *ngIf="activeDataset">
-              <div *ngIf="!activeDataset.personSetCollections.length" id="no-collections-message">No person set collections</div>
+              <div *ngIf="!activeDataset.personSetCollections.length" id="no-collections-message"
+                >No person set collections</div
+              >
 
               <div *ngFor="let collection of activeDataset.personSetCollections">
                 {{ collection.personSetCollectionName }}:
@@ -82,7 +84,9 @@
             [id]="'dataset-' + dataset.datasetId"
             class="btn-sm text-wrap"
             [class.active]="activeDataset?.datasetId === dataset.datasetId"
-            [class.modified]="activeDataset?.datasetId !== dataset.datasetId && modifiedDatasetIds.has(dataset.datasetId)"
+            [class.modified]="
+              activeDataset?.datasetId !== dataset.datasetId && modifiedDatasetIds.has(dataset.datasetId)
+            "
             [ngStyle]="{ 'padding-left': (dataset.children.length ? 5 : 19) + 'px' }"
             (click)="select(dataset)"
             >{{ dataset.datasetName }}</div
@@ -102,9 +106,7 @@
         style="display: inline-flex; flex-wrap: nowrap; width: 100%"
         matAutocompleteOrigin
         #geneSetsSearch="matAutocompleteOrigin"
-        [disabled]="
-          selectedGeneSetsCollection.name === 'denovo' && currentGeneSetsTypes.length === 0
-        ">
+        [disabled]="selectedGeneSetsCollection.name === 'denovo' && currentGeneSetsTypes.length === 0">
         <span
           style="width: 100%"
           [hidden]="!selectedGeneSet"

--- a/src/app/gene-sets/gene-sets.component.spec.ts
+++ b/src/app/gene-sets/gene-sets.component.spec.ts
@@ -6,9 +6,16 @@ import { UsersService } from 'app/users/users.service';
 import { GeneSetsComponent } from './gene-sets.component';
 import { GeneSetsService } from './gene-sets.service';
 import { NgbAccordionModule, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
-import { BrowserModule, By } from '@angular/platform-browser';
+import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule, APP_BASE_HREF } from '@angular/common';
-import { DenovoPersonSetCollection, GeneSet, GeneSetsCollection, GeneSetType, GeneSetTypeNode, SelectedDenovoTypes, SelectedPersonSetCollections } from './gene-sets';
+import {
+  DenovoPersonSetCollection,
+  GeneSet,
+  GeneSetsCollection,
+  GeneSetType,
+  GeneSetTypeNode,
+  SelectedDenovoTypes,
+  SelectedPersonSetCollections } from './gene-sets';
 import { Observable } from 'rxjs/internal/Observable';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -99,7 +106,7 @@ const geneSetsCollectionMock = [
       )
     ]
   )
-]
+];
 class MockGeneSetsService {
   public provide = true;
 
@@ -129,22 +136,22 @@ class MockGeneSetsService {
 }
 
 const datasetHierarchyMock = [
-    new DatasetHierarchy(
+  new DatasetHierarchy(
     'SSC_genotypes',
     'SSC Genotypes',
     true,
     [
       new DatasetHierarchy('SFARI_SSC_WGS_2', 'SSC NYGC WGS', true, null),
       new DatasetHierarchy('SFARI_SSC_WGS_CSHL', 'SSC CSHL WGS', true, null),
-        ]
-    ),
-    new DatasetHierarchy(
-      'ssc_rna_seq',
-      'SSC LCL RNA Sequencing',
-      true,
-      []
-    )
-  ]
+    ]
+  ),
+  new DatasetHierarchy(
+    'ssc_rna_seq',
+    'SSC LCL RNA Sequencing',
+    true,
+    []
+  )
+];
 
 class MockDatasetsTreeService {
   public getDatasetHierarchy(): Observable<DatasetHierarchy[]> {
@@ -156,8 +163,8 @@ describe('GeneSetsComponent', () => {
   let component: GeneSetsComponent;
   let fixture: ComponentFixture<GeneSetsComponent>;
   let store: Store;
-  let geneSetsServiceMock = new MockGeneSetsService();
-  let datasetsTreeServiceMock = new MockDatasetsTreeService();
+  const geneSetsServiceMock = new MockGeneSetsService();
+  const datasetsTreeServiceMock = new MockDatasetsTreeService();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -220,12 +227,12 @@ describe('GeneSetsComponent', () => {
       new GeneSetType(
         'datasetId3',
         'datasetName4',
-        [new DenovoPersonSetCollection('personSetCollectionId5', 'personSetCollectionName6',[])]
+        [new DenovoPersonSetCollection('personSetCollectionId5', 'personSetCollectionName6', [])]
       ),
       new GeneSetType(
         'datasetId9',
         'datasetName10',
-        [new DenovoPersonSetCollection('personSetCollectionId11', 'personSetCollectionName12',[])]
+        [new DenovoPersonSetCollection('personSetCollectionId11', 'personSetCollectionName12', [])]
       )
     ]);
 
@@ -436,7 +443,8 @@ describe('GeneSetsComponent', () => {
     expect(component.modifiedDatasetIds).toStrictEqual(new Set<string>(['deNovo']));
   });
 
-  it('should remove the only collection of a dataset removing the last type and remove the dataset from current selected types object', () => {
+  it('should remove the only collection of a dataset removing the last type' +
+    ' and remove the dataset from current selected types object', () => {
     jest.useFakeTimers();
 
     component.currentGeneSetsTypes = [
@@ -461,8 +469,16 @@ describe('GeneSetsComponent', () => {
   });
   it('should set onSelect', () => {
     const geneSetsCollectionMock1 = new GeneSetsCollection('name1', 'desc2', [
-      new GeneSetType('datasetId3', 'datasetName4', [new DenovoPersonSetCollection('personSetCollectionId5', 'personSetCollectionName6', [])]),
-      new GeneSetType('datasetId9', 'datasetName10', [new DenovoPersonSetCollection('personSetCollectionId11', 'personSetCollectionName12', [])])
+      new GeneSetType(
+        'datasetId3',
+        'datasetName4',
+        [new DenovoPersonSetCollection('personSetCollectionId5', 'personSetCollectionName6', [])]
+      ),
+      new GeneSetType(
+        'datasetId9',
+        'datasetName10',
+        [new DenovoPersonSetCollection('personSetCollectionId11', 'personSetCollectionName12', [])]
+      )
     ]);
 
     component.selectedGeneSetsCollection = geneSetsCollectionMock1;
@@ -480,8 +496,16 @@ describe('GeneSetsComponent', () => {
 
   it('should set onSearch', () => {
     component.selectedGeneSetsCollection = new GeneSetsCollection('name1', 'desc2', [
-      new GeneSetType('datasetId1', 'datasetName2', [new DenovoPersonSetCollection('personSetCollectionId3', 'personSetCollectionName4', [])]),
-      new GeneSetType('datasetId7', 'datasetName8', [new DenovoPersonSetCollection('personSetCollectionId9', 'personSetCollectionName10', [])]),
+      new GeneSetType(
+        'datasetId1',
+        'datasetName2',
+        [new DenovoPersonSetCollection('personSetCollectionId3', 'personSetCollectionName4', [])]
+      ),
+      new GeneSetType(
+        'datasetId7',
+        'datasetName8',
+        [new DenovoPersonSetCollection('personSetCollectionId9', 'personSetCollectionName10', [])]
+      ),
     ]);
 
     component.geneSets = [
@@ -511,7 +535,7 @@ describe('GeneSetsComponent', () => {
     const setSelectedGeneTypeSpy = jest.spyOn(component, 'setSelectedGeneType');
     component.removeFromList('deNovo: 16p_status: negative');
 
-    expect(setSelectedGeneTypeSpy).toBeCalledWith('deNovo', '16p_status', 'negative', false);
+    expect(setSelectedGeneTypeSpy).toHaveBeenCalledWith('deNovo', '16p_status', 'negative', false);
   });
 
   it('should set the selected dataset as an active dataset', () => {
@@ -529,14 +553,18 @@ describe('GeneSetsComponent', () => {
 
     component.toggleDatasetCollapse(datasetNode);
     expect(component.expandedDatasets).toStrictEqual([datasetNode]);
-  
   });
 
   it('should close all inner opened datasets when closing a parent in the hierarchy', () => {
     const datasetNodeChild2 = new GeneSetTypeNode('childStudyId2', 'childStudyName2', [], []);
     const datasetNodeChild1 = new GeneSetTypeNode('childStudyId1', 'childStudyName1', [], [datasetNodeChild2]);
     const datasetNode = new GeneSetTypeNode('datasetId', 'datasetName', [], [datasetNodeChild1]);
-    const datasetNodeParallel = new GeneSetTypeNode('parallelDatasetId', 'parallelDatasetName', [], [datasetNodeChild1]);
+    const datasetNodeParallel = new GeneSetTypeNode(
+      'parallelDatasetId',
+      'parallelDatasetName',
+      [],
+      [datasetNodeChild1]
+    );
     component.expandedDatasets = [datasetNode, datasetNodeChild1, datasetNodeParallel];
 
     component.toggleDatasetCollapse(datasetNode);
@@ -546,64 +574,77 @@ describe('GeneSetsComponent', () => {
   it('should create denovo modal hierarchy', () => {
     const rxjs = jest.requireActual('rxjs');
     jest.spyOn(rxjs, 'combineLatest').mockReturnValueOnce(of([
-    datasetHierarchyMock,
-    denovoGeneSetsMock,
-     'SSC_genotypes',
-     {
-      geneSet: null,
-      geneSetsCollection: null,
-      geneSetsTypes: null,
-    }
+      datasetHierarchyMock,
+      denovoGeneSetsMock,
+      'SSC_genotypes',
+      {
+        geneSet: null,
+        geneSetsCollection: null,
+        geneSetsTypes: null,
+      }
     ]));
 
     component.ngOnInit();
-    expect(component.denovoDatasetsHierarchy).toEqual(
+    expect(component.denovoDatasetsHierarchy).toStrictEqual(
       [
         new GeneSetTypeNode('SSC_genotypes', 'SSC Genotypes', [new DenovoPersonSetCollection('phenotype', 'phenotype', [
           new PersonSet('autism', 'autism', '#0000'),
           new PersonSet('unaffected', 'unaffected', '#0000'),
         ])], [
-          new GeneSetTypeNode('SFARI_SSC_WGS_2', 'SSC NYGC WGS', [new DenovoPersonSetCollection('phenotype', 'phenotype', [
-            new PersonSet('autism', 'autism', '#0000'),
-            new PersonSet('unaffected', 'unaffected', '#0000'),
-          ])], []),
-          new GeneSetTypeNode('SFARI_SSC_WGS_CSHL', 'SSC CSHL WGS', [new DenovoPersonSetCollection('phenotype', 'phenotype', [
-            new PersonSet('autism', 'autism', '#0000'),
-            new PersonSet('unaffected', 'unaffected', '#0000'),
-          ])], []),
+          new GeneSetTypeNode(
+            'SFARI_SSC_WGS_2', 'SSC NYGC WGS',
+            [new DenovoPersonSetCollection('phenotype', 'phenotype', [
+              new PersonSet('autism', 'autism', '#0000'),
+              new PersonSet('unaffected', 'unaffected', '#0000'),
+            ])],
+            []
+          ),
+          new GeneSetTypeNode(
+            'SFARI_SSC_WGS_CSHL',
+            'SSC CSHL WGS',
+            [new DenovoPersonSetCollection('phenotype', 'phenotype', [
+              new PersonSet('autism', 'autism', '#0000'),
+              new PersonSet('unaffected', 'unaffected', '#0000'),
+            ])],
+            []),
         ]),
-        new GeneSetTypeNode('ssc_rna_seq', 'SSC LCL RNA Sequencing', [new DenovoPersonSetCollection('phenotype', 'phenotype', [
-          new PersonSet('autism', 'autism', '#0000'),
-          new PersonSet('unaffected', 'unaffected', '#0000'),
-        ])], []),
+        new GeneSetTypeNode(
+          'ssc_rna_seq',
+          'SSC LCL RNA Sequencing',
+          [new DenovoPersonSetCollection('phenotype', 'phenotype', [
+            new PersonSet('autism', 'autism', '#0000'),
+            new PersonSet('unaffected', 'unaffected', '#0000'),
+          ])],
+          []
+        ),
       ]
     );
 
     expect(component.geneSetsCollections).toEqual(geneSetsCollectionMock);
-    expect(component.selectedGeneSetsCollection.name).toEqual('denovo');
-    expect(component.activeDataset.datasetId).toEqual('SSC_genotypes');
-    expect(component.geneSetsLoaded).toEqual(2);
+    expect(component.selectedGeneSetsCollection.name).toBe('denovo');
+    expect(component.activeDataset.datasetId).toBe('SSC_genotypes');
+    expect(component.geneSetsLoaded).toBe(2);
   });
 
   it('should restore gene sets types', () => {
     const rxjs = jest.requireActual('rxjs');
     jest.spyOn(rxjs, 'combineLatest').mockReturnValueOnce(of([
-    datasetHierarchyMock,
-    denovoGeneSetsMock,
-     'datasetId',
-     {
-      geneSet: new GeneSet('geneSet1', 10, 'geneSet1', 'download'),
-      geneSetsCollection: new GeneSetsCollection('denovo', 'denovo', []),
-      geneSetsTypes: [
-        new SelectedDenovoTypes('SFARI_SSC_WGS_CSHL', [
-          new SelectedPersonSetCollections('phenotype', ['unaffected'])
-        ])
-      ]
-    }
+      datasetHierarchyMock,
+      denovoGeneSetsMock,
+      'datasetId',
+      {
+        geneSet: new GeneSet('geneSet1', 10, 'geneSet1', 'download'),
+        geneSetsCollection: new GeneSetsCollection('denovo', 'denovo', []),
+        geneSetsTypes: [
+          new SelectedDenovoTypes('SFARI_SSC_WGS_CSHL', [
+            new SelectedPersonSetCollections('phenotype', ['unaffected'])
+          ])
+        ]
+      }
     ]));
 
     component.ngOnInit();
-    expect(component.selectedGeneSet.name).toEqual('geneSet1');
+    expect(component.selectedGeneSet.name).toBe('geneSet1');
     expect(component.expandedDatasets[0].datasetId).toBe('SSC_genotypes');
     expect(component.datasetsList).toContain('SFARI_SSC_WGS_CSHL: phenotype: unaffected');
     expect(component.modifiedDatasetIds).toStrictEqual(new Set<string>(['SFARI_SSC_WGS_CSHL']));
@@ -612,14 +653,14 @@ describe('GeneSetsComponent', () => {
   it('should select first person set type from the first dataset as default', () => {
     const rxjs = jest.requireActual('rxjs');
     jest.spyOn(rxjs, 'combineLatest').mockReturnValueOnce(of([
-    datasetHierarchyMock,
-    denovoGeneSetsMock,
-     'SSC_genotypes',
-     {
-      geneSet: null,
-      geneSetsCollection: null,
-      geneSetsTypes: null
-    }
+      datasetHierarchyMock,
+      denovoGeneSetsMock,
+      'SSC_genotypes',
+      {
+        geneSet: null,
+        geneSetsCollection: null,
+        geneSetsTypes: null
+      }
     ]));
 
     component.ngOnInit();
@@ -628,5 +669,4 @@ describe('GeneSetsComponent', () => {
     expect(component.datasetsList).toContain('SSC_genotypes: phenotype: autism');
     expect(component.modifiedDatasetIds).toStrictEqual(new Set<string>(['SSC_genotypes']));
   });
-
 });

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -174,14 +174,16 @@ export class GeneSetsComponent extends ComponentValidator implements OnInit {
     geneSet: GeneSet;
 }): void {
     if (state.geneSet && state.geneSetsCollection) {
-      this.selectedGeneSetsCollection = this.geneSetsCollections.find(collection => collection.name === state.geneSetsCollection.name);
-        if (state.geneSetsTypes) {
-          this.restoreGeneTypes(state.geneSetsTypes);
-        }
-        // the gene set must be restored last, as that triggers the state update
-        // otherwise, sharing a restored state won't work properly
-        this.selectedGeneSet = state.geneSet;
-        this.onSearch();
+      this.selectedGeneSetsCollection = this.geneSetsCollections.find(
+        collection => collection.name === state.geneSetsCollection.name
+      );
+      if (state.geneSetsTypes) {
+        this.restoreGeneTypes(state.geneSetsTypes);
+      }
+      // the gene set must be restored last, as that triggers the state update
+      // otherwise, sharing a restored state won't work properly
+      this.selectedGeneSet = state.geneSet;
+      this.onSearch();
     } else {
       this.onSearch();
     }
@@ -202,15 +204,15 @@ export class GeneSetsComponent extends ComponentValidator implements OnInit {
 
   private expandUntil(datasetId: string, hierarchy: GeneSetTypeNode[]): boolean {
     let parentExpand = false;
-    if(!hierarchy.length) {
+    if (!hierarchy.length) {
       return parentExpand;
     }
     hierarchy.forEach(node => {
-      if(node.datasetId === datasetId) {
+      if (node.datasetId === datasetId) {
         parentExpand = true;
       } else {
         const toExpand = this.expandUntil(datasetId, node.children);
-        if(toExpand) {
+        if (toExpand) {
           this.expandedDatasets.push(node);
           parentExpand = true;
         }
@@ -363,9 +365,8 @@ export class GeneSetsComponent extends ComponentValidator implements OnInit {
         }
       }
 
-      if(!this.currentGeneSetsTypes.find(type => type.datasetId === datasetId)) {
+      if (!this.currentGeneSetsTypes.find(type => type.datasetId === datasetId)) {
         this.modifiedDatasetIds.delete(datasetId);
-
       }
     }
   }

--- a/src/app/gene-sets/gene-sets.service.spec.ts
+++ b/src/app/gene-sets/gene-sets.service.spec.ts
@@ -58,9 +58,9 @@ describe('GeneSetsService', () => {
     const downloadLink = service.getGeneSetDownloadLink(collectionName, geneSetName, geneSetTypes);
 
     expect(downloadLink).toBe(`${configMock.baseUrl}gene_sets/gene_set_download?` +
-      `geneSetsCollection=denovo&` +
-      `geneSet=LGDs.Male&` +
-      `geneSetsTypes=` +
-      `[{\"datasetId\":\"deNovo\",\"collections\":[{\"personSetId\":\"phenotype\",\"types\":[\"autism\",\"unaffected\"]}]}]`);
+      'geneSetsCollection=denovo&' +
+      'geneSet=LGDs.Male&' +
+      'geneSetsTypes=' +
+      '[{"datasetId":"deNovo","collections":[{"personSetId":"phenotype","types":["autism","unaffected"]}]}]');
   });
 });

--- a/src/app/gene-sets/gene-sets.service.ts
+++ b/src/app/gene-sets/gene-sets.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { GeneSetsCollection, GeneSet, GeneSetJson, GeneSetType, GeneSetCollectionJson, SelectedDenovoTypes } from './gene-sets';
+import {
+  GeneSetsCollection,
+  GeneSet,
+  GeneSetJson,
+  GeneSetType,
+  GeneSetCollectionJson,
+  SelectedDenovoTypes } from './gene-sets';
 import { ConfigService } from '../config/config.service';
 import { map } from 'rxjs/operators';
 
@@ -64,6 +70,5 @@ export class GeneSetsService {
       `geneSetsCollection=${geneSetsCollectionName}&` +
       `geneSet=${geneSetName}&` +
       `geneSetsTypes=${JSON.stringify(geneSetsTypes)}`;
-    ;
   }
 }

--- a/src/app/gene-sets/gene-sets.spec.ts
+++ b/src/app/gene-sets/gene-sets.spec.ts
@@ -24,7 +24,7 @@ describe('GeneSets', () => {
         new GeneSetType('datasetId9', 'datasetName10', [
           new DenovoPersonSetCollection('personSetCollectionId11', 'personSetCollectionName12', [])
         ])
-       ]
+      ]
     });
     expect(geneSetsCollectionMock1).toStrictEqual(geneSetsCollectionMockFromJSON1);
   });

--- a/src/app/genotype-browser/genotype-browser.component.spec.ts
+++ b/src/app/genotype-browser/genotype-browser.component.spec.ts
@@ -179,7 +179,6 @@ describe('GenotypeBrowserComponent', () => {
     component = fixture.componentInstance;
     loadingService = TestBed.inject(FullscreenLoadingService);
 
-    // eslint-disable-next-line max-len
     const selectedDatasetMockModel = {selectedDatasetId: 'testId'};
 
     store = TestBed.inject(Store);
@@ -202,7 +201,7 @@ describe('GenotypeBrowserComponent', () => {
         submit: jest.fn()
       }
     };
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     component.selectedDataset = new Dataset('datasetId', 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeMock, null, [], null, null, '', null);
 
     component.onSubmit(mockEvent);

--- a/src/app/pedigree-chart/pedigree-chart.component.spec.ts
+++ b/src/app/pedigree-chart/pedigree-chart.component.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable @stylistic/max-len */
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ChangeDetectorRef } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';

--- a/src/app/pheno-browser/pheno-browser.component.spec.ts
+++ b/src/app/pheno-browser/pheno-browser.component.spec.ts
@@ -84,7 +84,7 @@ class MockPhenoBrowserService {
 }
 class MockDatasetsService {
   public getDataset(datasetId: string): Observable<Dataset> {
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     return of(new Dataset(datasetId, 'testDataset', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, null, '', null));
   }
 }
@@ -252,7 +252,7 @@ describe('PhenoBrowserComponent', () => {
       search_term: 'search'
       /* eslint-enable */
     };
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     component.selectedDataset = new Dataset(data.dataset_id, '', [], true, [], [], [], '', true, true, true, true, null, null, null, [], null, true, '', null);
     component.selectedInstrument$ = new BehaviorSubject(data.instrument);
     component.searchTermObs$ = of(data.search_term);

--- a/src/app/pheno-tool-measure/pheno-tool-measure.component.spec.ts
+++ b/src/app/pheno-tool-measure/pheno-tool-measure.component.spec.ts
@@ -39,9 +39,7 @@ describe('PhenoToolMeasureComponent', () => {
     fixture = TestBed.createComponent(PhenoToolMeasureComponent);
     component = fixture.componentInstance;
 
-    // eslint-disable-next-line max-len
     const selectedDatasetMockModel = {selectedDatasetId: 'testId'};
-
 
     store = TestBed.inject(Store);
     jest.spyOn(store, 'select').mockReturnValue(of(selectedDatasetMockModel));

--- a/src/app/pheno-tool/pheno-tool.component.spec.ts
+++ b/src/app/pheno-tool/pheno-tool.component.spec.ts
@@ -43,9 +43,9 @@ class PhenoToolServiceMock {
 
 class MockDatasetsService {
   public getDataset(datasetId: string): Observable<Dataset> {
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     const genotypeBrowserConfigMock = new GenotypeBrowser(true, true, true, true, true, true, true, true, true, new Array<object>(), new Array<PersonFilter>(), new Array<PersonFilter>(), [], [], [], [], 0);
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @stylistic/max-len
     return of(new Dataset(datasetId, 'testDataset', [], true, [], [], [], '', true, true, true, true, null, genotypeBrowserConfigMock, null, [], null, null, '', null));
   }
 }

--- a/src/app/utils/gpf.state.ts
+++ b/src/app/utils/gpf.state.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable @stylistic/max-len */
 import { createReducer, on } from '@ngrx/store';
 import { GeneProfiles, initialState as geneProfilesInitialState } from 'app/gene-profiles-table/gene-profiles-table.state';
 import { GeneScoresState, initialState as geneScoresInitialState } from 'app/gene-scores/gene-scores.state';
@@ -11,7 +11,7 @@ import { initialState as personIdsInitialState } from 'app/person-ids/person-ids
 import { initialState as personFiltersInitialState } from 'app/person-filters/person-filters.state';
 import { initialState as studyFiltersInitialState } from 'app/study-filters/study-filters.state';
 import { initialState as effectTypesInitialState } from 'app/effect-types/effect-types.state';
-import { initialState as genderInitialState } from 'app/gender/gender.state'
+import { initialState as genderInitialState } from 'app/gender/gender.state';
 import { initialState as variantTypesInitialState } from 'app/variant-types/variant-types.state';
 import { initialState as inheritanceTypesInitialState } from 'app/inheritancetypes/inheritancetypes.state';
 import { EnrichmentModels, initialState as enrichmentModelsInitialState } from 'app/enrichment-models/enrichment-models.state';


### PR DESCRIPTION
* If the query sending user info has delay, the request for getting the gene profiles state of the user will not be sent. This can result in logged in user with missing state for gene profiles.

* Update gene profiles unit test by providing mock implementation of the get user info query.

## Background

Sometimes when refreshing gene profiles the state, loaded from backend, disappears.

## Aim

To fix it.

## Implementation

Before requesting the state from backend, we have to wait for user info to come.