### PR TITLE
Remove dataset child descriptions title when empty

### DIFF
--- a/src/app/dataset-description/dataset-description.component.html
+++ b/src/app/dataset-description/dataset-description.component.html
@@ -10,7 +10,10 @@
     >No dataset description available</span
   >
 
-  <div class="container" style="display: block; padding: 20px 0; width: auto">
+  <div
+    *ngIf="descriptionHierarchy.children.length > 0"
+    class="container"
+    style="display: block; padding: 20px 0; width: auto">
     <p>This dataset includes:</p>
     <ul class="container">
       <ng-container


### PR DESCRIPTION
Hide title text before dataset children descriptions when the descriptions list is empty.

## Background
Datasets children descriptions (below the dataset description) had a title before the list.
![image](https://github.com/user-attachments/assets/94107311-d974-4b40-b153-992df3384944)
The title stayed even if no descriptions are listed.

## Aim
Remove/hide the text or the whole section when the dataset had no children with descriptions.

## Implementation
Remove children descriptions elements when zero descriptions are found.
