### PR TITLE
set logout redirect url using location strategy

### DIFF
--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -7,6 +7,7 @@ import { User, UserInfo } from './users';
 import { catchError, map, tap, take, switchMap } from 'rxjs/operators';
 import { AuthService } from '../auth.service';
 import { FederationCredential, FederationJson } from 'app/federation-credentials/federation-credentials';
+import { LocationStrategy } from '@angular/common';
 
 @Injectable()
 export class UsersService {
@@ -28,6 +29,7 @@ export class UsersService {
     private config: ConfigService,
     private cookieService: CookieService,
     private authService: AuthService,
+    private locationStrategy: LocationStrategy
   ) { }
 
   public logout(): Observable<object> {
@@ -43,7 +45,7 @@ export class UsersService {
       switchMap(() => this.authService.revokeAccessToken()),
       tap(() => {
         this.authService.clearTokens();
-        window.location.href = window.location.origin;
+        window.location.href = this.locationStrategy.getBaseHref();
       })
     );
   }


### PR DESCRIPTION
## Background

Currently the url where the user is redirected after logout is incorrect. 
`window.location.href` which is used doesn't give the full url but protocol, domain name and port only.
When working with localhost there is no issue because localhost:4200 is enought to navigate to Home page, but in other instances (dory and e2e) path must be provided. 
For dory - dory.seqpipe.org:8000 **/hg38**
For e2e instance - localhost:8080 **/gpf**
dory.seqpipe.org:8000 and  localhost:8080 will not navigate to Home page.

## Implementation

Return using LocationStrategy and getBaseHref() which gives the correct url.
