### PR TITLE
restore load-query family ids and person ids

### DIFF
--- a/src/app/load-query/load-query.component.ts
+++ b/src/app/load-query/load-query.component.ts
@@ -21,6 +21,8 @@ import { setGenomicScores } from 'app/genomic-scores-block/genomic-scores-block.
 import { setUniqueFamilyVariantsFilter } from 'app/unique-family-variants-filter/unique-family-variants-filter.state';
 import { setFamilyFilters, setPersonFilters } from 'app/person-filters/person-filters.state';
 import { setPhenoToolMeasure } from 'app/pheno-tool-measure/pheno-tool-measure.state';
+import { setFamilyIds } from 'app/family-ids/family-ids.state';
+import { setPersonIds } from 'app/person-ids/person-ids.state';
 
 const PAGE_TYPE_TO_NAVIGATE = {
   genotype: (datasetId: string): string[] => ['datasets', datasetId, 'genotype-browser'],
@@ -99,6 +101,8 @@ export class LoadQueryComponent implements OnInit {
       this.store.dispatch(setFamilyFilters({familyFilters: state.personFilters.familyFilters}));
       this.store.dispatch(setPersonFilters({personFilters: state.personFilters.personFilters}));
       this.store.dispatch(setPhenoToolMeasure({phenoToolMeasure: state.phenoToolMeasure}));
+      this.store.dispatch(setFamilyIds({familyIds: state.familyIds}));
+      this.store.dispatch(setPersonIds({personIds: state.personIds}));
       this.router.navigate(navigationParams);
     }
   }


### PR DESCRIPTION
## Background

Family ids and person ids were not restored when loading query.

## Implementation

Add them when loading query.
