### PR TITLE
move pheno tool report image download link under the chart

### DIFF
--- a/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
+++ b/src/app/pheno-tool-results-chart/pheno-tool-results-chart.component.html
@@ -1,6 +1,3 @@
-<div id="image-download-container">
-  <a id="image-download">Download report as an image</a>
-</div>
 <div style="display: flex; justify-content: center; max-height: 700px; min-width: 1000px">
   <svg [attr.max-width]="width" [attr.max-height]="height" [attr.viewBox]="getViewBox()">
     <text x="50%" y="20" alignment-baseline="middle" text-anchor="middle" class="description">
@@ -31,4 +28,8 @@
       <text x="20" y="60">female without hit</text>
     </g>
   </svg>
+</div>
+
+<div id="image-download-container">
+  <a id="image-download">Download report as an image</a>
 </div>


### PR DESCRIPTION
Move the link for downloading the report as an image below the result to be in cosistency with other downloads in Phenotype tool.
