### PR TITLE
fix gene and genomic scores state actions types

### DIFF
--- a/src/app/gene-scores/gene-scores.state.ts
+++ b/src/app/gene-scores/gene-scores.state.ts
@@ -28,18 +28,18 @@ export const selectGeneScores =
   createFeatureSelector<GeneScoresState>('geneScores');
 
 export const setGeneScoreContinuous = createAction(
-  '[Genotype] Set score with continuous histogram data',
+  '[Genotype] Set gene score with continuous histogram data',
   props<{score: string, rangeStart: number, rangeEnd: number}>()
 );
 
 export const setGeneScoreCategorical = createAction(
-  '[Genotype] Set score with categorical histogram data',
+  '[Genotype] Set gene score with categorical histogram data',
 
   props<{score: string, values: string[], categoricalView: CategoricalHistogramView}>()
 );
 
 export const resetGeneScoresValues = createAction(
-  '[Genotype] Reset geneScores values'
+  '[Genotype] Reset gene scores values'
 );
 
 export const geneScoresReducer = createReducer(

--- a/src/app/genomic-scores-block/genomic-scores-block.state.ts
+++ b/src/app/genomic-scores-block/genomic-scores-block.state.ts
@@ -24,17 +24,17 @@ export const setGenomicScores = createAction(
 );
 
 export const setGenomicScoresContinuous = createAction(
-  '[Genotype] Set score with continuous histogram data',
+  '[Genotype] Set genomic score with continuous histogram data',
   props<{score: string, rangeStart: number, rangeEnd: number}>()
 );
 
 export const setGenomicScoresCategorical = createAction(
-  '[Genotype] Set score with categorical histogram data',
+  '[Genotype] Set genomic score with categorical histogram data',
   props<{score: string, values: string[], categoricalView: CategoricalHistogramView}>()
 );
 
 export const removeGenomicScore = createAction(
-  '[Genotype] Remove score with histogram data',
+  '[Genotype] Remove genomic score with histogram data',
   props<{genomicScoreName: string}>()
 );
 


### PR DESCRIPTION
* each action creation requires setting a type which is a short description of the action. The type is used as an id and needs to be unique otherwise multiple actions will be called.
* In this case setting gene score and setting genomic score happened at the same time despite working with only one of the components.

## Background

When setting gene score state at the same time the state of the genomic score is also changed with the same changes. Also when setting genomic score state, the gene score state is changed as well.

## Aim

To fix it.

## Implementation

Change types of each state action in gene scores and genomic scores.
