### PR TITLE
Pheno tool anonymous access

### DIFF
--- a/src/app/datasets/datasets.component.html
+++ b/src/app/datasets/datasets.component.html
@@ -1,8 +1,9 @@
 <div *ngIf="selectedDataset" class="content">
-  <div
-    *ngIf="registerAlertVisible"
-    id="register-alert">
-    <span>To gain full access of the data and tools in GPF please consider registering. Visit the <a routerLink="/about">About</a> page for more information.</span>
+  <div *ngIf="registerAlertVisible" id="register-alert">
+    <span
+      >To gain full access of the data and tools in GPF please consider registering. Visit the
+      <a routerLink="/about">About</a> page for more information.</span
+    >
   </div>
 
   <nav class="navbar navbar-custom navbar-toggleable-md navbar-expand-lg navbar-light bg-light">
@@ -32,9 +33,7 @@
           </div>
         </div>
       </li>
-      <li
-        [class.disabled-tool]="!selectedDataset.geneBrowser.enabled"
-        class="nav-item">
+      <li [class.disabled-tool]="!selectedDataset.geneBrowser.enabled" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.geneBrowser }}" routerLinkActive="active">Gene Browser</a>
       </li>
       <li [class.disabled-tool]="!(selectedDataset.genotypeBrowser && selectedDataset.accessRights)" class="nav-item">
@@ -42,12 +41,12 @@
           >Genotype Browser</a
         >
       </li>
-      <li [class.disabled-tool]="!(selectedDataset.phenotypeBrowser)" class="nav-item">
+      <li [class.disabled-tool]="!selectedDataset.phenotypeBrowser" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.phenotypeBrowser }}" routerLinkActive="active"
           >Phenotype Browser</a
         >
       </li>
-      <li [class.disabled-tool]="!(selectedDataset.enrichmentTool)" class="nav-item">
+      <li [class.disabled-tool]="!selectedDataset.enrichmentTool" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.enrichmentTool }}" routerLinkActive="active"
           >Enrichment Tool</a
         >
@@ -60,9 +59,7 @@
           >Dataset Description</a
         >
       </li>
-      <li
-        [class.disabled-tool]="!(selectedDataset.commonReport.enabled)"
-        class="nav-item">
+      <li [class.disabled-tool]="!selectedDataset.commonReport.enabled" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.datasetStatistics }}" routerLinkActive="active"
           >Dataset Statistics</a
         >
@@ -71,12 +68,14 @@
   </nav>
 
   <router-outlet
-    *ngIf="selectedDataset.accessRights
-      || selectedTool === toolPageLinks.datasetDescription
-      || selectedTool === toolPageLinks.phenotypeBrowser
-      || selectedTool === toolPageLinks.datasetStatistics
-      || selectedTool === toolPageLinks.geneBrowser
-      || selectedTool === toolPageLinks.enrichmentTool"
+    *ngIf="
+      selectedDataset.accessRights ||
+      selectedTool === toolPageLinks.datasetDescription ||
+      selectedTool === toolPageLinks.phenotypeBrowser ||
+      selectedTool === toolPageLinks.datasetStatistics ||
+      selectedTool === toolPageLinks.geneBrowser ||
+      selectedTool === toolPageLinks.enrichmentTool
+    "
     (activate)="routeChange()"
     class="content"></router-outlet>
 </div>

--- a/src/app/datasets/datasets.component.html
+++ b/src/app/datasets/datasets.component.html
@@ -51,7 +51,7 @@
           >Enrichment Tool</a
         >
       </li>
-      <li [class.disabled-tool]="!(selectedDataset.phenotypeTool && selectedDataset.accessRights)" class="nav-item">
+      <li [class.disabled-tool]="!selectedDataset.phenotypeTool" class="nav-item">
         <a class="nav-link" routerLink="{{ toolPageLinks.phenotypeTool }}" routerLinkActive="active">Phenotype Tool</a>
       </li>
       <li class="nav-item">
@@ -74,7 +74,8 @@
       selectedTool === toolPageLinks.phenotypeBrowser ||
       selectedTool === toolPageLinks.datasetStatistics ||
       selectedTool === toolPageLinks.geneBrowser ||
-      selectedTool === toolPageLinks.enrichmentTool
+      selectedTool === toolPageLinks.enrichmentTool ||
+      selectedTool === toolPageLinks.phenotypeTool
     "
     (activate)="routeChange()"
     class="content"></router-outlet>

