### PR TITLE
Famiy filters block errors state not updating

### DIFF
--- a/src/app/common/errors.state.ts
+++ b/src/app/common/errors.state.ts
@@ -36,9 +36,16 @@ export const errorsReducer = createReducer(
       updatedState = [...state, cloneDeep(errors)];
       return updatedState;
     }
+
+    errors.errors.forEach(e => {
+      if (!state[currentIndex].errors.includes(e)) {
+        state[currentIndex].errors.push(e);
+      }
+    });
+
     updatedState[currentIndex] = {
       componentId: state[currentIndex].componentId,
-      errors: [...state[currentIndex].errors, ...errors.errors]
+      errors: [...state[currentIndex].errors]
     };
     return updatedState;
   }),

--- a/src/app/family-ids/family-ids.component.ts
+++ b/src/app/family-ids/family-ids.component.ts
@@ -24,8 +24,10 @@ export class FamilyIdsComponent extends ComponentValidator implements OnInit {
 
     this.focusTextInputArea();
     this.store.select(selectFamilyIds).pipe(take(1)).subscribe((familyIds: string[]) => {
-      // restore state
-      this.setFamilyIds(familyIds.join('\n')); // must join on more conditions most likely
+      if (familyIds.length) {
+        // restore state
+        this.setFamilyIds(familyIds.join('\n')); // must join on more conditions most likely
+      }
     });
   }
 

--- a/src/app/person-filters/person-filters.component.ts
+++ b/src/app/person-filters/person-filters.component.ts
@@ -34,14 +34,12 @@ export class PersonFiltersComponent extends ComponentValidator implements OnInit
 
   public ngOnInit(): void {
     this.selectedDatasetId = this.dataset.id;
-
     this.store.select(selectPersonFilters).subscribe((state: PersonAndFamilyFilters) => {
       if (this.isFamilyFilters) {
         this.areFiltersSelected = Boolean(state.familyFilters?.filter(f => f.sourceType === 'continuous').length);
       } else {
         this.areFiltersSelected = Boolean(state.personFilters?.filter(f => f.sourceType === 'continuous').length);
       }
-      super.ngOnInit();
     });
 
     this.store.select(selectPersonFilters).pipe(take(1)).subscribe((state: PersonAndFamilyFilters) => {
@@ -49,6 +47,8 @@ export class PersonFiltersComponent extends ComponentValidator implements OnInit
       this.setDefaultFilters();
       this.setFiltersFromState(clonedState);
     });
+
+    super.ngOnInit();
   }
 
   private setDefaultFilters(): void {

--- a/src/app/person-filters/person-filters.state.ts
+++ b/src/app/person-filters/person-filters.state.ts
@@ -104,7 +104,7 @@ export const personFiltersReducer = createReducer(
     };
   }),
   on(removeFamilyFilter, (state, {familyFilter}) => {
-    const newFamilyFilters = state.familyFilters;
+    const newFamilyFilters = cloneDeep(state.familyFilters);
     newFamilyFilters?.splice(newFamilyFilters.findIndex(filter => filter.id === familyFilter.id), 1);
 
     return {
@@ -113,7 +113,7 @@ export const personFiltersReducer = createReducer(
     };
   }),
   on(removePersonFilter, (state, {personFilter}) => {
-    const newPersonFilters = state.personFilters;
+    const newPersonFilters = cloneDeep(state.personFilters);
     newPersonFilters?.splice(newPersonFilters.findIndex(filter => filter.id === personFilter.id), 1);
 
     return {


### PR DESCRIPTION
## Background

Validation of Family filters block `Advanced` tab saves error in state and when switching to another tab, the error doesn't get clean which results in disabled buttons (Report, Downloadn and Share/ save query).
This can be reproduced by switching once or several times between `Family ids` tab and `Advanced` and then go to `All` tab and the buttons should be disabled.

Another issue that was found while working is when clearing the selected pheno measure in family filters 'Advanced' tab, in browser console appears TypeError message - `TypeError: Cannot delete property '0' of [object Array].`

## Implementation

To trigger validation, person filters component need to call ngOnInit of the parent which is the validation class. This call is moved outside store subscription and moved at the end of the person filters ngOnInit. 

Remove filters state actions are made to work with cloned arrays with filters to fix the TypeError.
