### PR TITLE
move genomic scores score selecting

### DIFF
--- a/src/app/genomic-scores-block/genomic-scores-block.component.css
+++ b/src/app/genomic-scores-block/genomic-scores-block.component.css
@@ -3,3 +3,54 @@
   right: 20px;
   top: 5px;
 }
+
+::ng-deep .mat-mdc-form-field-focus-overlay {
+  background-color: transparent !important;
+}
+
+mat-form-field {
+  width: 700px !important;
+}
+
+::ng-deep .mdc-text-field {
+  height: 38px !important;
+  border: 1px solid #dee2e6 !important;
+  border-radius: 0.375rem !important;
+  background: white !important;
+}
+
+::ng-deep .mdc-text-field:hover {
+  background-color: white;
+  border: 1px solid #dee2e6 !important;
+  border-radius: 0.375rem !important;
+}
+
+::ng-deep .mat-mdc-form-field-infix {
+  top: -9px;
+}
+
+::ng-deep div.mat-mdc-select-panel {
+  padding: 0 !important;
+  box-shadow: none !important;
+  border: 1px solid #dee2e6 !important;
+}
+
+::ng-deep div.mat-mdc-select-panel .mat-mdc-option {
+  background-color: white !important;
+}
+
+::ng-deep div.mat-mdc-select-panel .mat-mdc-option:hover {
+  background-color: rgba(0, 0, 0, 4%) !important;
+}
+
+::ng-deep .mdc-line-ripple {
+  display: none;
+}
+
+::ng-deep .mat-mdc-select-placeholder {
+  color: black !important;
+}
+
+::ng-deep .mat-mdc-form-field-subscript-wrapper {
+  display: none;
+}

--- a/src/app/genomic-scores-block/genomic-scores-block.component.html
+++ b/src/app/genomic-scores-block/genomic-scores-block.component.html
@@ -3,8 +3,16 @@
     <ul ngbNav #nav="ngbNav" class="navbar bg-light nav-pills" style="justify-content: flex-start">
       <div class="nav-title-custom">Genomic scores</div>
       <li ngbNavItem>
-        <a *ngIf="allGenomicScores?.length > 0" ngbNavLink>
-          <gpf-add-button (addFilter)="addFilter()"></gpf-add-button>
+        <a *ngIf="allGenomicScores?.length > 0">
+          <mat-form-field>
+            <mat-select disableRipple [placeholder]="'Select filter'">
+              <mat-option
+                *ngFor="let genomicScore of unusedGenomicScores; let i = index"
+                (click)="addFilter(genomicScore, i)"
+                >{{ genomicScore.desc }}</mat-option
+              >
+            </mat-select>
+          </mat-form-field>
         </a>
         <span *ngIf="allGenomicScores?.length === 0" style="opacity: 75%"><i>No genomic scores available</i></span>
       </li>
@@ -20,9 +28,7 @@
           <gpf-genomic-scores
             [selectedGenomicScore]="selectedScore.score"
             [initialState]="selectedScore.state"
-            [otherGenomicScores]="unusedGenomicScores"
-            (updateState)="addToState($event)"
-            (changeGenomicScore)="changeFilter($event)">
+            (updateState)="addToState($event)">
           </gpf-genomic-scores>
         </span>
       </div>

--- a/src/app/genomic-scores-block/genomic-scores-block.component.ts
+++ b/src/app/genomic-scores-block/genomic-scores-block.component.ts
@@ -91,24 +91,6 @@ export class GenomicScoresBlockComponent implements OnInit {
     this.addToState(cloneDeep(defaultState));
   }
 
