### PR TITLE
add pheno browser table images lazy loading

### DIFF
--- a/src/app/pheno-browser-table/pheno-browser-table.component.html
+++ b/src/app/pheno-browser-table/pheno-browser-table.component.html
@@ -116,7 +116,11 @@
 
     <div class="grid-cell figure-distribution-cell">
       <a [class.clickable]="!!measure.figureDistribution" (click)="openModal(measure.figureDistribution)">
-        <img *ngIf="measure.figureDistributionSmall" class="table-chart" [src]="measure.figureDistributionSmall" />
+        <img
+          *ngIf="measure.figureDistributionSmall"
+          class="table-chart"
+          [src]="measure.figureDistributionSmall"
+          loading="lazy" />
       </a>
     </div>
 
@@ -157,7 +161,8 @@
           <img
             *ngIf="measure.regressions.getReg(regressionId).figureRegressionSmall"
             class="table-chart"
-            [src]="measure.regressions.getReg(regressionId).figureRegressionSmall" />
+            [src]="measure.regressions.getReg(regressionId).figureRegressionSmall"
+            loading="lazy" />
         </a>
       </div>
 


### PR DESCRIPTION
## Background

All images in Phenotype browser table load at the same time which means there are a lot of requests that slower the table loading.

## Aim

To load images which are in and near the view port.

## Implementation

Add html `img` property attribute `loading="lazy"`.
