### PR TITLE
Gene browser cancel family variants request on gene symbol change

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -175,6 +175,7 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.queryService.cancelStreamPost();
     this.geneSymbol = '';
     this.showResults = false;
     this.geneSymbolSuggestions = [];


### PR DESCRIPTION
If the user changes the input gene symbol field mid-request, the family variants request will now be properly canceled.