### PR TITLE
check gene browser query summary variants param

### DIFF
--- a/src/app/gene-browser/gene-browser.component.ts
+++ b/src/app/gene-browser/gene-browser.component.ts
@@ -336,12 +336,15 @@ export class GeneBrowserComponent implements OnInit, OnDestroy {
   }
 
   private get requestParams(): Record<string, unknown> {
+    const summaryVariantsIdsToSend =
+    this.summaryVariantsArrayFiltered.summaryAlleleIds.length < this.maxFamilyVariants ?
+      this.summaryVariantsArrayFiltered.summaryAlleleIds : null;
     return {
       ...this.summaryVariantsFilter.queryParams,
       geneSymbols: [this.selectedGene.geneSymbol],
       datasetId: this.selectedDatasetId,
       regions: this.selectedGene.getRegionString(...this.summaryVariantsFilter.selectedRegion),
-      summaryVariantIds: this.summaryVariantsArrayFiltered.summaryAlleleIds,
+      summaryVariantIds: summaryVariantsIdsToSend,
       frequencyScores: [{
         metric: this.geneBrowserConfig.frequencyColumn,
         rangeStart: this.summaryVariantsFilter.minFreq,


### PR DESCRIPTION
* send summary variants ids list if they are less than max family variants, otherwise send null

## Background

Gene browser `api/v3/genotype_browser/query` query has summaryVariantIds property which is a list of ids of all summary variants. In some cases the list is too big.

## Aim

Send ids only if they are less than 1001.

## Implementation

Check summary variants length before sending the query.
