### PR TITLE
Make pheno report image

### DIFF
--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.css
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.css
@@ -3,3 +3,13 @@
   width: 100%;
   font-weight: bold;
 }
+
+#image-download-container {
+  max-width: 1140px;
+  margin: auto;
+  padding: 0 15px 30px;
+}
+
+#image-download {
+  float: right;
+}

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -1,10 +1,14 @@
-<div class="description">{{ phenoToolResults.description }}</div>
+<div id="image-download-container">
+  <a id="image-download">Download report as an image</a>
+</div>
 <div style="display: flex; justify-content: center; max-height: 700px; min-width: 1000px">
   <svg [attr.max-width]="width" [attr.max-height]="height" [attr.viewBox]="getViewBox()">
-    <text x="0" y="45">with hit</text>
-    <text x="0" y="65">without hit</text>
+    <text x="40%" y="20" class="description">{{ phenoToolResults.description }}</text>
 
-    <g #innerGroup transform="translate(30, 80)">
+    <text x="0" y="70">with hit</text>
+    <text x="0" y="90">without hit</text>
+
+    <g #innerGroup transform="translate(30, 110)">
       <g
         *ngFor="let result of phenoToolResults.results; let i = index"
         gpf-pheno-tool-results-chart-per-effect

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.spec.ts
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.spec.ts
@@ -16,6 +16,14 @@ describe('PhenoToolResultsChartComponent', () => {
       description: undefined,
       results: []
     };
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: jest.fn()
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: jest.fn()
+    });
+
     fixture.detectChanges();
   }));
 

--- a/src/app/pheno-tool/pheno-tool.component.css
+++ b/src/app/pheno-tool/pheno-tool.component.css
@@ -4,5 +4,6 @@
 
 .pheno-tool-results {
   padding: 30px;
+  padding-top: 0;
   width: 100%;
 }


### PR DESCRIPTION
## Background

Pheno tool report is an svg element which cannot be saved by right click + save beacuse it's not an image or downloaded by other methods. It can be screenshotted only.

## Aim

Add button to download converted to image svg element.

## Implementation

The solution uses JavaScript only. There is no way of converting svg into png without using HTML canvas element natively.
Convert svg into image in `createImgFromSvg() `method: 
- get the svg element from template, transform it to xml string using `XMLSerializer` and `serializeToString` and then to Blob. 
- create a URL representing the object is created by `URL.createObjectURL` using the Blob
- create an image element which will contain the report
- attach the created url as the image source
- draw the image in the created canvas element
- get the data url from canvas using `toDataURL()` method which returns a data URL containing a representation of the image in png format
- attach it to the anchor element responsible for the downloading

The CSS from the .css file is ignored so some important styles (font and background color) need to be set in the method. 
The method is invoked in ngAfterViewInit() because it executes after the child components are loaded.
