### PR TITLE
enable image source to be blob

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
 
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="content-security-policy" content="img-src 'self' blob: data:"/ >
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&amp;subset=latin-ext" rel="stylesheet" />


### PR DESCRIPTION
* When loading pheno tool report image, there was content security policy violation in deployed app because the image source was blob which was not set to be a valid source type