--- a/src/app/enrichment-tool/enrichment-tool.component.html
+++ b/src/app/enrichment-tool/enrichment-tool.component.html
@@ -11,12 +11,10 @@
       value="Enrichment Test"
       (click)="submitQuery()" />
     <gpf-save-query
-      [disabled]="disableQueryButtons || !(selectedDataset?.accessRights)"
-      queryType="enrichment"
-    ></gpf-save-query>
+      [disabled]="disableQueryButtons || !selectedDataset?.accessRights"
+      queryType="enrichment"></gpf-save-query>
   </div>
   <gpf-enrichment-table
-    [class.disabled-table-links]="!(selectedDataset?.accessRights)"
-    [enrichmentResults]="enrichmentResults"
-  ></gpf-enrichment-table>
+    [class.disabled-table-links]="!selectedDataset?.accessRights"
+    [enrichmentResults]="enrichmentResults"></gpf-enrichment-table>
 </div>

--- a/src/app/pheno-browser/pheno-browser.component.html
+++ b/src/app/pheno-browser/pheno-browser.component.html
@@ -41,7 +41,7 @@
         <span>Phenotype measures</span>
         <input name="queryData" type="hidden" />
         <button
-          [class.disabled-download]="!(selectedDataset?.accessRights)"
+          [class.disabled-download]="!selectedDataset?.accessRights"
           (click)="downloadMeasures()"
           id="download-measures"
           class="btn btn-md btn-primary btn-right">

--- a/src/app/pheno-tool/pheno-tool.component.html
+++ b/src/app/pheno-tool/pheno-tool.component.html
@@ -19,14 +19,16 @@
           [disabled]="disableQueryButtons">
           Report
         </button>
-        <gpf-save-query [disabled]="disableQueryButtons" queryType="phenotool"></gpf-save-query>
+        <gpf-save-query
+          [disabled]="disableQueryButtons || !selectedDataset?.accessRights"
+          queryType="phenotool"></gpf-save-query>
       </div>
       <div class="btn-group">
         <form (ngSubmit)="onDownload($event)" action="{{ configService.baseUrl }}pheno_tool/download" method="post">
           <input name="queryData" type="hidden" />
           <button
             class="btn btn-md btn-primary"
-            [disabled]="disableQueryButtons"
+            [disabled]="disableQueryButtons || !selectedDataset?.accessRights"
             type="submit"
             id="download-pheno-report-button"
             >Download</button

--- a/src/app/save-query/save-query.component.html
+++ b/src/app/save-query/save-query.component.html
@@ -1,4 +1,4 @@
-<div ngbDropdown *ngIf="(userInfo$ | async)?.email" autoClose="outside">
+<div ngbDropdown autoClose="outside">
   <button
     (click)="focusNameInput(); toggleDropdown()"
     [disabled]="disabled"

--- a/src/app/variant-reports/variant-reports.component.html
+++ b/src/app/variant-reports/variant-reports.component.html
@@ -33,7 +33,7 @@
   <ng-template #familiesByNumber>
     <div id="download-total-families">
       <a
-        [class.disabled-download]="!(selectedDataset?.accessRights)"
+        [class.disabled-download]="!selectedDataset?.accessRights"
         class="download-link"
         [href]="getDownloadLink()"
         download
@@ -104,10 +104,11 @@
           action="{{ config.baseUrl }}common_reports/families_data/{{ selectedDataset.id }}"
           method="post"
           style="display: flex; align-items: center">
-          <span>Selected families: </span><span id="families-sum">{{ filteredFamiliesCount + ' / ' + totalFamiliesCount }}</span>
+          <span>Selected families: </span>
+          <span id="families-sum">{{ filteredFamiliesCount + ' / ' + totalFamiliesCount }}</span>
           <input name="queryData" type="hidden" />
           <button
-            [class.disabled-download]="!(selectedDataset?.accessRights)"
+            [class.disabled-download]="!selectedDataset?.accessRights"
             class="btn btn-md btn-primary btn-right"
             id="download-button"
             [disabled]="currentPedigreeTable.pedigrees.length === 0"


### PR DESCRIPTION
## Background

Pheno tool was disabled for anonymous users.

## Aim

To enable it.

## Implementation

Enable pheno tool - user can view reports and work with all filters. Only download and share/save query are disabled.
