### PR TITLE
change redirecting to gene profiles table

### DIFF
--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.spec.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.spec.ts
@@ -296,18 +296,14 @@ describe('GeneProfileSingleViewComponent', () => {
   it('should go back from error modal', () => {
     jest.clearAllMocks();
 
-    Object.defineProperty(window, 'location', {
-      value: { assign: jest.fn() }
-    });
-
-    const locationAssignSpy = jest.spyOn(window.location, 'assign').mockImplementation();
+    const routerSpy = jest.spyOn(component['router'], 'navigate');
 
     component.errorModal = true;
     Object.defineProperty(component, 'geneSymbol', {value: 'tab2' });
     component.errorModalBack();
 
     expect(component.errorModal).toBe(false);
-    expect(locationAssignSpy).toHaveBeenCalledWith('/gene-profiles');
+    expect(routerSpy).toHaveBeenCalledWith(['/gene-profiles']);
   });
 
   it('should remove invalid gene from state and show error modal', () => {

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.component.ts
@@ -23,6 +23,7 @@ import { setStudyTypes } from 'app/study-types/study-types.state';
 import { setGenomicScores } from 'app/genomic-scores-block/genomic-scores-block.state';
 import { cloneDeep } from 'lodash';
 import { GeneProfilesTableService } from 'app/gene-profiles-table/gene-profiles-table.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'gpf-gene-profiles-single-view',
@@ -65,7 +66,8 @@ export class GeneProfileSingleViewComponent implements OnInit {
     private geneScoresService: GeneScoresService,
     private queryService: QueryService,
     private store: Store,
-    private geneProfilesTableService: GeneProfilesTableService
+    private geneProfilesTableService: GeneProfilesTableService,
+    private router: Router
   ) { }
 
   public errorModal = false;
@@ -269,7 +271,7 @@ export class GeneProfileSingleViewComponent implements OnInit {
 
   public errorModalBack(): void {
     this.errorModal = false;
-    window.location.assign('/gene-profiles');
+    this.router.navigate(['/gene-profiles']);
   }
 
   public isNumberHistogram(arg: object): arg is NumberHistogram {


### PR DESCRIPTION
* window.location doesn't give the full url, use router.navigate instead

## Background

When loading invalid gene in single view and click on back button, it navigates to wrong url.


## Implementation

Use Router instead.
