### PR TITLE
Fix pheno report image

### DIFF
--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -3,7 +3,9 @@
 </div>
 <div style="display: flex; justify-content: center; max-height: 700px; min-width: 1000px">
   <svg [attr.max-width]="width" [attr.max-height]="height" [attr.viewBox]="getViewBox()">
-    <text x="40%" y="20" class="description">{{ phenoToolResults.description }}</text>
+    <text x="50%" y="20" alignment-baseline="middle" text-anchor="middle" class="description">
+      {{ phenoToolResults.description }}
+    </text>
 
     <text x="0" y="70">with hit</text>
     <text x="0" y="90">without hit</text>

--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.ts
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.ts
@@ -94,7 +94,7 @@ export class PhenoToolResultsChartComponent implements OnInit, OnChanges, AfterV
         a.download = 'pheno-tool-report.png';
         a.href = canvas.toDataURL();
       });
-      img.src = 'data:image/svg+xml;base64,'+ window.btoa(svgStr);
+      img.src = 'data:image/svg+xml;base64,'+ window.btoa(unescape(encodeURIComponent(svgStr)));
     }
   }
 }


### PR DESCRIPTION
## Background

Pheno tool report header is not centered when the header is too long. Also creating the source of the image fails when trying to encode tilde character contained in the header.

## Implementation

Center the header by adding some attributes.
The svg string need to be encoded to utf-8 before setting it as image source.
