### PR TITLE
Improve denovo gene sets UI

### DIFF
--- a/src/app/gene-sets/gene-sets.component.css
+++ b/src/app/gene-sets/gene-sets.component.css
@@ -148,7 +148,6 @@
   display: flex;
 }
 
-#no-collections-message {
-  opacity: 75%;
-  font-style: italic;
+.disabled-dataset {
+  pointer-events: none;
 }

--- a/src/app/gene-sets/gene-sets.component.html
+++ b/src/app/gene-sets/gene-sets.component.html
@@ -28,10 +28,6 @@
             </div>
 
             <div id="filters" *ngIf="activeDataset">
-              <div *ngIf="!activeDataset.personSetCollections.length" id="no-collections-message"
-                >No person set collections</div
-              >
-
               <div *ngFor="let collection of activeDataset.personSetCollections">
                 {{ collection.personSetCollectionName }}:
                 <div *ngFor="let personSet of collection.personSetCollectionLegend">
@@ -87,6 +83,7 @@
             [class.modified]="
               activeDataset?.datasetId !== dataset.datasetId && modifiedDatasetIds.has(dataset.datasetId)
             "
+            [class.disabled-dataset]="!dataset.personSetCollections.length"
             [style.opacity]="dataset.personSetCollections.length ? 1.0 : 0.3"
             [ngStyle]="{ 'padding-left': (dataset.children.length ? 5 : 19) + 'px' }"
             (click)="select(dataset)"

--- a/src/app/gene-sets/gene-sets.component.html
+++ b/src/app/gene-sets/gene-sets.component.html
@@ -87,6 +87,7 @@
             [class.modified]="
               activeDataset?.datasetId !== dataset.datasetId && modifiedDatasetIds.has(dataset.datasetId)
             "
+            [style.opacity]="dataset.personSetCollections.length ? 1.0 : 0.3"
             [ngStyle]="{ 'padding-left': (dataset.children.length ? 5 : 19) + 'px' }"
             (click)="select(dataset)"
             >{{ dataset.datasetName }}</div

--- a/src/app/gene-sets/gene-sets.component.ts
+++ b/src/app/gene-sets/gene-sets.component.ts
@@ -235,7 +235,6 @@ export class GeneSetsComponent extends ComponentValidator implements OnInit {
     this.searchQuery = '';
     this.selectedGeneSet = null;
     this.isDropdownOpen = true;
-    this.onSearch();
   }
 
   public openCloseDropdown(): void {
@@ -379,6 +378,8 @@ export class GeneSetsComponent extends ComponentValidator implements OnInit {
         this.modifiedDatasetIds.delete(datasetId);
       }
     }
+
+    this.onSearch();
   }
 
   public get selectedGeneSetsCollection(): GeneSetsCollection {

--- a/src/styles.css
+++ b/src/styles.css
@@ -565,6 +565,10 @@ mat-option.mat-mdc-option-active {
   background: rgba(0, 0, 0, 4%) !important;
 }
 
+.mat-mdc-option .mat-pseudo-checkbox-minimal {
+  display: none;
+}
+
 /* stylelint-disable-next-line selector-class-pattern */
 .mdc-list-item__primary-text {
   color: black !important;


### PR DESCRIPTION
## Background

Denovo gene sets ui need some improvements.

## Implementation

- Disable dataset and lower the opacity when it has no person set collection. However it should be still expandable.
- Change the place where a new dropdown content is requested in order to prevent the old content to be visible and to flicker when opening the dropdown. 
- Remove a red check icon that appears on the line of a selected dropdown option.


