### PR TITLE
Update and refactor gp configuration

### DIFF
--- a/src/app/gene-profiles-block/gene-profiles.service.spec.ts
+++ b/src/app/gene-profiles-block/gene-profiles.service.spec.ts
@@ -9,6 +9,101 @@ import {
 import { take } from 'rxjs/operators';
 import { provideHttpClient } from '@angular/common/http';
 
+const mockConfigJson = {
+  defaultDataset: 'ALL_genotypes',
+  geneLinks: [
+    {
+      name: 'Gene Browser',
+      url: 'datasets/ALL_genotypes/gene-browser/{gene}'
+    }
+  ],
+  order: [
+    {
+      section: null,
+      id: 'autism_gene_sets_rank'
+    },
+    {
+      section: 'genomicScores',
+      id: 'autism_scores'
+    },
+    {
+      section: 'datasets',
+      id: 'sequencing_de_novo'
+    }
+  ],
+  geneSets: [
+    {
+      category: 'autism_gene_sets',
+      displayName: 'Autism Gene Sets',
+      sets: [
+        {
+          setId: 'SFARI ALL',
+          collectionId: 'sfari',
+          defaultVisible: true
+        }
+      ],
+      defaultVisible: true
+    }
+  ],
+  genomicScores: [
+    {
+      category: 'autism_scores',
+      displayName: 'Autism Gene Scores',
+      scores: [
+        {
+          scoreName: 'SFARI gene score',
+          format: '%s',
+          defaultVisible: true
+        }
+      ],
+      defaultVisible: true
+    }
+  ],
+  datasets: [
+    {
+      id: 'sequencing_de_novo',
+      displayName: 'Sequencing de Novo',
+      defaultVisible: true,
+      statistics: [
+        {
+          id: 'denovo_lgds',
+          description: 'de Novo LGDs',
+          displayName: 'dn LGDs',
+          effects: [
+            'LGDs'
+          ],
+          category: 'denovo',
+          defaultVisible: true
+        }
+      ],
+      personSets: [
+        {
+          id: 'autism',
+          displayName: 'autism',
+          collectionId: 'phenotype',
+          description: '',
+          parentsCount: 0,
+          childrenCount: 21795,
+          statistics: [
+            {
+              id: 'denovo_lgds',
+              description: 'de Novo LGDs',
+              displayName: 'dn LGDs',
+              effects: [
+                'LGDs'
+              ],
+              category: 'denovo',
+              defaultVisible: true
+            }
+          ]
+        }
+      ]
+    },
+  ],
+  confDir: '/data',
+  pageSize: 50
+};
+
 describe('GeneProfilesService', () => {
   let service: GeneProfilesService;
 
@@ -26,14 +121,26 @@ describe('GeneProfilesService', () => {
 
   it('should get config', async() => {
     const getConfigSpy = jest.spyOn(service['http'], 'get');
-    getConfigSpy.mockReturnValue(of({ mockConfigProperty: 'mockConfigValue' }));
+    getConfigSpy.mockReturnValue(of(mockConfigJson));
 
     const resultConfig = service.getConfig();
 
     expect(getConfigSpy).toHaveBeenCalledWith(service['config'].baseUrl + service['configUrl']);
-    const res = await lastValueFrom(resultConfig.pipe(take(1)));
-    expect(res['mockConfigProperty']).toBe('mockConfigValue');
-    expect(res).toBeInstanceOf(GeneProfilesSingleViewConfig);
+    const config = await lastValueFrom(resultConfig.pipe(take(1)));
+    expect(config).toBeInstanceOf(GeneProfilesSingleViewConfig);
+    expect(config.geneLinkTemplates[0]).toStrictEqual({
+      name: 'Gene Browser',
+      url: 'datasets/ALL_genotypes/gene-browser/{gene}'
+    });
+    expect(config.order[1].id).toBe('autism_scores');
+    expect(config.geneSets[0].displayName).toBe('Autism Gene Sets');
+    expect(config.geneSets[0].sets[0].setId).toBe('SFARI ALL');
+    expect(config.genomicScores[0].displayName).toBe('Autism Gene Scores');
+    expect(config.genomicScores[0].scores[0].scoreName).toBe('SFARI gene score');
+    expect(config.datasets[0].id).toBe('sequencing_de_novo');
+    expect(config.datasets[0].statistics[0].id).toBe('denovo_lgds');
+    expect(config.datasets[0].personSets[0].id).toBe('autism');
+    expect(config.datasets[0].personSets[0].statistics[0].id).toBe('denovo_lgds');
   });
 
   it('should get invalid config response', async() => {

--- a/src/app/gene-profiles-block/gene-profiles.service.ts
+++ b/src/app/gene-profiles-block/gene-profiles.service.ts
@@ -28,7 +28,7 @@ export class GeneProfilesService {
           if (Object.keys(res).length === 0) {
             return;
           }
-          return plainToClass(GeneProfilesSingleViewConfig, res);
+          return GeneProfilesSingleViewConfig.fromJson(res);
         })
       );
   }

--- a/src/app/gene-profiles-single-view/gene-profiles-single-view.ts
+++ b/src/app/gene-profiles-single-view/gene-profiles-single-view.ts
@@ -1,100 +1,205 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { GenomicScoreState } from 'app/genomic-scores-block/genomic-scores-block.state';
 import { Type } from 'class-transformer';
 
 export class GeneProfilesSingleViewConfig {
-  public shown: Array<{category: any; section: string; id: string}>;
-  public defaultDataset: string;
-  public description: string;
-  public geneLinkTemplates: {name: string; url: string}[];
+  public constructor(
+    public shown: Array<{category: any; section: string; id: string}>,
+    public defaultDataset: string,
+    public description: string,
+    public geneLinkTemplates: {name: string; url: string}[],
+    public geneSets: GeneProfilesGeneSetsCategory[],
+    public genomicScores: GeneProfilesGenomicScoresCategory[],
+    public datasets: GeneProfilesDataset[],
+    public order: GeneProfilesOrder[],
+    public pageSize: number,
+  ) {}
 
-  @Type(() => GeneProfilesGeneSetsCategory)
-  public geneSets: GeneProfilesGeneSetsCategory[];
-
-  @Type(() => GeneProfilesGenomicScoresCategory)
-  public genomicScores: GeneProfilesGenomicScoresCategory[];
-
-  @Type(() => GeneProfilesDataset)
-  public datasets: GeneProfilesDataset[];
-
-  @Type(() => GeneProfilesOrder)
-  public order: GeneProfilesOrder[];
-
-  public pageSize: number;
+  public static fromJson(json): GeneProfilesSingleViewConfig {
+    return new GeneProfilesSingleViewConfig(
+      json['shown']?.map(s => ({category: s['category'], section: s['section'], id: s['id']})),
+      json['defaultDataset'],
+      json['description'],
+      json['geneLinks']?.map(g => ({name: g['name'], url: g['url']})),
+      json['geneSets']?.map(g => GeneProfilesGeneSetsCategory.fromJson(g)),
+      json['genomicScores']?.map(g => GeneProfilesGenomicScoresCategory.fromJson(g)),
+      json['datasets']?.map(d => GeneProfilesDataset.fromJson(d)),
+      json['order']?.map(o => GeneProfilesOrder.fromJson(o)),
+      json['pageSize'],
+    );
+  }
 }
 
 export class GeneProfilesGeneSetsCategory {
-  public category: string;
-  public displayName: string;
-  public defaultVisible: boolean;
+  public constructor(
+    public category: string,
+    public displayName: string,
+    public defaultVisible: boolean,
+    public sets: GeneProfilesGeneSet[],
+  ) {}
 
-  @Type(() => GeneProfilesGeneSet)
-  public sets: GeneProfilesGeneSet[];
+  public static fromJson(json): GeneProfilesGeneSetsCategory {
+    return new GeneProfilesGeneSetsCategory(
+      json['category'],
+      json['displayName'],
+      json['defaultVisible'],
+      json['sets'].map(s => GeneProfilesGeneSet.fromJson(s)),
+    );
+  }
 }
 
 export class GeneProfilesGeneSet {
-  public setId: string;
-  public collectionId: string;
-  public meta: string;
-  public defaultVisible: boolean;
+  public constructor(
+    public setId: string,
+    public collectionId: string,
+    public meta: string,
+    public defaultVisible: boolean,
+  ) {}
+
+  public static fromJson(json): GeneProfilesGeneSet {
+    return new GeneProfilesGeneSet(
+      json['setId'],
+      json['collectionId'],
+      json['meta'],
+      json['defaultVisible'],
+    );
+  }
 }
 
 export class GeneProfilesGenomicScoresCategory {
-  public category: string;
-  public displayName: string;
-  public defaultVisible: boolean;
+  public constructor(
+    public category: string,
+    public displayName: string,
+    public defaultVisible: boolean,
+    public scores: GeneProfilesGenomicScore[],
+  ) {}
 
-  @Type(() => GeneProfilesGenomicScore)
-  public scores: GeneProfilesGenomicScore[];
+  public static fromJson(json): GeneProfilesGenomicScoresCategory {
+    return new GeneProfilesGenomicScoresCategory(
+      json['category'],
+      json['displayName'],
+      json['defaultVisible'],
+      json['scores'].map(s => GeneProfilesGenomicScore.fromJson(s)),
+    );
+  }
 }
 
 export class GeneProfilesGenomicScore {
-  public scoreName: string;
-  public format: string;
-  public meta: string;
-  public defaultVisible: boolean;
+  public constructor(
+    public scoreName: string,
+    public format: string,
+    public meta: string,
+    public defaultVisible: boolean,
+  ) {}
+
+  public static fromJson(json): GeneProfilesGenomicScore {
+    return new GeneProfilesGenomicScore(
+      json['scoreName'],
+      json['format'],
+      json['meta'],
+      json['defaultVisible'],
+    );
+  }
 }
 
 export class GeneProfilesDataset {
-  public id: string;
-  public displayName: string;
-  public meta: string;
-  public defaultVisible: boolean;
+  public constructor(
+    public id: string,
+    public displayName: string,
+    public meta: string,
+    public defaultVisible: boolean,
+    public shown: GeneProfilesDatasetPersonSet[],
+    public statistics: GeneProfilesDatasetStatistic[],
+    public personSets: GeneProfilesDatasetPersonSet[],
+  ) {}
 
-  public shown: GeneProfilesDatasetPersonSet[];
-  public statistics: GeneProfilesDatasetStatistic[];
-
-  @Type(() => GeneProfilesDatasetPersonSet)
-  public personSets: GeneProfilesDatasetPersonSet[];
+  public static fromJson(json): GeneProfilesDataset {
+    return new GeneProfilesDataset(
+      json['id'],
+      json['displayName'],
+      json['meta'],
+      json['defaultVisible'],
+      json['shown']?.map(s => GeneProfilesDatasetPersonSet.fromJson(s)),
+      json['statistics'].map(s => GeneProfilesDatasetStatistic.fromJson(s)),
+      json['personSets'].map(p => GeneProfilesDatasetPersonSet.fromJson(p)),
+    );
+  }
 }
 
 export class GeneProfilesDatasetPersonSet {
-  public id: string;
-  public displayName: string;
-  public collectionId: string;
-  public description: string;
-  public childrenCount: number;
   public defaultVisible = true;
 
-  public shown: GeneProfilesDatasetStatistic[];
+  public constructor(
+    public id: string,
+    public displayName: string,
+    public collectionId: string,
+    public description: string,
+    public childrenCount: number,
+    public shown: GeneProfilesDatasetStatistic[],
+    public statistics: GeneProfilesDatasetStatistic[],
+  ) {}
 
-  @Type(() => GeneProfilesDatasetStatistic)
-  public statistics: GeneProfilesDatasetStatistic[];
+  public static fromJson(json): GeneProfilesDatasetPersonSet {
+    return new GeneProfilesDatasetPersonSet(
+      json['id'],
+      json['displayName'],
+      json['collectionId'],
+      json['description'],
+      json['childrenCount'],
+      json['shown']?.map(s => GeneProfilesDatasetStatistic.fromJson(s)),
+      json['statistics'].map(s => GeneProfilesDatasetStatistic.fromJson(s)),
+    );
+  }
 }
 
 export class GeneProfilesDatasetStatistic {
-  public id: string;
-  public displayName: string;
-  public effects: string[];
-  public category: string;
-  public description: string;
-  public variantTypes: string[];
-  public scores: GenomicScoreState[];
-  public defaultVisible: boolean;
+  public constructor(
+    public id: string,
+    public displayName: string,
+    public effects: string[],
+    public category: string,
+    public description: string,
+    public variantTypes: string[],
+    public scores: GenomicScoreState[],
+    public defaultVisible: boolean,
+  ) {}
+
+  public static fromJson(json): GeneProfilesDatasetStatistic {
+    return new GeneProfilesDatasetStatistic(
+      json['id'],
+      json['displayName'],
+      json['effects'],
+      json['category'],
+      json['description'],
+      json['variantTypes'],
+      json['scores']?.map(s => ({
+        score: s['name'],
+        histogramType: 'continuous',
+        rangeStart: s['min'],
+        rangeEnd: s['max'],
+        values: null,
+        categoricalView: null,
+      } as GenomicScoreState)),
+      json['defaultVisible'],
+    );
+  }
 }
 
 export class GeneProfilesOrder {
-  public section: string;
-  public id: string;
+  public constructor(
+    public section: string,
+    public id: string,
+  ) {}
+
+  public static fromJson(json): GeneProfilesOrder {
+    return new GeneProfilesOrder(
+      json['section'],
+      json['id'],
+    );
+  }
 }
 
 export class GeneProfilesGene {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -268,7 +268,6 @@ describe('HomeComponent', () => {
   it('should open sinle view', () => {
     component.loadingFinished = true;
     component.content = [];
-    component.geneProfilesConfig = new GeneProfilesSingleViewConfig();
     fixture.detectChanges();
 
     let geneSymbols = 'CHD8';
@@ -287,7 +286,6 @@ describe('HomeComponent', () => {
   it('should not open sinle view', () => {
     component.loadingFinished = true;
     component.content = [];
-    component.geneProfilesConfig = new GeneProfilesSingleViewConfig();
     const getGeneSpy = jest.spyOn(mockGeneService, 'getGene');
 
     fixture.detectChanges();
@@ -301,7 +299,6 @@ describe('HomeComponent', () => {
 
     component.loadingFinished = true;
     component.content = [];
-    component.geneProfilesConfig = new GeneProfilesSingleViewConfig();
     fixture.detectChanges();
 
     let geneSymbols = '   ';

--- a/src/app/utils/truncate.pipe.ts
+++ b/src/app/utils/truncate.pipe.ts
@@ -8,6 +8,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class TruncatePipe implements PipeTransform {
   public transform(value: string, limit: number, ellipsis = '...'): string {
-    return value.length > limit ? value.substring(0, limit) + ellipsis : value;
+    return value?.length > limit ? value.substring(0, limit) + ellipsis : value;
   }
 }


### PR DESCRIPTION
- Scores in the config should get updated property names.
- "plainToClass" usage for creating gp configurations made this change
imposible since it depends on creating 1:1 object as the one
the backend sends.
- Replace "plainToClass" with customizable and reliable fromJson logic.
- As side effect make gp configurations fully comply with their
assigned type. PlainToClass was creating incomplete class instances.