-  public changeFilter(change: {old: string, new: string}): void {
-    // Add the old genomic score to the unused list
-    const oldIndex = this.selectedGenomicScores.findIndex(selected => selected.score.score === change.old);
-    this.unusedGenomicScores.push(this.selectedGenomicScores[oldIndex].score);
-    this.unusedGenomicScores.sort((a, b) => a.score.localeCompare(b.score));
-
-    // Add the unused genomic score to the selected and update the state
-    this.store.dispatch(removeGenomicScore({genomicScoreName: this.selectedGenomicScores[oldIndex].state.score}));
-    const newIndex = this.unusedGenomicScores.findIndex(unused => unused.score === change.new);
-    const defaultState = this.createScoreDefaultState(this.unusedGenomicScores[newIndex]);
-    this.selectedGenomicScores[oldIndex] = {
-      score: this.unusedGenomicScores[newIndex],
-      state: defaultState,
-    };
-    this.addToState(cloneDeep(defaultState));
-    this.unusedGenomicScores.splice(newIndex, 1);
-  }
-
   public removeFromState(state: GenomicScoreState): void {
     const oldIndex = this.selectedGenomicScores.findIndex(selected => selected.score.score === state.score);
     this.unusedGenomicScores.push(this.selectedGenomicScores[oldIndex].score);

--- a/src/app/genomic-scores-block/genomic-scores-block.component.ts
+++ b/src/app/genomic-scores-block/genomic-scores-block.component.ts
@@ -81,13 +81,13 @@ export class GenomicScoresBlockComponent implements OnInit {
     return state;
   }
 
-  public addFilter(): void {
-    const defaultState = this.createScoreDefaultState(this.unusedGenomicScores[0]);
+  public addFilter(score: GenomicScore, index: number): void {
+    const defaultState = this.createScoreDefaultState(score);
     this.selectedGenomicScores.push({
-      score: this.unusedGenomicScores[0],
+      score: score,
       state: defaultState,
     });
-    this.unusedGenomicScores.splice(0, 1);
+    this.unusedGenomicScores.splice(index, 1);
     this.addToState(cloneDeep(defaultState));
   }
 

--- a/src/app/genomic-scores/genomic-scores.component.css
+++ b/src/app/genomic-scores/genomic-scores.component.css
@@ -1,46 +1,3 @@
-mat-form-field {
-  width: 700px !important;
-}
-
-::ng-deep .mdc-text-field {
-  height: 38px !important;
-  border: 1px solid #dee2e6 !important;
-  border-radius: 0.375rem !important;
-  background: white !important;
-}
-
-::ng-deep .mdc-text-field:hover {
-  background-color: white;
-  border: 1px solid #dee2e6 !important;
-  border-radius: 0.375rem !important;
-}
-
-::ng-deep .mat-mdc-form-field-infix {
-  top: -9px;
-}
-
-::ng-deep div.mat-mdc-select-panel {
-  padding: 0 !important;
-  box-shadow: none !important;
-  border: 1px solid #dee2e6 !important;
-}
-
-::ng-deep div.mat-mdc-select-panel .mat-mdc-option {
-  background-color: white !important;
-}
-
-::ng-deep div.mat-mdc-select-panel .mat-mdc-option:hover {
-  background-color: rgba(0, 0, 0, 4%) !important;
-}
-
-::ng-deep .mdc-line-ripple {
-  display: none;
-}
-
-::ng-deep .mat-mdc-form-field-focus-overlay {
-  opacity: 100%;
-}
-
 #view-menu-button {
   background: #2a6395;
   color: white;
@@ -50,10 +7,8 @@ mat-form-field {
   margin-left: 10px;
 }
 
-.select-wrapper {
+.title-wrapper {
   width: auto;
-}
-
-::ng-deep .mat-mdc-select-placeholder {
-  color: black !important;
+  font-weight: bold;
+  font-size: 16px;
 }

--- a/src/app/genomic-scores/genomic-scores.component.html
+++ b/src/app/genomic-scores/genomic-scores.component.html
@@ -2,21 +2,10 @@
   class="panel"
   style="display: flex; flex-wrap: wrap; justify-content: center; border-top: 0"
   *ngIf="selectedGenomicScore && localState">
-  <div class="col-sm-9" style="display: flex; padding: 0 12px 0 12px">
-    <div class="select-wrapper">
-      <mat-form-field>
-        <mat-select disableRipple [title]="selectedGenomicScore.desc" [placeholder]="selectedGenomicScore.desc">
-          <mat-option
-            *ngFor="let genomicScore of otherGenomicScores"
-            [value]="genomicScore.desc"
-            (click)="updateSelectedGenomicScore(genomicScore)"
-            >{{ genomicScore.desc }}</mat-option
-          >
-        </mat-select>
-      </mat-form-field>
-    </div>
+  <div style="display: flex; padding: 0 12px 0 12px">
+    <div class="title-wrapper">{{ selectedGenomicScore.desc }}</div>
     <gpf-helper-modal
-      style="height: 32px; margin-left: 4px; margin-top: 5px"
+      style="height: 32px; margin-left: 4px"
       [style.visibility]="selectedGenomicScore.help ? 'visible' : 'hidden'"
       [modalContent]="selectedGenomicScore.help"
       [isMarkdown]="true"></gpf-helper-modal>

--- a/src/app/genomic-scores/genomic-scores.component.ts
+++ b/src/app/genomic-scores/genomic-scores.component.ts
@@ -23,8 +23,6 @@ export class GenomicScoresComponent implements OnInit {
   @Input() public selectedGenomicScore: GenomicScore;
   @Input() public initialState: GenomicScoreState;
   public localState: GenomicScoreState;
-  @Input() public otherGenomicScores: GenomicScore[];
-  @Output() public changeGenomicScore = new EventEmitter<{ old: string, new: string }>();
   @Output() public updateState = new EventEmitter<GenomicScoreState>();
   public errors: string[] = [];
   private categoricalValueMax = 1000;
@@ -60,13 +58,6 @@ export class GenomicScoresComponent implements OnInit {
   public get domainMax(): number {
     const lastIndex = (this.selectedGenomicScore.histogram as NumberHistogram).bins.length - 1;
     return (this.selectedGenomicScore.histogram as NumberHistogram).bins[lastIndex];
-  }
-
-  public updateSelectedGenomicScore(newGenomicScore: GenomicScore): void {
-    this.changeGenomicScore.emit({
-      old: this.selectedGenomicScore.score,
-      new: newGenomicScore.score
-    });
   }
 
   private updateHistogramState(): void {


### PR DESCRIPTION
* replace selecting score in each genomic score component and filtering the dropdown content with selecting scores from one dropdown placed in the parent
* each genomic score component has its score as a title which is placed where the dropdown was


## Aim

Move selecting a score to be in genomic scores block component (parent component) instead of in each genomic score component.

## Implementation

Move the dropdown and its styles to the parent component. Replace dropdown in genomic score components with title which is the selected score.