### PR TITLE
Update save query sent parameters

### DIFF
--- a/src/app/enrichment-table/enrichment-table-row.component.ts
+++ b/src/app/enrichment-table/enrichment-table-row.component.ts
@@ -54,8 +54,7 @@ export class EnrichmentTableRowComponent {
         delete queryData['geneSetsState'];
         delete queryData['geneScoresState'];
       }
-
-      this.queryService.saveQuery(queryData, 'genotype')
+      this.queryService.saveQuery(queryData, 'genotype', 'system')
         .pipe(take(1))
         .subscribe(urlObject => {
           const url = this.queryService.getLoadUrlFromResponse(urlObject);

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -239,7 +239,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
     store.pipe(take(1)).subscribe(state => {
       const clonedState = cloneDeep(state);
       clonedState['datasetId'] = datasetId;
-      queryService.saveQuery(clonedState, 'genotype')
+      queryService.saveQuery(clonedState, 'genotype', 'system')
         .pipe(take(1))
         .subscribe(urlObject => {
           const url = queryService.getLoadUrlFromResponse(urlObject);

--- a/src/app/query/query.service.ts
+++ b/src/app/query/query.service.ts
@@ -156,7 +156,7 @@ export class QueryService {
     return this.http.post(this.config.baseUrl + this.geneViewVariantsUrl, filter);
   }
 
-  public saveQuery(queryData: object, page: string): Observable<object> {
+  public saveQuery(queryData: object, page: string, origin: 'saved' | 'user' | 'system'): Observable<object> {
     const options = { headers: this.headers };
 
     queryData = {...queryData};
@@ -164,7 +164,8 @@ export class QueryService {
 
     const data = {
       data: queryData,
-      page: page
+      page: page,
+      origin: origin,
     };
 
     return this.http

--- a/src/app/save-query/save-query.component.ts
+++ b/src/app/save-query/save-query.component.ts
@@ -48,7 +48,7 @@ export class SaveQueryComponent implements OnInit {
 
     this.store.pipe(
       take(1),
-      switchMap(state => this.queryService.saveQuery(state, this.queryType).pipe(take(1))),
+      switchMap(state => this.queryService.saveQuery(state, this.queryType, 'saved').pipe(take(1))),
       switchMap((response: {uuid: string}) =>
         this.queryService.saveUserQuery(response.uuid, name, description).pipe(take(1)))
     ).subscribe((response: {uuid: string}) => {
@@ -76,7 +76,7 @@ export class SaveQueryComponent implements OnInit {
 
     this.store.pipe(
       take(1),
-      switchMap(state => this.queryService.saveQuery(state, this.queryType).pipe(take(1)))
+      switchMap(state => this.queryService.saveQuery(state, this.queryType, 'user').pipe(take(1)))
     ).subscribe({
       next: (response: {uuid: string}) => {
         this.urlUUID = response.uuid;


### PR DESCRIPTION
## Background
Saved queries must now send what made them.

## Aim
Add info about the origin of the query creation.
- Made when clicking link on the site that loads a query somewhere.
- Made when using the share query menu.
- Made when a user saves a query to his profile.